### PR TITLE
fix: provide correct import of windowExists after refactoring

### DIFF
--- a/pages/includes/scripts.js
+++ b/pages/includes/scripts.js
@@ -3,7 +3,7 @@ import 'uno.css';
 import { toast, updateToast, removeToast } from '../../index.js';
 import { WarpToastContainer } from '../../packages/toast/toast-container.js';
 import '@fabric-ds/icons/elements/bag-16';
-import { windowExists } from '../../packages/utils/index.js';
+import { windowExists } from '../../packages/utils/window-exists';
 
 if (windowExists) {
     window.WarpToastContainer = WarpToastContainer;


### PR DESCRIPTION
Styles are gone due to 👇 
<img width="1576" alt="image" src="https://github.com/warp-ds/elements/assets/37986637/d56ba9b3-879f-48b8-8cb7-5d36d3d5b395">
