### PR TITLE
fix: anchor text alignment & icon translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
     "@warp-ds/css": "^1.1.1",
-    "@warp-ds/icons": "1.1.0-next.12",
+    "@warp-ds/icons": "1.1.0",
     "@warp-ds/uno": "^1.1.0",
     "glob": "8.1.0",
     "html-format": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@lingui/core": "^4.5.0",
     "@open-wc/testing": "3.2.0",
     "@warp-ds/core": "1.0.0",
-    "@warp-ds/css": "^1.1.1",
+    "@warp-ds/css": "^1.1.2",
     "@warp-ds/icons": "1.1.0",
     "@warp-ds/uno": "^1.1.0",
     "glob": "8.1.0",

--- a/pages/components/button.html
+++ b/pages/components/button.html
@@ -102,17 +102,17 @@
           </div>
         </div>
 
-        <h3 class="mt-32">Link</h3>
+        <h3 class="mt-32">Link (anchor) styled as button</h3>
 
         <div class="md:grid md:grid-cols-3">
           <div class="col-span-2">
             Buttons will be rendered as an anchor (a tag) if they use an href attribute.
             <syntax-highlight>
-              <w-button href="https://google.no">Button as anchor</w-button>
+              <w-button href="https://google.no">Go to google.com</w-button>
             </syntax-highlight>
           </div>
           <div class="grid-example md:ml-48 col-span-2 md:col-span-1">
-            <w-button href="https://google.no">Button as anchor</w-button>
+            <w-button href="https://google.com">Go to google.com</w-button>
           </div>
         </div>
 
@@ -137,12 +137,14 @@
           <div class="col-span-2">
             Button will take the parent's width instead of content width. Useful on mobile when button should take full width. 
             <syntax-highlight>
-              <w-button full-width variant="primary" loading>Primary button loading</w-button>
+              <w-button full-width variant="primary">Button full width</w-button>
+              <w-button full-width variant="primary" href="https://google.com">Go to google.com</w-button>
             </syntax-highlight>
           </div>
           <div class="grid-example md:ml-48 col-span-2 md:col-span-1">
-            <div class="w-full">
+            <div class="w-full flex flex-col gap-8">
               <w-button full-width variant="primary">Button full width</w-button>
+              <w-button full-width variant="primary" href="https://google.com">Go to google.com</w-button>
             </div>
           </div>
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^1.1.1
     version: 1.1.1
   '@warp-ds/icons':
-    specifier: 1.1.0-next.12
-    version: 1.1.0-next.12
+    specifier: 1.1.0
+    version: 1.1.0
   '@warp-ds/uno':
     specifier: ^1.1.0
     version: 1.1.0
@@ -2411,8 +2411,8 @@ packages:
     resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
     dev: false
 
-  /@warp-ds/icons@1.1.0-next.12:
-    resolution: {integrity: sha512-wj0lStq1j5yqlK3G5AZUS5R9uFZVo01rdk3mwilYVsQRoa/xu10L7eQZJluY6pG5jItPmXal/wswZTrWNnpB0A==}
+  /@warp-ds/icons@1.1.0:
+    resolution: {integrity: sha512-2EJhU6L2nhaM3iTC9uApe5KU5/Pb5oNC6UncClfo5VMSjBzUn4RNkwyiyJlk4FrL41P7kre30M+VXpr+3KclFA==}
     dependencies:
       '@lingui/core': 4.5.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: 1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: ^1.1.2
+    version: 1.1.2
   '@warp-ds/icons':
     specifier: 1.1.0
     version: 1.1.0
@@ -2399,16 +2399,11 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.1.1:
-    resolution: {integrity: sha512-xki6RMW9tO1jknPSkBNsWNlU/ADcGUOj4rlMfTBgOm7phwsI9kHd64zxI/29Xuh3dVE+ah7x9BIB0TxoZonSKA==}
+  /@warp-ds/css@1.1.2:
+    resolution: {integrity: sha512-fHR5tY7u62E8mIx2CC7aMDepQKeuBHpbB5DKsGzP6zp+8s1VngWXiQzcemYvLpFUac8BxNy49Ku+ckFQjFoGpQ==}
     dependencies:
-      '@warp-ds/fonts': 1.1.0
       '@warp-ds/tokenizer': 0.0.2
       '@warp-ds/uno': 1.1.0
-    dev: false
-
-  /@warp-ds/fonts@1.1.0:
-    resolution: {integrity: sha512-kLNZzK3o0rMJApm7/YT3K7rYoFKgH5PyJMTVwv34O4Dx6ikfN7appc4f2DFYkE2XY6gifpD5F2r1ftcJtdW4+w==}
     dev: false
 
   /@warp-ds/icons@1.1.0:


### PR DESCRIPTION
- update @warp-ds/css to 1.1.2 to make full-width link (anchor) styled as Button have centered text (Fixes [WARP-347](https://nmp-jira.atlassian.net/browse/WARP-347))
- update @warp-ds/icons to 1.1.0 to fix translations in svg titles