### PR TITLE
fix(select): add component classes to select

### DIFF
--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -57,7 +57,7 @@ class WarpCard extends LitElement {
   }
 
   get uuButton() {
-    return html`<button class={${ccCard.a11y}} aria-pressed="${this.selected}" tabindex="-1">
+    return html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">
       Velg
     </button>`;
   }

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -2,6 +2,7 @@ import { html, LitElement, css } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import { classNames } from '@chbphone55/classnames';
+import { select as ccSelect, helpText as ccHelpText, label as ccLabel } from "@warp-ds/component-classes"
 import { kebabCaseAttributes } from '../utils';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
@@ -33,9 +34,31 @@ export class WarpSelect extends kebabCaseAttributes(LitElement) {
   `;
 
   get #classes() {
-    return classNames('input mb-0', {
-      'input--is-invalid': this.invalid,
+    return classNames({
+      [ccSelect.default]: true,
+      [ccSelect.invalid]: this.invalid
     });
+  }
+
+  get #labelClasses() {
+    return classNames({
+      [ccLabel.label]: true,
+      [ccLabel.labelInvalid]: this.invalid
+    })
+  }
+
+  get #helpTextClasses() {
+    return classNames({
+      [ccHelpText.helpText]: true,
+      [ccHelpText.helpTextInvalid]: this.invalid
+    })
+  }
+
+  get #chevronClasses() {
+    return classNames({
+      [ccSelect.chevron]: true,
+      [ccSelect.chevronDisabled]: this.disabled,
+    })
   }
 
   get #id() {
@@ -52,21 +75,22 @@ export class WarpSelect extends kebabCaseAttributes(LitElement) {
   }
 
   render() {
-    return html`<div class="${this.#classes}">
+    return html`<div class="${ccSelect.wrapper}">
       ${when(
         this.label,
         () =>
-          html`<label for="${this.#id}">
+          html`<label class="${this.#labelClasses}" for="${this.#id}">
             ${this.label}
             ${when(
               this.optional,
               () =>
-                html`<span className="pl-8 font-normal text-14 text-gray-500">(valgfritt)</span>`,
+                html`<span class="${ccLabel.optional}">(valgfritt)</span>`,
             )}</label
           >`,
       )}
-      <div class="input--select__wrap">
+      <div class="${ccSelect.selectWrapper}">
         <select
+          class="${this.#classes}"
           id="${this.#id}"
           ?autofocus=${this.autoFocus}
           aria-describedby="${ifDefined(this.#helpId)}"
@@ -75,10 +99,27 @@ export class WarpSelect extends kebabCaseAttributes(LitElement) {
         >
           ${unsafeHTML(this._options)}
         </select>
+        <div class="${this.#chevronClasses}">
+          <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="none"
+              viewBox="0 0 16 16"
+          >
+            <path
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.5"
+              d="M2.5 5.5L8 11L13.5 5.5"
+            />
+          </svg>
+        </div>
       </div>
       ${when(
         this.always || this.invalid,
-        () => html`<div id="${this.#helpId}" class="input__sub-text">${this.hint}</div>`,
+        () => html`<div id="${this.#helpId}" class="${this.#helpTextClasses}">${this.hint}</div>`,
       )}
     </div>`;
   }

--- a/pages/includes/scripts.js
+++ b/pages/includes/scripts.js
@@ -1,4 +1,5 @@
 import '../../index.js';
+import 'uno.css';
 import { toast, updateToast, removeToast } from '../../index.js';
 import { WarpToastContainer } from '../../packages/toast/toast-container.js';
 import '@fabric-ds/icons/elements/bag-16';

--- a/vite.config.js
+++ b/vite.config.js
@@ -77,7 +77,10 @@ export default ({ mode }) => {
         presets: [presetWarp()],
         mode: 'shadow-dom',
         safelist: classes,
-      }),  
+      }),
+      uno({
+        presets: [presetWarp()],
+      }),
       // litElementTailwindPlugin({ mode }),
       mode !== 'lib' && createHtmlPlugin({
         minify: false,


### PR DESCRIPTION
This was supposed to be done together with corresponding changes from https://github.com/warp-ds/vue/pull/18 so before we announce a stable FINN prod version of this package, this had to be fixed, too.
 
Before:
<img width="434" alt="Screenshot 2023-07-10 at 12 16 14" src="https://github.com/warp-ds/elements/assets/41303231/d159076d-fe58-470c-ab2c-2fd27b2378ac">


After:
<img width="426" alt="Screenshot 2023-07-10 at 12 12 19" src="https://github.com/warp-ds/elements/assets/41303231/7794c7ce-8cc6-4137-9121-ae18fea57b64">


Also:
- apply unocss to the internal docs document for easier testing
- fix a bug where w-card's hidden button was visible