### PR TITLE
docs(textfield): add aria-labels to affix buttons with icons

### DIFF
--- a/packages/textfield/test.js
+++ b/packages/textfield/test.js
@@ -199,7 +199,7 @@ test('Component with search suffix is rendered on the page', async (t) => {
   // GIVEN: A box component
   const component = `
     <w-textfield label="Price" placeholder="1 000 000">
-      <w-affix slot="suffix" search></w-affix>
+      <w-affix slot="suffix" search aria-label="Search"></w-affix>
     </w-textfield>
   `;
 
@@ -221,7 +221,7 @@ test('Component with clear suffix is rendered on the page', async (t) => {
   // GIVEN: A box component
   const component = `
     <w-textfield label="Price" placeholder="1 000 000">
-      <w-affix slot="suffix" clear></w-affix>
+      <w-affix slot="suffix" clear aria-label="Clear text"></w-affix>
     </w-textfield>
   `;
 
@@ -244,7 +244,7 @@ test('Component with prefix label and clear suffix is rendered on the page', asy
   const component = `
     <w-textfield label="Price" placeholder="1 000 000">
       <w-affix slot="prefix" label="kr"></w-affix>
-      <w-affix slot="suffix" clear></w-affix>
+      <w-affix slot="suffix" clear aria-label="Clear text"></w-affix>
     </w-textfield>
   `;
 
@@ -267,7 +267,7 @@ test('Affix component button events bubble', async (t) => {
   // GIVEN: A box component
   const component = `
     <w-textfield label="Price" placeholder="1 000 000">
-      <w-affix slot="suffix" clear></w-affix>
+      <w-affix slot="suffix" clear aria-label="Clear text"></w-affix>
     </w-textfield>
     <script>
       const el = document.querySelector('w-affix');

--- a/pages/components/textfield.html
+++ b/pages/components/textfield.html
@@ -280,13 +280,13 @@
         <syntax-highlight>
           <w-textfield label="Price" placeholder="1 000 000">
             <w-affix slot="prefix" label="kr"></w-affix>
-            <w-affix slot="suffix" search></w-affix>
+            <w-affix slot="suffix" search aria-label="Search"></w-affix>
           </w-textfield>
         </syntax-highlight>
         <div class="example">
           <w-textfield label="Price" placeholder="1 000 000">
             <w-affix slot="prefix" label="kr"></w-affix>
-            <w-affix slot="suffix" search></w-affix>
+            <w-affix slot="suffix" search aria-label="Search"></w-affix>
           </w-textfield>
         </div>
 


### PR DESCRIPTION
Fixes [WARP-337](https://nmp-jira.atlassian.net/browse/WARP-337)

Previously the clear and search Affix button would be announced using its icon's title, which describes the appearance of the icon. However, to satisfy the regulations, the Affix button’s aria-label should describe the purpose of the button, i.e. "Clear text", "Search". A11y team doesn't agree with this and says that we should rather describe its appearance, but Uu-tilsynet’s regulations trump those personal views.

In this PR we pass respective aria-labels to Affix components that render as buttons with icons. This means icons title will not be announced, but just the provided aria-label.