### PR TITLE
fix(packages): use new semantic classes

### DIFF
--- a/elements.css
+++ b/elements.css
@@ -1,1 +1,1 @@
-@import "https://assets.finn.no/pkg/@warp-ds/tokens/v1/finn-no.css";
+@import "https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/tokens/finn-no.css";

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "@fabric-ds/icons": "0.6.7",
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
-    "@warp-ds/uno": "^1.0.0-alpha.49",
-    "@warp-ds/component-classes": "^1.0.0-alpha.116",
+    "@warp-ds/uno": "^1.0.0-alpha.58",
+    "@warp-ds/css": "^1.0.0-alpha.33",
     "glob": "8.1.0",
     "html-format": "1.1.2",
     "lit": "2.7.5"

--- a/packages/affix/index.js
+++ b/packages/affix/index.js
@@ -1,6 +1,6 @@
 import { html, LitElement, css } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { suffix, prefix } from '@warp-ds/component-classes';
+import { suffix, prefix } from '@warp-ds/css/component-classes';
 import { search, clear } from './icons';
 import { fclasses } from '../utils';
 

--- a/packages/alert/index.js
+++ b/packages/alert/index.js
@@ -1,7 +1,7 @@
 // TODO: replace text-14 with a token
 
 import { css, html, LitElement } from 'lit';
-import { alert as ccAlert } from '@warp-ds/component-classes';
+import { alert as ccAlert } from '@warp-ds/css/component-classes';
 import { infoSvg, negativeSvg, positiveSvg, warningSvg } from './svgs';
 import { classNames } from '@chbphone55/classnames';
 

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { classes, kebabCaseAttributes, generateRandomId } from '../utils';
-import { attention as ccAttention } from '@warp-ds/component-classes';
+import { attention as ccAttention } from '@warp-ds/css/component-classes';
 import {
   opposites,
   rotation,

--- a/packages/box/index.js
+++ b/packages/box/index.js
@@ -1,6 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { fclasses } from '../utils';
-import { box as ccBox } from '@warp-ds/component-classes';
+import { box as ccBox } from '@warp-ds/css/component-classes';
 
 class WarpBox extends LitElement {
   static properties = {

--- a/packages/breadcrumbs/index.js
+++ b/packages/breadcrumbs/index.js
@@ -1,6 +1,6 @@
 import { html, LitElement, css } from 'lit';
 import { interleave } from '@warp-ds/core/breadcrumbs';
-import { breadcrumbs as ccBreadcrumbs } from '@warp-ds/component-classes'
+import { breadcrumbs as ccBreadcrumbs } from '@warp-ds/css/component-classes'
 import { kebabCaseAttributes } from '../utils';
 
 const separator = html`<span class=${ccBreadcrumbs.separator} aria-hidden='true'>/</span>`;

--- a/packages/button/index.js
+++ b/packages/button/index.js
@@ -1,5 +1,5 @@
 import { html, LitElement, css } from 'lit';
-import { button as ccButton } from '@warp-ds/component-classes';
+import { button as ccButton } from '@warp-ds/css/component-classes';
 import { classNames } from '@chbphone55/classnames';
 import { kebabCaseAttributes } from '../utils';
 

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { card as ccCard } from '@warp-ds/component-classes';
+import { card as ccCard } from '@warp-ds/css/component-classes';
 import { fclasses } from '../utils';
 
 const keys = {

--- a/packages/expandable/index.js
+++ b/packages/expandable/index.js
@@ -3,7 +3,7 @@ import { fclasses, kebabCaseAttributes } from '../utils';
 import {
   box as ccBox,
   expandable as ccExpandable,
-} from '@warp-ds/component-classes';
+} from '@warp-ds/css/component-classes';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import '@fabric-ds/icons/elements/chevron-down-16';
 

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -2,7 +2,7 @@ import { html, LitElement, css } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
 import { classNames } from '@chbphone55/classnames';
-import { select as ccSelect, helpText as ccHelpText, label as ccLabel } from "@warp-ds/component-classes"
+import { select as ccSelect, helpText as ccHelpText, label as ccLabel } from "@warp-ds/css/component-classes"
 import { kebabCaseAttributes } from '../utils';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from 'lit';
-import { input, label as l, helpText as h } from '@warp-ds/component-classes';
+import { input, label as l, helpText as h } from '@warp-ds/css/component-classes';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { fclasses } from '../utils';
 

--- a/packages/toast/toast-container.js
+++ b/packages/toast/toast-container.js
@@ -1,5 +1,5 @@
 import { LitElement, css, html } from 'lit';
-import { toaster as ccToaster } from '@warp-ds/component-classes';
+import { toaster as ccToaster } from '@warp-ds/css/component-classes';
 import { repeat } from 'lit/directives/repeat.js';
 
 /**

--- a/packages/toast/toast.js
+++ b/packages/toast/toast.js
@@ -1,7 +1,7 @@
 import { LitElement, css, html } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
-import { toast as ccToast } from '@warp-ds/component-classes';
+import { toast as ccToast } from '@warp-ds/css/component-classes';
 import { expand, collapse } from 'element-collapse';
 import { closeSVG, successSVG, failureSVG, warningSVG } from './svgs';
 

--- a/pages/includes/head.html
+++ b/pages/includes/head.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
 
-  <link href="https://assets.finn.no/pkg/@warp-ds/tokens/v1/finn-no.css" rel="stylesheet" />
+  <link href="https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/tokens/finn-no.css" rel="stylesheet" />
 
   <style>
     html { font-size: 62.5%; }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ dependencies:
   '@open-wc/testing':
     specifier: 3.2.0
     version: 3.2.0
-  '@warp-ds/component-classes':
-    specifier: ^1.0.0-alpha.116
-    version: 1.0.0-alpha.116
   '@warp-ds/core':
     specifier: 1.0.0
     version: 1.0.0
+  '@warp-ds/css':
+    specifier: ^1.0.0-alpha.33
+    version: 1.0.0-alpha.33(@warp-ds/component-classes@1.0.0-alpha.110)
   '@warp-ds/uno':
-    specifier: ^1.0.0-alpha.49
-    version: 1.0.0-alpha.49
+    specifier: ^1.0.0-alpha.58
+    version: 1.0.0-alpha.58(@warp-ds/component-classes@1.0.0-alpha.110)
   glob:
     specifier: 8.1.0
     version: 8.1.0
@@ -2245,8 +2245,8 @@ packages:
       - rollup
     dev: true
 
-  /@warp-ds/component-classes@1.0.0-alpha.116:
-    resolution: {integrity: sha512-7bAQOPtynoGtgcZ+TSX6OE+chK2s0tW/fnE1dOScjDMvd7O+6EFbBi3eTKSnmozEKL/d9c7gGL/9/OnGxlF9lg==}
+  /@warp-ds/component-classes@1.0.0-alpha.110:
+    resolution: {integrity: sha512-kqOYLHBxNjyuIs7X7hlZyywxua//Gxd6+h3H13d1RT/Zfkjnr/ByUJdFvbcYqPNrNsLLwqdPsRZTbL02f0EuDg==}
     dev: false
 
   /@warp-ds/core@1.0.0:
@@ -2255,11 +2255,35 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/uno@1.0.0-alpha.49:
-    resolution: {integrity: sha512-72c5dT6QAy7GFmL+SN2gRlOsJWBWYM4uJpyw8WA9gCQHNENHXtoWu+D24+c47T9K908M3ZG+2+U1M/FXEZ7ojA==}
+  /@warp-ds/css@1.0.0-alpha.33(@warp-ds/component-classes@1.0.0-alpha.110):
+    resolution: {integrity: sha512-zc+g1CyKptApAfryLKpEc5N3SnPW87gl7Rx2Zz9hGOrqY42PvjG2NplkKbas1/bLvpGKW5VTBrdaVcyt049cFA==}
+    dependencies:
+      '@warp-ds/fonts': 1.1.0
+      '@warp-ds/tokenizer': 0.0.2
+      '@warp-ds/uno': 1.0.0-alpha.58(@warp-ds/component-classes@1.0.0-alpha.110)
+    transitivePeerDependencies:
+      - '@warp-ds/component-classes'
+    dev: false
+
+  /@warp-ds/fonts@1.1.0:
+    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
+    dev: false
+
+  /@warp-ds/tokenizer@0.0.2:
+    resolution: {integrity: sha512-pEtBvP6my14f1kOmYSoDNhofGK/L2yNqnZkEotvY6boVs3jcIncHpgo9Nt4AHOiAvzDrPP0t8b36jwqGaWzNPg==}
+    dependencies:
+      glob: 9.3.5
+      yaml: 2.3.1
+    dev: false
+
+  /@warp-ds/uno@1.0.0-alpha.58(@warp-ds/component-classes@1.0.0-alpha.110):
+    resolution: {integrity: sha512-azdVumf9P46ZwT0uLxOm2ik8yUWupBsVyE7pHncOdkubUBj23oSH8MalaqSO0p/7sK5H9hl6yKFG4lsD/kCYsQ==}
+    peerDependencies:
+      '@warp-ds/component-classes': 1.0.0-alpha.110
     dependencies:
       '@unocss/core': 0.50.8
       '@unocss/preset-mini': 0.50.8
+      '@warp-ds/component-classes': 1.0.0-alpha.110
     dev: false
 
   /@web/browser-logs@0.3.2:
@@ -5030,7 +5054,6 @@ packages:
       minimatch: 8.0.4
       minipass: 4.2.8
       path-scurry: 1.9.2
-    dev: true
 
   /global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -6586,7 +6609,6 @@ packages:
   /lru-cache@9.1.2:
     resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /magic-string@0.30.0:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
@@ -6972,7 +6994,6 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimatch@9.0.1:
     resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
@@ -7065,12 +7086,10 @@ packages:
   /minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -8053,7 +8072,6 @@ packages:
     dependencies:
       lru-cache: 9.1.2
       minipass: 5.0.0
-    dev: true
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -10355,6 +10373,11 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
     dev: true
+
+  /yaml@2.3.1:
+    resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
+    engines: {node: '>= 14'}
+    dev: false
 
   /yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -2,7 +2,8 @@ export async function addContentToPage({ page, content }) {
   let updatedPage = page;
   await page.setContent(content);
   await page.addScriptTag({ path: './dist/index.js', type: 'module' });
-  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/tokens/v1/finn-no.css' });
+  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/tokens/finn-no.css' });
+  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/resets.min.css' });
 
   return updatedPage;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,10 +5,17 @@ import { defineConfig } from 'vite'
 import { createHtmlPlugin } from 'vite-plugin-html';
 import path from 'path';
 import glob from 'glob';
-import { classes } from '@warp-ds/component-classes/classes';
+import { classes } from '@warp-ds/css/component-classes/classes';
 import { MinifyWarpLib } from './.minifier-plugin.js'
 
-
+let reset;
+async function getReset() {
+  if (reset) return reset;
+  else {
+    reset = (await fetch('https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/resets.min.css')).text();
+    return reset;
+  }
+}
 
 export default ({ mode }) => {
   let input = {};
@@ -69,17 +76,25 @@ export default ({ mode }) => {
       }
     })
   }
-  
+
   return {
     // base: isProduction ? '/elements/' : '',
     plugins: [
       uno({
-        presets: [presetWarp()],
+        presets: [presetWarp({ skipResets: true })],
+        preflights: [{
+          layer: 'preflights',
+          getCSS: getReset,
+        }],
         mode: 'shadow-dom',
         safelist: classes,
       }),
       uno({
-        presets: [presetWarp()],
+        presets: [presetWarp({ skipResets: true })],
+        preflights: [{
+          layer: 'preflights',
+          getCSS: getReset,
+        }],
       }),
       // litElementTailwindPlugin({ mode }),
       mode !== 'lib' && createHtmlPlugin({


### PR DESCRIPTION
In this PR we are supporting the new semantic classes that was a breaking change in the @warp-ds/css@1.0.0-alpha.33.

Changes include:

- bump @warp-ds/uno to -alpha.58 & @warp-ds/css to -alpha.33
- import component classes from @warp-ds/css/component-classes
- use new semantic color tokens from @warp-ds/css/1.0.0-alpha.33
- use new resets in uno config