### PR TITLE
chore: remove comments wrapping @unocss-placeholder in components styles

### DIFF
--- a/packages/affix/index.js
+++ b/packages/affix/index.js
@@ -6,7 +6,7 @@ import { fclasses } from '../utils';
 
 class WarpAffix extends LitElement {
   static styles = css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
   `;
 
   static properties = {

--- a/packages/alert/index.js
+++ b/packages/alert/index.js
@@ -55,7 +55,7 @@ class WarpAlert extends LitElement {
   // so never gets higher Specificity. Thus in order to overwrite style linked within shadowDOM, we need to use !important.
   // https://stackoverflow.com/a/61631668
   static styles = css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
     :host {
       display: block;
     }

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -28,7 +28,7 @@ class WarpAttention extends kebabCaseAttributes(LitElement) {
 
   static styles = [
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       #attention {
         position: absolute;
         z-index: 50;

--- a/packages/box/index.js
+++ b/packages/box/index.js
@@ -16,7 +16,7 @@ class WarpBox extends LitElement {
   // https://stackoverflow.com/a/61631668
   static styles = 
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       :host {
           display: block;
         }

--- a/packages/breadcrumbs/index.js
+++ b/packages/breadcrumbs/index.js
@@ -7,7 +7,7 @@ const separator = html`<span class=${ccBreadcrumbs.separator} aria-hidden='true'
 
 class WarpBreadcrumbs extends kebabCaseAttributes(LitElement) {
   static styles = css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
   `;
 
   static properties = {

--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -23,7 +23,7 @@ export class WarpBroadcast extends LitElement {
   };
 
   static styles = css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
   `;
 
   constructor() {

--- a/packages/button/index.js
+++ b/packages/button/index.js
@@ -31,7 +31,7 @@ class WarpButton extends kebabCaseAttributes(LitElement) {
 
 
   static styles = css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
   `;
 
   constructor() {

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -11,7 +11,7 @@ const keys = {
 class WarpCard extends LitElement {
   static styles = [
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       a::after {
         content: '';
         position: absolute;

--- a/packages/expandable/index.js
+++ b/packages/expandable/index.js
@@ -40,7 +40,7 @@ class WarpExpandable extends kebabCaseAttributes(LitElement) {
   // https://stackoverflow.com/a/61631668
   static styles = [
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       :host {
         display: block;
       }

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -29,7 +29,7 @@ export class WarpSelect extends kebabCaseAttributes(LitElement) {
   };
 
   static styles = css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
   `;
 
   get #classes() {

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -32,7 +32,7 @@ class WarpTextField extends LitElement {
   // https://stackoverflow.com/a/61631668
   static styles = [
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       :host {
         display: block;
       }

--- a/packages/toast/toast-container.js
+++ b/packages/toast/toast-container.js
@@ -15,7 +15,7 @@ import { repeat } from 'lit/directives/repeat.js';
 export class WarpToastContainer extends LitElement {
   static styles = [
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       :host {
         display: block;
       }

--- a/packages/toast/toast.js
+++ b/packages/toast/toast.js
@@ -18,7 +18,7 @@ const classes = (definition) => {
 export class WarpToast extends LitElement {
   static styles = [
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       :host {
         display: block;
       }

--- a/packages/utils/expand-transition.js
+++ b/packages/utils/expand-transition.js
@@ -56,7 +56,7 @@ class ExpandTransition extends LitElement {
   static styles = [
     styles,
     css`
-      /* @unocss-placeholder */
+      @unocss-placeholder
       :host {
         display: block;
       }

--- a/packages/utils/unstyled-heading.js
+++ b/packages/utils/unstyled-heading.js
@@ -9,7 +9,7 @@ class UnstyledHeading extends LitElement {
   };
 
   static styles = [styles, css`
-    /* @unocss-placeholder */
+    @unocss-placeholder
   `];
 
   get _markup() {


### PR DESCRIPTION
The placeholder worked regardless the wrapping comments but we remove it to avoid confusion.