### PR TITLE
fix: add lit to rollup options to be able to build icons

### DIFF
--- a/build-elements.js
+++ b/build-elements.js
@@ -9,7 +9,7 @@ import importSvg from 'postcss-import-svg';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url); // have to do these hacks it seems because import.meta.resolve is cranky
-const iconsLocation = path.resolve(path.dirname(require.resolve('@fabric-ds/icons/package.json')), 'dist');
+const iconsLocation = path.resolve(path.dirname(require.resolve('@warp-ds/icons/package.json')), 'dist');
 
 const from = './elements.css';
 const css = fs.readFileSync(from, 'utf8');

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "vite-plugin-html": "3.2.0"
   },
   "dependencies": {
-    "@fabric-ds/icons": "0.6.7",
+    "@warp-ds/icons": "1.0.0",
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
     "@warp-ds/uno": "^1.1.0",

--- a/packages/expandable/index.js
+++ b/packages/expandable/index.js
@@ -5,7 +5,7 @@ import {
   expandable as ccExpandable,
 } from '@warp-ds/css/component-classes';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import '@fabric-ds/icons/elements/chevron-down-16';
+import '@warp-ds/icons/elements/chevron-down-16';
 
 class WarpExpandable extends kebabCaseAttributes(LitElement) {
   static properties = {
@@ -103,7 +103,7 @@ class WarpExpandable extends kebabCaseAttributes(LitElement) {
                         [ccExpandable.chevronNonBox]: !this.box,
                       })}
                     >
-                      <f-icon-chevron-down16></f-icon-chevron-down16>
+                      <w-icon-chevron-down16></w-icon-chevron-down16>
                     </div>`}
               </div>
             </button>

--- a/pages/includes/scripts.js
+++ b/pages/includes/scripts.js
@@ -2,7 +2,7 @@ import '../../index.js';
 import 'uno.css';
 import { toast, updateToast, removeToast } from '../../index.js';
 import { WarpToastContainer } from '../../packages/toast/toast-container.js';
-import '@fabric-ds/icons/elements/bag-16';
+import '@warp-ds/icons/elements/bag-16';
 import { windowExists } from '../../packages/utils/window-exists';
 
 if (windowExists) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@fabric-ds/icons':
-    specifier: 0.6.7
-    version: 0.6.7
   '@open-wc/testing':
     specifier: 3.2.0
     version: 3.2.0
@@ -17,6 +14,9 @@ dependencies:
   '@warp-ds/css':
     specifier: ^1.1.0
     version: 1.1.0
+  '@warp-ds/icons':
+    specifier: 1.0.0
+    version: 1.0.0
   '@warp-ds/uno':
     specifier: ^1.1.0
     version: 1.1.0
@@ -918,10 +918,6 @@ packages:
     resolution: {integrity: sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==}
     dependencies:
       '@types/chai': 4.3.5
-    dev: false
-
-  /@fabric-ds/icons@0.6.7:
-    resolution: {integrity: sha512-1UYhIuvJz9d1c5d3WfuQJLtMc8GNgsFhhFd61PNvSgFbl2IxwuBStK1LqLO0ntrqF2CxxVenhl8ccx4rOql9+w==}
     dev: false
 
   /@fastify/ajv-compiler@3.5.0:
@@ -2281,6 +2277,10 @@ packages:
 
   /@warp-ds/fonts@1.1.0:
     resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
+    dev: false
+
+  /@warp-ds/icons@1.0.0:
+    resolution: {integrity: sha512-wAKyzaanqsB9p6tb1WgwjVuASryEeuH4ypUs+YFH8lw1b12KY3crtlPDB5eWHca/kA8AcKu0Cwz5oJJ+LJ+hGg==}
     dev: false
 
   /@warp-ds/tokenizer@0.0.2:

--- a/vite.config.js
+++ b/vite.config.js
@@ -52,7 +52,7 @@ export default ({ mode }) => {
           entry: './index.js',
           fileName: 'index'
         },
-        rollupOptions: { external: ['elements'] }
+        rollupOptions: { external: ['elements', 'lit'] }
       }
     })
   }


### PR DESCRIPTION
Reverts warp-ds/elements#57

I have reverted the PR before as it was too early before we've published the icons. Now it will be possible I think