### PR TITLE
revert: add lit to rollup options to be able to build icons

### DIFF
--- a/build-elements.js
+++ b/build-elements.js
@@ -9,7 +9,7 @@ import importSvg from 'postcss-import-svg';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url); // have to do these hacks it seems because import.meta.resolve is cranky
-const iconsLocation = path.resolve(path.dirname(require.resolve('@warp-ds/icons/package.json')), 'dist');
+const iconsLocation = path.resolve(path.dirname(require.resolve('@fabric-ds/icons/package.json')), 'dist');
 
 const from = './elements.css';
 const css = fs.readFileSync(from, 'utf8');

--- a/packages/expandable/index.js
+++ b/packages/expandable/index.js
@@ -5,7 +5,7 @@ import {
   expandable as ccExpandable,
 } from '@warp-ds/css/component-classes';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import '@warp-ds/icons/elements/chevron-down-16';
+import '@fabric-ds/icons/elements/chevron-down-16';
 
 class WarpExpandable extends kebabCaseAttributes(LitElement) {
   static properties = {
@@ -103,7 +103,7 @@ class WarpExpandable extends kebabCaseAttributes(LitElement) {
                         [ccExpandable.chevronNonBox]: !this.box,
                       })}
                     >
-                      <w-icon-chevron-down16></w-icon-chevron-down16>
+                      <f-icon-chevron-down16></f-icon-chevron-down16>
                     </div>`}
               </div>
             </button>

--- a/pages/includes/scripts.js
+++ b/pages/includes/scripts.js
@@ -2,7 +2,7 @@ import '../../index.js';
 import 'uno.css';
 import { toast, updateToast, removeToast } from '../../index.js';
 import { WarpToastContainer } from '../../packages/toast/toast-container.js';
-import '@warp-ds/icons/elements/bag-16';
+import '@fabric-ds/icons/elements/bag-16';
 import { windowExists } from '../../packages/utils/window-exists';
 
 if (windowExists) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -72,7 +72,7 @@ export default ({ mode }) => {
           entry: './index.js',
           fileName: 'index'
         },
-        rollupOptions: { external: ['elements', 'lit'] }
+        rollupOptions: { external: ['elements'] }
       }
     })
   }


### PR DESCRIPTION
Reverts warp-ds/elements#53

We need to import @warp-ds/icons before the merge