### PR TITLE
chore: bump @warp-ds/css package and update eik urls

### DIFF
--- a/elements.css
+++ b/elements.css
@@ -1,1 +1,2 @@
-@import "https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/tokens/finn-no.css";
+@import "https://assets.finn.no/pkg/@warp-ds/fonts/v1/finn-no.css";
+@import "https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.37/tokens/finn-no.css";

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
     "@warp-ds/uno": "^1.0.0-alpha.60",
-    "@warp-ds/css": "1.0.0-alpha.33",
+    "@warp-ds/css": "1.0.0-alpha.37",
     "glob": "8.1.0",
     "html-format": "1.1.2",
     "lit": "2.7.5"

--- a/pages/includes/head.html
+++ b/pages/includes/head.html
@@ -2,8 +2,8 @@
   <title>Warp Elements</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
-
-  <link href="https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/tokens/finn-no.css" rel="stylesheet" />
+  <link href="https://assets.finn.no/pkg/@warp-ds/fonts/v1/finn-no.css" rel="stylesheet" />
+  <link href="https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.37/tokens/finn-no.css" rel="stylesheet" />
 
   <style>
     html { font-size: 62.5%; }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ dependencies:
     specifier: 1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: 1.0.0-alpha.33
-    version: 1.0.0-alpha.33
+    specifier: 1.0.0-alpha.37
+    version: 1.0.0-alpha.37
   '@warp-ds/uno':
     specifier: ^1.0.0-alpha.60
-    version: 1.0.0-alpha.60(@warp-ds/css@1.0.0-alpha.33)
+    version: 1.0.0-alpha.60(@warp-ds/css@1.0.0-alpha.37)
   glob:
     specifier: 8.1.0
     version: 8.1.0
@@ -2232,12 +2232,12 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.0.0-alpha.33:
-    resolution: {integrity: sha512-zc+g1CyKptApAfryLKpEc5N3SnPW87gl7Rx2Zz9hGOrqY42PvjG2NplkKbas1/bLvpGKW5VTBrdaVcyt049cFA==}
+  /@warp-ds/css@1.0.0-alpha.37:
+    resolution: {integrity: sha512-kBJ6zytvgaIH0GSDMg2IC8VYMtCDoCN/TxxtdQyh4wq+VPe95+5hz+asqUSnJuMUUuIj1jsrPkQb2bfCCcTUdg==}
     dependencies:
       '@warp-ds/fonts': 1.1.0
       '@warp-ds/tokenizer': 0.0.2
-      '@warp-ds/uno': 1.0.0-alpha.60(@warp-ds/css@1.0.0-alpha.33)
+      '@warp-ds/uno': 1.0.0-alpha.60(@warp-ds/css@1.0.0-alpha.37)
     dev: false
 
   /@warp-ds/fonts@1.1.0:
@@ -2251,14 +2251,14 @@ packages:
       yaml: 2.3.1
     dev: false
 
-  /@warp-ds/uno@1.0.0-alpha.60(@warp-ds/css@1.0.0-alpha.33):
+  /@warp-ds/uno@1.0.0-alpha.60(@warp-ds/css@1.0.0-alpha.37):
     resolution: {integrity: sha512-66rZPwuneD7UY31CgCvwVpTN/dlmnutoGRBqHaVsJHNCkQT9SumE5jaz+iCmuoA4hbsxFmrsGHO89Oq1CX4WJQ==}
     peerDependencies:
       '@warp-ds/css': ^1.0.0-alpha.33
     dependencies:
       '@unocss/core': 0.50.8
       '@unocss/preset-mini': 0.50.8
-      '@warp-ds/css': 1.0.0-alpha.33
+      '@warp-ds/css': 1.0.0-alpha.37
     dev: false
 
   /@web/browser-logs@0.3.3:

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -2,8 +2,9 @@ export async function addContentToPage({ page, content }) {
   let updatedPage = page;
   await page.setContent(content);
   await page.addScriptTag({ path: './dist/index.js', type: 'module' });
-  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/tokens/finn-no.css' });
-  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/resets.min.css' });
+  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/fonts/v1/finn-no.css' });
+  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.37/tokens/finn-no.css' });
+  await page.addStyleTag({ url: 'https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.37/resets.css' });
 
   return updatedPage;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,7 @@ let reset;
 async function getReset() {
   if (reset) return reset;
   else {
-    reset = (await fetch('https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.33/resets.min.css')).text();
+    reset = (await fetch('https://assets.finn.no/pkg/@warp-ds/css/1.0.0-alpha.37/resets.css')).text();
     return reset;
   }
 }


### PR DESCRIPTION
Bumping @warp-ds/css package includes a fix for the select chevron in component classes