### PR TITLE
fix: alert examples

### DIFF
--- a/pages/components/alert.html
+++ b/pages/components/alert.html
@@ -147,7 +147,7 @@
           <w-alert variant="info" show role="">
             <p role="alert" class="font-bold">This is a "info" variant of the alert element</p>
             <p>You see this warning because you did something wrong</p>
-            <w-button small primary>Hide and show alert</w-button>
+            <w-button variant="primary" small>Hide and show alert</w-button>
           </w-alert>
         </syntax-highlight>
         <div class="example">
@@ -155,7 +155,7 @@
             <p role="alert" class="font-bold">This is "info" variant of the alert element</p>
             <p>With an additional description</p>
             <div id="selfHidingAlertControllers">
-              <w-button small primary>Hide and show alert</w-button>
+              <w-button variant="primary" small>Hide and show alert</w-button>
             </div>
           </w-alert>
         </div>

--- a/pages/includes/alertControllersScripts.html
+++ b/pages/includes/alertControllersScripts.html
@@ -3,7 +3,7 @@
     const alertElement = document.getElementById(alertId);
     const controllersWrapperId = `#${alertId}Controllers`;
 
-    document.querySelectorAll(`${controllersWrapperId} button`).forEach((el) => {
+    document.querySelectorAll(`${controllersWrapperId} w-button`).forEach((el) => {
       el.addEventListener('click', (event) => {
         alertElement.show = false;
         const name = event.target.name || 'info';

--- a/pages/includes/alertControllersScripts.html
+++ b/pages/includes/alertControllersScripts.html
@@ -6,7 +6,7 @@
     document.querySelectorAll(`${controllersWrapperId} w-button`).forEach((el) => {
       el.addEventListener('click', (event) => {
         alertElement.show = false;
-        const name = event.target.name || 'info';
+        const name = el.getAttribute('name') || 'info';
 
         // update alert after hide transition ends
         setTimeout(() => {


### PR DESCRIPTION
Now when clicking controller buttons the Alert closes and opens + its variant and text updates correctly:
![alert-examples](https://github.com/warp-ds/elements/assets/41303231/fc038041-1158-4c42-a6eb-286271e614ae)
