### PR TITLE
chore(crowdin-sync): trigger only on push to next & specify files to track

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -2,7 +2,11 @@ name: Crowdin Synchronisation
 
 on:
   push:
-    branches: [next, main]
+    branches:
+      - next
+    paths:
+      - "**.po"
+      - "crowdin.yml"
 
 jobs:
   synchronize-with-crowdin:


### PR DESCRIPTION
Trigger crowdin-sync job only on push to next branch and if crowdin.yml or .po files change.