### PR TITLE
fix(@warp-ds/toast): remove window reference from toast api bundle, fixing server-side rendering

### DIFF
--- a/packages/broadcast/component.js
+++ b/packages/broadcast/component.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
-import { windowExists } from '../utils';
+import { windowExists } from '../utils/window-exists';
 
 export class WarpBroadcast extends LitElement {
   static properties = {

--- a/packages/toast/api.js
+++ b/packages/toast/api.js
@@ -1,4 +1,4 @@
-import { windowExists } from '../utils';
+import { windowExists } from '../utils/window-exists';
 
 /**
  * Toast helper function options

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -28,8 +28,6 @@ export function classes(defn) {
   return classes.join(' ');
 }
 
-export const windowExists = typeof window !== 'undefined';
-
 export function fclasses(definition) {
   const defn = {};
   for (const [key, value] of Object.entries(definition)) {

--- a/packages/utils/window-exists.js
+++ b/packages/utils/window-exists.js
@@ -1,0 +1,1 @@
+export const windowExists = typeof window !== 'undefined';


### PR DESCRIPTION
The toast API relies on a utility function to prevent browser APIs from being called in a non-browser environment (eg. Node). The utility function identifies non-browser environments by checking  if the window object is defined. The function was imported from a package that also imported the classmap function from lit-html, which in itself contains a reference to the window object on top-level of the module. This causes server-side rendering to fail as soon as the imported modules are parsed and evaluated.

To fix this issue, the utility function in question is moved to a separate module that does not contain transitive references to the window object, and it can now safely be used for server-side rendering.