### PR TITLE
fix: trigger release of 1.0.0-alpha.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.0.0-alpha.28](https://github.com/warp-ds/elements/compare/v1.0.0-alpha.27...v1.0.0-alpha.28) (2023-07-14)
-
-
-### Bug Fixes
-
-* use css packages instead of component-classes ([#31](https://github.com/warp-ds/elements/issues/31)) ([1bf8a0a](https://github.com/warp-ds/elements/commit/1bf8a0aee7d5cc46be495648beaf433996f0db4d))
-
 # [1.0.0-alpha.27](https://github.com/warp-ds/elements/compare/v1.0.0-alpha.26...v1.0.0-alpha.27) (2023-07-10)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-ds/elements",
   "type": "module",
-  "version": "1.0.0-alpha.28",
+  "version": "1.0.0-alpha.27",
   "description": "Custom elements for Warp",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
The release job failed in https://github.com/warp-ds/elements/actions/runs/5551876426/jobs/10138511203 so we need to trigger it again by:
a) removing the 1.0.0-alpha.28 tag from https://github.com/warp-ds/elements/tags
b) reverting the last semantic-release-bot commit: 81ca835160352825353caaf3c0664cc93fb7a15a.
c) setting `fix:` prefix on the PR title to tell semantic-release we want our changes released.