### PR TITLE
fix(textfield): allow styling input's left padding when prefix is wider than 40px

### DIFF
--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -39,6 +39,9 @@ class WarpTextField extends WarpElement {
       ::slotted(:last-child) {
         margin-bottom: 0px !important;
       }
+      .warp-input-with-prefix {
+        padding-left:var(--w-prefix-width, 40px);
+      }
     `,
   ];
 
@@ -54,7 +57,9 @@ class WarpTextField extends WarpElement {
       [input.disabled]: this.disabled,
       [input.readOnly]: this.readOnly,
       [input.suffix]: this._hasSuffix,
-      [input.prefix]: this._hasPrefix,
+      // we style input with prefix here because we cannot use
+      // arbitrary values with commas in UnoCSS like pl-[var(--w-prefix-width, 40px)]
+      'warp-input-with-prefix': this._hasPrefix,
     });
   }
 

--- a/pages/components/textfield.html
+++ b/pages/components/textfield.html
@@ -275,6 +275,16 @@
             <w-affix slot="prefix" label="kr"></w-affix>
           </w-textfield>
         </div>
+        <syntax-highlight>
+          <w-textfield class="[--w-prefix-width:90px]" label="Price" placeholder="1 000 000">
+            <w-affix slot="prefix" label="Long prefix"></w-affix>
+          </w-textfield>
+        </syntax-highlight>
+        <div class="example">
+          <w-textfield class="[--w-prefix-width:90px]" label="Price" placeholder="1 000 000">
+            <w-affix slot="prefix" label="Long prefix"></w-affix>
+          </w-textfield>
+        </div>
 
         You can also use both a prefix and suffix
         <syntax-highlight>


### PR DESCRIPTION
Fixes [WARP-374](https://nmp-jira.atlassian.net/browse/WARP-374)

Prefix is an absolutely positioned component and the gap between that component and the `input`'s content is handled using a left padding on the `input`. It’s currently hard-coded to 40px, but with this quick fix we can let users change it by setting a CSS variable in `TextField`’s class (`<TextField class=”[--w-prefix-wdith: 100px]”>`). It’s not dynamic and users will need to calculate how much padding their input needs, but it’s the only non-breaking quick fix we managed to come up with. We should really consider rewriting these form components completely to properly approach styling of different text fields, affixes etc.

<img width="464" alt="Screenshot with long prefix" src="https://github.com/warp-ds/react/assets/41303231/cc3300d8-d4d0-4cc4-8666-8dc0688cb3a2">
<img width="452" alt="Screenshot with 2-letter prefix" src="https://github.com/warp-ds/react/assets/41303231/ff500993-0a96-48bc-9eec-5c1559c313d4">
<img width="454" alt="Screenshot with no prefix" src="https://github.com/warp-ds/react/assets/41303231/ac9c56e2-410a-4774-a959-98b4c4343168">
