### PR TITLE
fix: add fabrics old template to style our internal docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 
   <%- include('head.html'); -%>
   <body>
+    <f-docs-template>
       <%- include('nav.html'); -%>
 
       <div slot="banner" class="mx-auto p-32" style="max-width: 1024">
@@ -96,6 +97,7 @@
         </div>
       </main>
       <%- include('footer.html'); -%>
-
+    </f-docs-template>
+    <%- include('scripts.html'); -%>
   </body>
 </html>

--- a/pages/components/button.html
+++ b/pages/components/button.html
@@ -1,6 +1,7 @@
 <html lang="en">
   <%- include('head.html'); -%>
   <body>
+    <f-docs-template>
       <%- include('nav.html'); -%>
       <main slot="content">
         <h1 class="mb-16">Button</h1>
@@ -144,6 +145,8 @@
         </p>
       </main>
       <%- include('footer.html'); -%>
+    </f-docs-template>
     <%- include('buttonVariantsTable.html'); -%>
+    <%- include('scripts.html'); -%>
   </body>
 </html>

--- a/pages/includes/head.html
+++ b/pages/includes/head.html
@@ -2,9 +2,21 @@
   <title>Warp Elements</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
+  <style>
+    f-docs-template {
+      visibility: hidden;
+    }
+    f-docs-template:defined {
+      visibility: visible;
+    }
+  </style>
   <link href="https://assets.finn.no/pkg/@warp-ds/fonts/v1/finn-no.css" rel="stylesheet" />
   <link href="https://assets.finn.no/pkg/@warp-ds/css/v1/tokens/finn-no.css" rel="stylesheet" />
-
+  <link href="https://assets.finn.no/pkg/@fabric-ds/common/v1/css/markdown.css" rel="stylesheet" />
+  <link
+    href="https://assets.finn.no/pkg/@fabric-ds/common/v1/template/index.js?a=1"
+    rel="modulepreload"
+  />
   <style>
     html { font-size: 62.5%; }
     .tabledoc {

--- a/pages/includes/scripts.html
+++ b/pages/includes/scripts.html
@@ -1,0 +1,4 @@
+<script
+  src="https://assets.finn.no/pkg/@fabric-ds/common/v1/template/index.js"
+  type="module"
+></script>


### PR DESCRIPTION
Startpage 👇 
<img width="1561" alt="image" src="https://github.com/warp-ds/elements/assets/37986637/44fcddb0-5c19-4d0d-a845-906f3fc6ff04">

Button component 👇 
<img width="1600" alt="image" src="https://github.com/warp-ds/elements/assets/37986637/d8c07a13-7d5d-4fca-8c19-e889afc197b8">
