### PR TITLE
fix(attention): popover target is visible on Chrome 109

### DIFF
--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -36,6 +36,10 @@ class WarpAttention extends kebabCaseAttributes(LitElement) {
         display: var(--attention-display);
       }
 
+      :host([popover]:not(:popover-open):not(dialog[open])) {
+        display: contents;
+      }
+
       #arrow {
         border-top-left-radius: 4px;
         z-index: 1;

--- a/pages/components/attention.html
+++ b/pages/components/attention.html
@@ -87,7 +87,7 @@
           <w-attention placement="bottom" popover>
             <button
               id="target"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               onclick="toggleShow()"
               slot="target"
             >
@@ -100,7 +100,7 @@
           <w-attention placement="bottom" popover>
             <button
               id="popoverTarget"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               Click to toggle a popover on bottom
@@ -114,7 +114,7 @@
           <w-attention placement="right" show callout class="flex items-center">
             <div
               id="target"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               <p>This is a target to callout attention element</p>
@@ -126,7 +126,7 @@
           <w-attention placement="right" show callout class="flex items-center">
             <div
               id="calloutTarget"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               <p>This is a target to callout attention element</p>
@@ -140,7 +140,7 @@
           <w-attention placement="right" tooltip>
             <button
               id="target"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               Hover or focus to show a tooltip on right
@@ -152,7 +152,7 @@
           <w-attention placement="right" tooltip>
             <button
               id="tooltipTarget"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               Hover or focus to show a tooltip on right
@@ -188,7 +188,7 @@
             <button
               aria-describedby="aria-content"
               id="target"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               Click to toggle a popover on top
@@ -204,7 +204,7 @@
             <button
               aria-describedby="aria-content"
               id="popoverTarget2"
-              class="group block relative break-words last:mb-0 p-16 rounded-8 bg-aqua-50"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
               slot="target"
             >
               Click to toggle a popover on top


### PR DESCRIPTION
### Issue description
Attention's 'popover' property interferes with the new [Popover API](https://developer.chrome.com/docs/web-platform/popover-api/popover-property/) in Google Chrome and causes the popover to not appear.

### Reproduction
It was apparent when inspecting style of the `<w-attention>` custom element with `popover` attribute.
```
[popover]:not(:popover-open):not(dialog[open]) {
    display: none;
}
```

This PR introduces a quick fix for that, as well as some small style fixes.
<img width="365" alt="Screenshot 2023-09-21 at 10 11 35" src="https://github.com/warp-ds/elements/assets/41303231/f2a9afcf-d7c6-4882-be3b-728a69f9509a">
