### PR TITLE
fix: stable FINN prod alpha-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
     "@warp-ds/uno": "^1.0.0-alpha.49",
-    "@warp-ds/component-classes": "^1.0.0-alpha.115",
+    "@warp-ds/component-classes": "^1.0.0-alpha.116",
     "glob": "8.1.0",
     "html-format": "1.1.2",
     "lit": "2.7.5"

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "@eik/cli": "^2.0.22",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
-    "@warp-ds/uno": "^1.0.0-alpha.45",
-    "@warp-ds/component-classes": "1.0.0-alpha.110",
     "autoprefixer": "10.4.14",
     "cors": "2.8.5",
     "cz-conventional-changelog": "3.3.0",
@@ -74,6 +72,8 @@
     "@fabric-ds/icons": "0.6.7",
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
+    "@warp-ds/uno": "^1.0.0-alpha.49",
+    "@warp-ds/component-classes": "^1.0.0-alpha.115",
     "glob": "8.1.0",
     "html-format": "1.1.2",
     "lit": "2.7.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -11,9 +11,15 @@ dependencies:
   '@open-wc/testing':
     specifier: 3.2.0
     version: 3.2.0
+  '@warp-ds/component-classes':
+    specifier: ^1.0.0-alpha.115
+    version: 1.0.0-alpha.115
   '@warp-ds/core':
     specifier: 1.0.0
     version: 1.0.0
+  '@warp-ds/uno':
+    specifier: ^1.0.0-alpha.49
+    version: 1.0.0-alpha.49
   glob:
     specifier: 8.1.0
     version: 8.1.0
@@ -43,12 +49,6 @@ devDependencies:
   '@semantic-release/git':
     specifier: 10.0.1
     version: 10.0.1(semantic-release@21.0.5)
-  '@warp-ds/component-classes':
-    specifier: 1.0.0-alpha.110
-    version: 1.0.0-alpha.110
-  '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.45
-    version: 1.0.0-alpha.45
   autoprefixer:
     specifier: 10.4.14
     version: 10.4.14(postcss@8.4.24)
@@ -2089,7 +2089,7 @@ packages:
 
   /@unocss/core@0.50.8:
     resolution: {integrity: sha512-rWmyeNE0Na8dJPDynLVar0X22qMHFNhO+/F2FZDpG4tubTavXJJo9uvhZr/D381kiWxt+XZ38y6EAD4UMdBqMA==}
-    dev: true
+    dev: false
 
   /@unocss/core@0.53.1:
     resolution: {integrity: sha512-6CUaOMeQyoPIgMuSboX9yGywiCumhoYTPk6uMFhgD3vZmIRCZMwN9RFDLB+s2+NOlnBU6aQsJLONcUapZb/49g==}
@@ -2142,7 +2142,7 @@ packages:
     resolution: {integrity: sha512-/4sbOdyaqJMvFkw1xzo2+h6bZJHw6WCYw1mF+f0ydHzj8ruvwaj9ClDDOweW5cdrk3wzDzRZ6NPRahKqLwv6/Q==}
     dependencies:
       '@unocss/core': 0.50.8
-    dev: true
+    dev: false
 
   /@unocss/preset-mini@0.53.1:
     resolution: {integrity: sha512-tHfsAXmu82/0BMktgqaq6WLOU5FdLdK/iJvS38eQLZqZlQ2VtCtNybf+bqlNNr0cr8J4ju2iwp7n61pqIvcmOw==}
@@ -2245,9 +2245,9 @@ packages:
       - rollup
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.110:
-    resolution: {integrity: sha512-kqOYLHBxNjyuIs7X7hlZyywxua//Gxd6+h3H13d1RT/Zfkjnr/ByUJdFvbcYqPNrNsLLwqdPsRZTbL02f0EuDg==}
-    dev: true
+  /@warp-ds/component-classes@1.0.0-alpha.115:
+    resolution: {integrity: sha512-+Gvds1oLj2Jj5WW5hwFCPts2K0L3/yQCCMg6io49QnZ0qDwd6whof3TkDg7emhqF+xEVh87r67bqLewZbOsnyg==}
+    dev: false
 
   /@warp-ds/core@1.0.0:
     resolution: {integrity: sha512-HCzgWm6wHR2Wh/rvNu9I4Qe1HdUj/i3v5amjioW38ZPh/Ve/y/0imX//ZXMLjshDVK+ZKU34Xd0TC56z/Yg36g==}
@@ -2255,12 +2255,12 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/uno@1.0.0-alpha.45:
-    resolution: {integrity: sha512-Uemwf0EgmZV4En+aT74ZX6pw/+w+CLVhgTMV/4e6FouDq+e79MknNtHVpm/ktLHlUgb4fedFCChSxRExgU1/RQ==}
+  /@warp-ds/uno@1.0.0-alpha.49:
+    resolution: {integrity: sha512-72c5dT6QAy7GFmL+SN2gRlOsJWBWYM4uJpyw8WA9gCQHNENHXtoWu+D24+c47T9K908M3ZG+2+U1M/FXEZ7ojA==}
     dependencies:
       '@unocss/core': 0.50.8
       '@unocss/preset-mini': 0.50.8
-    dev: true
+    dev: false
 
   /@web/browser-logs@0.3.2:
     resolution: {integrity: sha512-4kYoH4XBpOnrYAzlG3M9fy3kj7jhUgOLXsBcdC5n4oALYzgX57mt2MeJT4LkdgLWbCGRl1K8KaZhOKgH4RktxQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: 3.2.0
     version: 3.2.0
   '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.115
-    version: 1.0.0-alpha.115
+    specifier: ^1.0.0-alpha.116
+    version: 1.0.0-alpha.116
   '@warp-ds/core':
     specifier: 1.0.0
     version: 1.0.0
@@ -2245,8 +2245,8 @@ packages:
       - rollup
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.115:
-    resolution: {integrity: sha512-+Gvds1oLj2Jj5WW5hwFCPts2K0L3/yQCCMg6io49QnZ0qDwd6whof3TkDg7emhqF+xEVh87r67bqLewZbOsnyg==}
+  /@warp-ds/component-classes@1.0.0-alpha.116:
+    resolution: {integrity: sha512-7bAQOPtynoGtgcZ+TSX6OE+chK2s0tW/fnE1dOScjDMvd7O+6EFbBi3eTKSnmozEKL/d9c7gGL/9/OnGxlF9lg==}
     dev: false
 
   /@warp-ds/core@1.0.0:


### PR DESCRIPTION
## Background
With this setup @warp-ds/elements will be compatible with [tokens](https://assets.finn.no/pkg/@warp-ds/tokens/v1/finn-no.css) currently available in FINN production. After merging this PR and so releasing a new alpha version, we will update [Warp Tech Docs](https://warp-ds.github.io/tech-docs/getting-started/developers/) and suggest the use of this particular version when relying on the above mentioned tokens.
 
## Changes
- bump `@warp-ds/uno` to `1.0.0.-alpha.49`
- bump `@warp-ds/component-classes` to `1.0.0.-alpha.116`

Also:
- Fix missing transparent background on buttons in Button of type "link" and suffix for Textfield

Before|After
---|---
![image](https://github.com/warp-ds/elements/assets/37986637/33becb40-9c09-482c-a32f-a558c72e5d6c)|![image](https://github.com/warp-ds/elements/assets/37986637/55bf2eb7-52e3-47e5-b3ec-990977999db7)
![image](https://github.com/warp-ds/elements/assets/37986637/77d10992-ef31-4631-b162-e77afbaf9571)|![image](https://github.com/warp-ds/elements/assets/37986637/f7c0999e-00d0-444e-a9a9-9e9606019128)
