### PR TITLE
fix: rename deleted icons after @warp-ds/icons update to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@warp-ds/core": "1.0.2",
     "@warp-ds/css": "^1.7.0",
     "@warp-ds/elements-core": "0.0.1-alpha.11",
-    "@warp-ds/icons": "1.4.0"
+    "@warp-ds/icons": "2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/alert/index.js
+++ b/packages/alert/index.js
@@ -3,10 +3,10 @@ import WarpElement from "@warp-ds/elements-core";
 import { css, html } from "lit";
 import { alert as ccAlert } from "@warp-ds/css/component-classes";
 import { classNames } from "@chbphone55/classnames";
-import '@warp-ds/icons/elements/alert-info-16'
-import '@warp-ds/icons/elements/alert-warning-16'
-import '@warp-ds/icons/elements/alert-error-16'
-import '@warp-ds/icons/elements/alert-success-16'
+import '@warp-ds/icons/elements/info-16'
+import '@warp-ds/icons/elements/warning-16'
+import '@warp-ds/icons/elements/error-16'
+import '@warp-ds/icons/elements/success-16'
 
 const variants = {
   negative: "negative",
@@ -74,13 +74,13 @@ class WarpAlert extends WarpElement {
 
   get _icon() {
     if (this.variant === variants.info)
-      return html`<w-icon-alert-info-16></w-icon-alert-info-16>`;
+      return html`<w-icon-info-16></w-icon-info-16>`;
     if (this.variant === variants.warning)
-      return html`<w-icon-alert-warning-16></w-icon-alert-warning-16>`;
+      return html`<w-icon-warning-16></w-icon-warning-16>`;
     if (this.variant === variants.negative)
-      return html`<w-icon-alert-error-16></w-icon-alert-error-16>`;
+      return html`<w-icon-error-16></w-icon-error-16>`;
     if (this.variant === variants.positive)
-      return html`<w-icon-alert-success-16></w-icon-alert-success-16>`;
+      return html`<w-icon-success-16></w-icon-success-16>`;
     else return "";
   }
 

--- a/packages/toast/toast.js
+++ b/packages/toast/toast.js
@@ -4,9 +4,9 @@ import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
 import { toast as ccToast } from '@warp-ds/css/component-classes';
 import { expand, collapse } from 'element-collapse';
-import '@warp-ds/icons/elements/alert-warning-16'
-import '@warp-ds/icons/elements/alert-error-16'
-import '@warp-ds/icons/elements/alert-success-16'
+import '@warp-ds/icons/elements/warning-16'
+import '@warp-ds/icons/elements/error-16'
+import '@warp-ds/icons/elements/success-16'
 import '@warp-ds/icons/elements/close-16'
 import { i18n } from '@lingui/core'
 import { messages as enMessages } from './locales/en/messages.mjs'
@@ -124,9 +124,9 @@ export class WarpToast extends WarpElement {
   }
 
   get _iconMarkup() {
-    if (this._warning) return html`<w-icon-alert-warning-16></w-icon-alert-warning-16>`;
-    if (this._error) return html`<w-icon-alert-error-16></w-icon-alert-error-16>`;
-    else return html`<w-icon-alert-success-16></w-icon-alert-success-16>`;
+    if (this._warning) return html`<w-icon-warning-16></w-icon-warning-16>`;
+    if (this._error) return html`<w-icon-error-16></w-icon-error-16>`;
+    else return html`<w-icon-success-16></w-icon-success-16>`;
   }
 
   async collapse() {

--- a/pages/includes/scripts.js
+++ b/pages/includes/scripts.js
@@ -3,6 +3,7 @@ import 'uno.css';
 import { toast, updateToast, removeToast } from '../../index.js';
 import { WarpToastContainer } from '../../packages/toast/toast-container.js';
 import { windowExists } from '../../packages/utils/window-exists';
+import '@warp-ds/icons/elements/bag-16';
 
 if (windowExists) {
     window.WarpToastContainer = WarpToastContainer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: 0.0.1-alpha.11
     version: 0.0.1-alpha.11
   '@warp-ds/icons':
-    specifier: 1.4.0
-    version: 1.4.0
+    specifier: 2.0.0
+    version: 2.0.0
 
 devDependencies:
   '@babel/core':
@@ -2689,8 +2689,8 @@ packages:
       lit: 2.7.6
     dev: false
 
-  /@warp-ds/icons@1.4.0:
-    resolution: {integrity: sha512-CC4LlDUlSa65/ts4REDk8hVC3vY+IA6D6mhTFYg31WpOf8KwfzNY4QnEnXdzbL/1WUFU+fmUSejgqbwI8nnpVw==}
+  /@warp-ds/icons@2.0.0:
+    resolution: {integrity: sha512-a6Zi9CEunu5V0ScfaG42j5LoPK/U9uL5Gcv+/4D9FNQjaPuissqflUL3YpYI2PxTMIrHuyYXfUMWu8gBVGoUdg==}
     dependencies:
       '@lingui/core': 4.7.0
     dev: false


### PR DESCRIPTION
## Description
Fixes [WARP-498](https://nmp-jira.atlassian.net/browse/WARP-498)

This PR updates @warp-ds/icons dependency to 2.0.0 and replaces deprecated icons with the [suggested equivalents](https://warp-ds.github.io/tech-docs/components/icons/#deprecated-icons):

## What's changed
### Rename deprecated alert- icons in Alert and Toast components
<img width="237" alt="Screenshot 2024-02-08 at 12 21 05" src="https://github.com/warp-ds/elements/assets/41303231/74af322c-229c-4902-9e16-849f6c23b7e2">

### Fix a missing bag-16 icon in Expandable example.
<img width="666" alt="Screenshot 2024-02-12 at 12 52 08" src="https://github.com/warp-ds/elements/assets/41303231/639f69e9-6de7-4315-8db7-ca83f364dded">

