### PR TITLE
feat(workflows): add eik aliasing script to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
       - name: Eik login and publish
-        run: pnpm run eik:login -k $EIK_TOKEN && pnpm run eik:publish || true
+        run: pnpm eik login -k $EIK_TOKEN && pnpm eik publish && pnpm eik pkg-alias || true
         env:
           EIK_TOKEN: ${{ secrets.EIK_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "lint:eslint": "eslint . --ext js,cjs,mjs --ignore-path .gitignore",
     "dev": "vite",
     "build:docs": "vite build && cp CNAME site",
-    "eik:login": "eik login",
-    "eik:publish": "eik publish",
     "test:mock-backend": "node ./tests/utils/broadcast-backend.js",
     "test:mock-backend:ci": "node ./tests/utils/broadcast-backend.js &",
     "test": "tap ./packages/**/test.js --no-check-coverage",


### PR DESCRIPTION
Allow the latest version of the package to be imported from eik server without the need to update the version number every time a new bundle version is published.
`https://assets.finn.no/pkg/@warp-ds/vue/v1/index.js` 
instead of
`https://assets.finn.no/pkg/@warp-ds/vue/v1.0.0-alpha.9/index.js`

More info on aliases in eik can be found [here](https://eik.dev/docs/client_aliases/).

When `1.0.0` version is published to NPM (`alpha` is merged to `main`), the `eik pkg-alias` script should only be run on pushes to `main`, which will be handled in [this task](https://trello.com/c/IfLXuWlg).