### PR TITLE
chore(deps): update @warp-ds/css to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@lingui/core": "^4.5.0",
     "@warp-ds/core": "1.0.0",
-    "@warp-ds/css": "^1.3.0",
+    "@warp-ds/css": "^1.4.1",
     "@warp-ds/elements-core": "0.0.1-alpha.9",
     "@warp-ds/icons": "1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: 1.0.0
     version: 1.0.0
   '@warp-ds/css':
-    specifier: ^1.3.0
-    version: 1.3.0
+    specifier: ^1.4.1
+    version: 1.4.1
   '@warp-ds/elements-core':
     specifier: 0.0.1-alpha.9
     version: 0.0.1-alpha.9
@@ -1329,7 +1329,6 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -2591,24 +2590,25 @@ packages:
 
   /@unocss/core@0.52.7:
     resolution: {integrity: sha512-dZonrlfu33SkUMsZXlsyYSM79tr2nLer/hBEU2ZaemRik2KchxIUNlZV6kX1f1k3m+gEtVQOyx1MImpgLS8PWg==}
+    dev: true
 
   /@unocss/core@0.55.3:
     resolution: {integrity: sha512-2hV9QlE/iOM4DHQ7i6L8sMC1t5/OVAz6AfGHjetTXcgbNfDCsHWqE8jhLZ1y2DeUvKwJvj2A09sYbYQ8E27+Gg==}
+    dev: true
 
   /@unocss/core@0.57.1:
     resolution: {integrity: sha512-cqQW/4gCuk+bFMPg9lBanuRNQ9Lx1l4PpMN/6uKxI5WROpq7ce/Xb4uGvAxKLh3ITtFSpXs2cLfsy7QD6cVD/Q==}
-    dev: true
 
   /@unocss/extractor-arbitrary-variants@0.52.7:
     resolution: {integrity: sha512-nJ4iE7nIRpoOIQfD8S58yG4qJd6AhVPEfEOf7ksX1u8xLf71rrBIojwraRXvv7aPqNdZiWvXdh/znpA/QC5b9w==}
     dependencies:
       '@unocss/core': 0.52.7
+    dev: true
 
   /@unocss/extractor-arbitrary-variants@0.57.1:
     resolution: {integrity: sha512-9s+azHhBnwjxm46TsD1RY0krDAwOR8tcw58Vtl3emd6C0VQsAOdoprt7UHE7GEXMvDVq7nMf8lAT0BM0LteW3w==}
     dependencies:
       '@unocss/core': 0.57.1
-    dev: true
 
   /@unocss/inspector@0.57.1:
     resolution: {integrity: sha512-qV7ta7iHGX2EpZJ4IWY/05kgyhKFeWlvVJbrOnGsaH8gVt33T/43YAhB/8K5GIXBXIwkhwk13iB13nlg2gSheg==}
@@ -2654,6 +2654,7 @@ packages:
     dependencies:
       '@unocss/core': 0.52.7
       '@unocss/extractor-arbitrary-variants': 0.52.7
+    dev: true
 
   /@unocss/preset-mini@0.57.1:
     resolution: {integrity: sha512-v9ZsIUGDfZNXbIrOc7zrBp+RFbFFGSQN/vKIf761js4fJ31j6lan4pPQPGcY17xHConkI1HJT/+yb/UVJaAcHw==}
@@ -2661,7 +2662,6 @@ packages:
       '@unocss/core': 0.57.1
       '@unocss/extractor-arbitrary-variants': 0.57.1
       '@unocss/rule-utils': 0.57.1
-    dev: true
 
   /@unocss/preset-tagify@0.57.1:
     resolution: {integrity: sha512-GV8knxnsOVH/XiG2KB+mVZeEJqr0PZvvkSTPftGPbjttoKVZ+28Y5q9/qezH7p4W6RYVAAK+3qHHy5wWZosiMw==}
@@ -2710,7 +2710,6 @@ packages:
     dependencies:
       '@unocss/core': 0.57.1
       magic-string: 0.30.5
-    dev: true
 
   /@unocss/scope@0.57.1:
     resolution: {integrity: sha512-ZAzg6lLGwKNQGCvJXEie3TvGztkAyajEFqygu0mjtHb+CmDql4iAjoygs+3dnRI5hSDwfMYFrJ2azX26+2CsoA==}
@@ -2774,11 +2773,11 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.3.0:
-    resolution: {integrity: sha512-RFq9rqsRz581RB3/VfeDIebGDGbjKDbARqTSPP1tOBjUo/+mBJ80Z1RP7DV0Q3bUi+5tAz8TuPBCZcoQqToSxw==}
+  /@warp-ds/css@1.4.1:
+    resolution: {integrity: sha512-AgVOEU4f023CKTMxTnH8+BTNhGjAVux88EeIR/ikch5FM2nArCTpp7af8/qGZOhc7QDegJvHlt6DcCR7rqyIQg==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.2
-      '@warp-ds/uno': 1.1.0
+      '@warp-ds/uno': 1.2.0
     dev: false
 
   /@warp-ds/elements-core@0.0.1-alpha.9:
@@ -2807,6 +2806,15 @@ packages:
     dependencies:
       '@unocss/core': 0.55.3
       '@unocss/preset-mini': 0.52.7
+    dev: true
+
+  /@warp-ds/uno@1.2.0:
+    resolution: {integrity: sha512-P5zq8/Bzg33HXR0UxupqJROZK3/QFJOc+bzABN3qTihPCkiqLJCWHxqf2a61Bleg1yK4mTQv+J3FRfYyeZCUow==}
+    dependencies:
+      '@unocss/core': 0.57.1
+      '@unocss/preset-mini': 0.57.1
+      '@unocss/rule-utils': 0.57.1
+    dev: false
 
   /@web/browser-logs@0.3.3:
     resolution: {integrity: sha512-wt8arj0x7ghXbnipgCvLR+xQ90cFg16ae23cFbInCrJvAxvyI22bAtT24W4XOXMPXwWLBVUJwBgBcXo3oKIvDw==}
@@ -7366,7 +7374,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}


### PR DESCRIPTION
@warp-ds/css v1.4.1 introduces the following fixes:

- **expandable**: fix long titles overflowing chevron (https://github.com/warp-ds/css/issues/89) ([9de1b4c](https://github.com/warp-ds/css/commit/9de1b4cc1bd28620fefb6f30e58acfd20d7c4119))
- **expandable**: Only show focus indicator in Expandable component on focus-visible (https://github.com/warp-ds/css/issues/84) ([ccf30f2](https://github.com/warp-ds/css/commit/ccf30f2f9e20a93477cc7f5cf9dc602293320fc6))
- **expandable**: fix chevron icons using part classes in Elements (https://github.com/warp-ds/css/issues/88) ([7940b1a](https://github.com/warp-ds/css/commit/7940b1a1d39c6343d80882f6fec4f51fdd02a9e9))

