### PR TITLE
fix(breadcrumbs): Accessability fix

### DIFF
--- a/packages/breadcrumbs/index.js
+++ b/packages/breadcrumbs/index.js
@@ -1,17 +1,19 @@
 import { html, LitElement, css } from 'lit';
 import { interleave } from '@warp-ds/core/breadcrumbs';
-import { breadcrumbs as ccBreadcrumbs } from '@warp-ds/css/component-classes'
+import { breadcrumbs as ccBreadcrumbs } from '@warp-ds/css/component-classes';
 import { kebabCaseAttributes } from '../utils';
 import { i18n } from '@lingui/core';
-import { messages as enMessages} from './locales/en/messages.mjs';
-import { messages as nbMessages} from './locales/nb/messages.mjs';
-import { messages as fiMessages} from './locales/fi/messages.mjs';
+import { messages as enMessages } from './locales/en/messages.mjs';
+import { messages as nbMessages } from './locales/nb/messages.mjs';
+import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { activateI18n } from '../i18n';
-const separator = html`<span class=${ccBreadcrumbs.separator} aria-hidden='true'>/</span>`;
+const separator = html`<span class=${ccBreadcrumbs.separator}
+  >/</span
+>`;
 
 class WarpBreadcrumbs extends kebabCaseAttributes(LitElement) {
   static styles = css`
-    @unocss-placeholder
+    @unocss-placeholder;
   `;
 
   static properties = {
@@ -22,26 +24,36 @@ class WarpBreadcrumbs extends kebabCaseAttributes(LitElement) {
     super();
     activateI18n(enMessages, nbMessages, fiMessages);
 
-    this.ariaLabel = i18n._(
-    {
+    this.ariaLabel = i18n._({
       id: 'breadcrumbs.ariaLabel',
       message: 'You are here',
-      comment: 'Default screenreader message for the breadcrumb component',
+      comment:
+        'Default screenreader message for the breadcrumb component',
     });
   }
 
   connectedCallback() {
     super.connectedCallback();
     // Grab existing children at the point that the component is added to the page
-    const flattenedChildren = Array.from(this.children).flat(Infinity).filter(child => child)
+    const flattenedChildren = Array.from(this.children)
+      .flat(Infinity)
+      .filter((child) => child);
     const styledChildren = flattenedChildren.map((child, index) => {
       if (typeof child === 'string') {
         const isLastEl = index === children.length - 1;
-        return html`<span class=${ccBreadcrumbs.text} aria-current=${isLastEl ? 'page' : undefined}>${child}</span>`;
+        return html`<span
+          class=${ccBreadcrumbs.text}
+          aria-current=${isLastEl ? 'page' : undefined}
+          >${child}</span
+        >`;
       }
-      child.classList.add(child.tagName === 'A' ? ccBreadcrumbs.link : ccBreadcrumbs.text)
-      return child
-    })
+      child.classList.add(
+        child.tagName === 'A'
+          ? ccBreadcrumbs.link
+          : ccBreadcrumbs.text
+      );
+      return child;
+    });
 
     // Interleave '/' separator with breadcrumbs
     this._children = interleave(styledChildren, separator);
@@ -49,11 +61,11 @@ class WarpBreadcrumbs extends kebabCaseAttributes(LitElement) {
 
   render() {
     return html`
-      <nav aria-label=${this.ariaLabel}>
-        <h2 class=${ccBreadcrumbs.a11y}>${this.ariaLabel}</h2>
-        <div class=${ccBreadcrumbs.wrapper}>
-          ${this._children}
-        </div>
+      <nav aria-labelledby="breadCrumbLabel">
+        <h2 id="breadCrumbLabel" class=${ccBreadcrumbs.a11y}>
+          ${this.ariaLabel}
+        </h2>
+        <div class=${ccBreadcrumbs.wrapper}>${this._children}</div>
       </nav>
     `;
   }


### PR DESCRIPTION
- Fixed the double Aria label
- Removed the aria-hidden from seperators

<img width="1485" alt="image" src="https://github.com/warp-ds/elements/assets/462825/d138b148-7ab0-4166-ad9a-bc2e4a358197">

This component assumes there is only one Breadcrumb on any single page. We should prob. not make assumptions like this anymore in any of or components and perhaps look into as separate tasks: 
- Random key gen all(?) ID's  (as in moving/modernizing this <code>@warp-ds/elements/packages/utils/index.js</code> <code>generateRandomId()</code> to a broader warp toolbox )
- Accept a root heading level if supplied to the component (we prob need to modernize the <code>unstyled-heading.js</code> script for this)