### PR TITLE
fix: use correct colors in label and error text

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   "dependencies": {
     "@lingui/core": "4.7.1",
     "@warp-ds/core": "1.0.2",
-    "@warp-ds/css": "1.8.3",
+    "@warp-ds/css": "1.9.1",
     "@warp-ds/elements-core": "0.0.1-alpha.12",
     "@warp-ds/icons": "2.0.0"
   },

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -49,17 +49,11 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
     });
   }
 
-  get #labelClasses() {
-    return classNames({
-      [ccLabel.label]: true,
-      [ccLabel.labelInvalid]: this.invalid,
-    });
-  }
-
   get #helpTextClasses() {
     return classNames({
       [ccHelpText.helpText]: true,
-      [ccHelpText.helpTextInvalid]: this.invalid,
+      [ccHelpText.helpTextColor]: !this.invalid,
+      [ccHelpText.helpTextColorInvalid]: this.invalid,
     });
   }
 
@@ -90,7 +84,7 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
       ${when(
         this.label,
         () =>
-          html`<label class="${this.#labelClasses}" for="${this.#id}">
+          html`<label class="${ccLabel.label}" for="${this.#id}">
             ${this.label}
             ${when(
               this.optional,

--- a/packages/textfield/index.js
+++ b/packages/textfield/index.js
@@ -66,20 +66,14 @@ class WarpTextField extends WarpElement {
   get _helpTextStyles() {
     return fclasses({
       [h.helpText]: true,
-      [h.helpTextInvalid]: this.invalid,
-    });
-  }
-
-  get _labelStyles() {
-    return fclasses({
-      [l.label]: true,
-      [l.labelInvalid]: this.invalid,
+      [h.helpTextColor]: !this.invalid,
+      [h.helpTextColorInvalid]: this.invalid,
     });
   }
 
   get _label() {
     if (this.label) {
-      return html`<label for="${this._id}" class=${this._labelStyles}>${this.label}</label>`;
+      return html`<label for="${this._id}" class=${l.label}>${this.label}</label>`;
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: 1.0.2
     version: 1.0.2
   '@warp-ds/css':
-    specifier: 1.8.3
-    version: 1.8.3
+    specifier: 1.9.1
+    version: 1.9.1
   '@warp-ds/elements-core':
     specifier: 0.0.1-alpha.12
     version: 0.0.1-alpha.12
@@ -2290,8 +2290,8 @@ packages:
       '@floating-ui/dom': 0.5.4
     dev: false
 
-  /@warp-ds/css@1.8.3:
-    resolution: {integrity: sha512-SFG9gmnMv0POtCb9HHp73Gq6Y7eZeoWZDdXhB8tBY71nMRLp45a7tvu5q28OEGIlNF44PGLmRoF2YHbfq+jThg==}
+  /@warp-ds/css@1.9.1:
+    resolution: {integrity: sha512-AlfEwB0ernCxA/TccSElR2sJcTP6crEJthBHBvJyqi+TpUFE8R/8oCdw2Lh4rDCG3b86dtfthi1hzp9JN0LK9w==}
     dependencies:
       '@warp-ds/tokenizer': 0.0.4
       '@warp-ds/uno': 1.9.0
@@ -5042,6 +5042,7 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    requiresBuild: true
     dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
@@ -6441,6 +6442,7 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: true
 
   /require-main-filename@2.0.0:


### PR DESCRIPTION
Depends on https://github.com/warp-ds/css/pull/180

## Description
Fixes [WARP-515](https://nmp-jira.atlassian.net/browse/WARP-515)

Changes based on the [Figma component library](https://www.figma.com/file/oHBCzDdJxHQ6fmFLYWUltf/Warp---Components-2.0?type=design&node-id=954-37013&mode=design&t=NPcTtpnw8dXLMG36-0):
- label color doesn't change when input is invalid
- label optional should have subtle text color (the other changes to label optional should be handled in a separate task)
- helpText color should be negative when input is invalid

<img width="240" alt="Screenshot of TextField component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/535a6a2f-e4ce-4299-9e08-c5710b78b83f">
<img width="245" alt="Screenshot of Selecta component with label in dark grey and help text in red" src="https://github.com/warp-ds/css/assets/41303231/3f9ad6e7-55be-48bd-acda-b87cbf8174d9">
<img width="242" alt="Screenshot of Select component with optional label in subtle grey" src="https://github.com/warp-ds/css/assets/41303231/524068df-b3f9-4de8-837c-cc6c6fd3be5e">
