### PR TITLE
chore(crowdin-sync): add new features

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -7,8 +7,12 @@ on:
     paths:
       - "**.po"
       - "crowdin.yml"
+  workflow_dispatch:
+  pull_request_review_comment:
 
 jobs:
   synchronize-with-crowdin:
     uses: warp-ds/reusable-workflows/.github/workflows/crowdin-sync.yml@main
     secrets: inherit
+    with:
+      pull_request_reviewers: "felicia-haggqvist"


### PR DESCRIPTION
Fixes [WARP-418](https://nmp-jira.atlassian.net/browse/WARP-418)

This PR uses the following features of our [reusable crowdin-sync workflow](https://github.com/warp-ds/reusable-workflows)
1. Set a default Crowdin PR reviewer for this repo
2. Forward Crowdin PR comments to Crowdin translators. Unfortunately, the translators won't be able to respond to our comments directly in the PR due to the fact that they are using schibsted enterprise email accounts in Crowdin + Github, and those cannot be added to a public GH organisation. Still, this one-way communication may prove useful when we spot typos or other mistakes in the suggested changes.

Additionally, we enable a manual trigger of the workflow in case we need to sync with Crowdin to get updates to previous translations.