### PR TITLE
feat: add more functionality to attention component

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@lingui/core": "4.7.1",
-    "@warp-ds/core": "1.1.0",
+    "@warp-ds/core": "1.1.1",
     "@warp-ds/css": "1.9.3",
     "@warp-ds/elements-core": "0.0.1-alpha.12",
     "@warp-ds/icons": "2.0.0"

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -177,7 +177,7 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
   }
 
   get _targetEl() {
-    const targetSlot = this.renderRoot.querySelector("slot[name='target']");
+    const targetSlot = this.renderRoot?.querySelector("slot[name='target']");
     return targetSlot ? targetSlot.assignedNodes()[0] : null;
   }
 

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -344,7 +344,7 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
       this.close();
     }
   }
-  
+
   render() {
     if (!this.callout && this._targetEl === undefined) return html``;
     return html`

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -36,7 +36,7 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
     skidding: { type: Number, reflect: true },
     // Whether Attention element should flip its placement in order to keep it in view
     flip: { type: Boolean, reflect: true },
-    // Whether Attention element should ignore cross axis overflow
+    // Whether Attention element should ignore cross axis overflow when flip is enabled
     crossAxis: { type: Boolean, reflect: true },
     // Choose which preferred placements the Attention element should flip to
     fallbackPlacements: { type: Array, reflect: true },

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -218,6 +218,7 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
     this.attentionState = {
       isShowing: this.show,
       isCallout: this.callout,
+      isTooltip: this.tooltip,
       actualDirection: this._actualDirection,
       directionName: this.placement,
       arrowEl: this._arrowEl,

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -344,29 +344,30 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
       this.close();
     }
   }
-
+  
   render() {
-    return html` ${this.callout || (this._targetEl !== undefined && !this.callout)
-      ? html`<div class=${ifDefined(this.className ? this.className : undefined)}>
-          ${this.placement === 'right-start' || this.placement === 'right' || this.placement === 'right-end' || this.placement === 'bottom-start' || this.placement === 'bottom' || this.placement === 'bottom-end' // Attention's and its arrow's visual position should be reflected in the DOM
-            ? html`
-                <slot name="target"></slot>
+    if (!this.callout && this._targetEl === undefined) return html``;
+    return html`
+      <div class=${ifDefined(this.className ? this.className : undefined)}>
+        ${this.placement === 'right-start' || this.placement === 'right' || this.placement === 'right-end' || this.placement === 'bottom-start' || this.placement === 'bottom' || this.placement === 'bottom-end' // Attention's and its arrow's visual position should be reflected in the DOM
+          ? html`
+              <slot name="target"></slot>
 
-                <div id="attention" role="${this.tooltip ? 'tooltip' : 'img'}" aria-label="${this.defaultAriaLabel()}" class="${this._wrapperClasses}">
-                  ${this._arrowHtml}
-                  <slot name="message"></slot>
-                  ${this.canClose ? this._closeBtnHtml : nothing}
-                </div>
-              `
-            : html`
-                <div id="attention" class="${this._wrapperClasses}">
-                  <slot name="message"></slot>
-                  ${this._arrowHtml} ${this.canClose ? this._closeBtnHtml : nothing}
-                </div>
-                <slot name="target"></slot>
-              `}
-        </div>`
-      : ''}`;
+              <div id="attention" role="${this.tooltip ? 'tooltip' : 'img'}" aria-label="${this.defaultAriaLabel()}" class="${this._wrapperClasses}">
+                ${this._arrowHtml}
+                <slot name="message"></slot>
+                ${this.canClose ? this._closeBtnHtml : nothing}
+              </div>
+            `
+          : html`
+              <div id="attention" class="${this._wrapperClasses}">
+                <slot name="message"></slot>
+                ${this._arrowHtml} ${this.canClose ? this._closeBtnHtml : nothing}
+              </div>
+              <slot name="target"></slot>
+            `}
+      </div>
+    `;
   }
 }
 

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -347,27 +347,27 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
   }
 
   render() {
-    return html`
-      <div class=${ifDefined(this.className ? this.className : undefined)}>
-        ${this.placement === 'right-start' || this.placement === 'right' || this.placement === 'right-end' || this.placement === 'bottom-start' || this.placement === 'bottom' || this.placement === 'bottom-end' // Attention's and its arrow's visual position should be reflected in the DOM
-          ? html`
-              <slot name="target"></slot>
+    return html` ${this.callout || (this._targetEl !== undefined && !this.callout)
+      ? html`<div class=${ifDefined(this.className ? this.className : undefined)}>
+          ${this.placement === 'right-start' || this.placement === 'right' || this.placement === 'right-end' || this.placement === 'bottom-start' || this.placement === 'bottom' || this.placement === 'bottom-end' // Attention's and its arrow's visual position should be reflected in the DOM
+            ? html`
+                <slot name="target"></slot>
 
-              <div id="attention" role="${this.tooltip ? 'tooltip' : 'img'}" aria-label="${this.defaultAriaLabel()}" class="${this._wrapperClasses}">
-                ${this._arrowHtml}
-                <slot name="message"></slot>
-                ${this.canClose ? this._closeBtnHtml : nothing}
-              </div>
-            `
-          : html`
-              <div id="attention" class="${this._wrapperClasses}">
-                <slot name="message"></slot>
-                ${this._arrowHtml} ${this.canClose ? this._closeBtnHtml : nothing}
-              </div>
-              <slot name="target"></slot>
-            `}
-      </div>
-    `;
+                <div id="attention" role="${this.tooltip ? 'tooltip' : 'img'}" aria-label="${this.defaultAriaLabel()}" class="${this._wrapperClasses}">
+                  ${this._arrowHtml}
+                  <slot name="message"></slot>
+                  ${this.canClose ? this._closeBtnHtml : nothing}
+                </div>
+              `
+            : html`
+                <div id="attention" class="${this._wrapperClasses}">
+                  <slot name="message"></slot>
+                  ${this._arrowHtml} ${this.canClose ? this._closeBtnHtml : nothing}
+                </div>
+                <slot name="target"></slot>
+              `}
+        </div>`
+      : ''}`;
   }
 }
 

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -221,7 +221,6 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
     this.attentionState = {
       isShowing: this.show,
       isCallout: this.callout,
-      isTooltip: this.tooltip,
       actualDirection: this._actualDirection,
       directionName: this.placement,
       arrowEl: this._arrowEl,

--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -36,6 +36,8 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
     skidding: { type: Number, reflect: true },
     // Whether Attention element should flip its placement in order to keep it in view
     flip: { type: Boolean, reflect: true },
+    // Whether Attention element should ignore cross axis overflow
+    crossAxis: { type: Boolean, reflect: true },
     // Choose which preferred placements the Attention element should flip to
     fallbackPlacements: { type: Array, reflect: true },
   };
@@ -73,6 +75,7 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
     this.distance = 8;
     this.skidding = 0;
     this.flip = false;
+    this.crossAxis = false;
     this._initialPlacement = this.placement;
     this._actualDirection = this.placement;
   }
@@ -228,6 +231,7 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
       distance: this.distance,
       skidding: this.skidding,
       flip: this.flip,
+      crossAxis: this.crossAxis,
       fallbackPlacements: this.fallbackPlacements,
     };
 

--- a/pages/components/attention.html
+++ b/pages/components/attention.html
@@ -237,7 +237,7 @@
 
         <h3 class="mt-24 mb-16">Highlight</h3>
         <syntax-highlight>
-          <w-attention placement="right" highlight>
+          <w-attention placement="right" highlight flip>
             <button
               id="target"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
@@ -250,7 +250,7 @@
           </w-attention>
         </syntax-highlight>
         <div class="example">
-          <w-attention placement="right" highlight>
+          <w-attention placement="right" highlight flip>
             <button
               id="highlightTarget"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
@@ -265,7 +265,7 @@
 
         <h3 class="mt-24 mb-16">Dismissible Highlight</h3>
         <syntax-highlight>
-          <w-attention placement="bottom" highlight can-close flip fallback-placements='["bottom", "right", "top"]'>
+          <w-attention placement="bottom" highlight can-close flip cross-axis fallback-placements='["bottom", "right", "top"]'>
             <button
               id="target"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
@@ -278,7 +278,7 @@
           </w-attention>
         </syntax-highlight>
         <div class="example">
-          <w-attention placement="bottom" highlight id="dismissibleHighlight" can-close flip fallback-placements='["bottom", "right", "top"]'>
+          <w-attention placement="bottom" highlight id="dismissibleHighlight" can-close flip cross-axis fallback-placements='["bottom", "right", "top"]'>
             <button
               id="dismissibleHighlightTarget"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"

--- a/pages/components/attention.html
+++ b/pages/components/attention.html
@@ -237,7 +237,7 @@
 
         <h3 class="mt-24 mb-16">Highlight</h3>
         <syntax-highlight>
-          <w-attention placement="right" highlight flip>
+          <w-attention placement="bottom" highlight flip>
             <button
               id="target"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
@@ -250,7 +250,7 @@
           </w-attention>
         </syntax-highlight>
         <div class="example">
-          <w-attention placement="right" highlight flip>
+          <w-attention placement="bottom" highlight flip>
             <button
               id="highlightTarget"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
@@ -265,7 +265,7 @@
 
         <h3 class="mt-24 mb-16">Dismissible Highlight</h3>
         <syntax-highlight>
-          <w-attention placement="bottom" highlight can-close flip cross-axis fallback-placements='["bottom", "right", "top"]'>
+          <w-attention placement="bottom" highlight can-close flip cross-axis fallback-placements='["right", "top", "left", "bottom"]'>
             <button
               id="target"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
@@ -278,7 +278,7 @@
           </w-attention>
         </syntax-highlight>
         <div class="example">
-          <w-attention placement="bottom" highlight id="dismissibleHighlight" can-close flip cross-axis fallback-placements='["bottom", "right", "top"]'>
+          <w-attention placement="bottom" highlight id="dismissibleHighlight" can-close flip cross-axis fallback-placements='["right", "top", "left", "bottom"]'>
             <button
               id="dismissibleHighlightTarget"
               class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: 4.7.1
     version: 4.7.1
   '@warp-ds/core':
-    specifier: 1.1.0
-    version: 1.1.0(@floating-ui/dom@1.6.3)
+    specifier: 1.1.1
+    version: 1.1.1(@floating-ui/dom@1.6.3)
   '@warp-ds/css':
     specifier: 1.9.3
     version: 1.9.3
@@ -2305,8 +2305,8 @@ packages:
       - rollup
     dev: true
 
-  /@warp-ds/core@1.1.0(@floating-ui/dom@1.6.3):
-    resolution: {integrity: sha512-ZMpeE/ZWLBJkHL6CtR02JIRGm7RM1iwhVal1Vo9wC2HU2JqGOMBG9T0vCK7FNqjZXTgw7TPgVqJpbkLnTD3KTg==}
+  /@warp-ds/core@1.1.1(@floating-ui/dom@1.6.3):
+    resolution: {integrity: sha512-JL7Zzi8djG9NOpZMebn4zuP7zAu8C5nAnplvJuMnWrExg3Kw+ZP9wnJWJJ+wNPASPbqHxshVHbNTBStGGTCeqw==}
     peerDependencies:
       '@floating-ui/dom': 1.6.3
     dependencies:


### PR DESCRIPTION
**Part of fixes for Jira-tickets:** [WARP-432](https://nmp-jira.atlassian.net/browse/WARP-432), [WARP-341](https://nmp-jira.atlassian.net/browse/WARP-341) & [WARP-373](https://nmp-jira.atlassian.net/browse/WARP-373)

- Add `cross-axis` prop
- Only render attention component when `targetEl` is not undefined or when it is a `callout`
- Bump to latest version of `@warp-ds/core` dependency
