### PR TITLE
fix: add a mr-8 to calloutTarget div

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@lingui/core": "4.7.1",
-    "@warp-ds/core": "1.1.1",
+    "@warp-ds/core": "1.1.2",
     "@warp-ds/css": "1.9.7",
     "@warp-ds/elements-core": "0.0.1",
     "@warp-ds/icons": "2.0.1"

--- a/pages/components/attention.html
+++ b/pages/components/attention.html
@@ -226,7 +226,7 @@
           <w-attention placement="right" show callout class="flex items-center">
             <div
               id="calloutTarget"
-              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle"
+              class="group block relative break-words last-child:mb-0 p-16 rounded-8 s-bg-subtle mr-8"
               slot="target"
             >
               <p>This is a target to callout attention element</p>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1
       '@warp-ds/core':
-        specifier: 1.1.1
-        version: 1.1.1(@floating-ui/dom@1.6.3)
+        specifier: 1.1.2
+        version: 1.1.2(@floating-ui/dom@1.6.3)
       '@warp-ds/css':
         specifier: 1.9.7
         version: 1.9.7
@@ -1279,8 +1279,8 @@ packages:
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0
 
-  '@warp-ds/core@1.1.1':
-    resolution: {integrity: sha512-JL7Zzi8djG9NOpZMebn4zuP7zAu8C5nAnplvJuMnWrExg3Kw+ZP9wnJWJJ+wNPASPbqHxshVHbNTBStGGTCeqw==}
+  '@warp-ds/core@1.1.2':
+    resolution: {integrity: sha512-Y5m3cqbtB1qlp9/OYBmO7N6CE9x8l57HUHyynBWXFQDqcfxKZxjCcU4TCleQFpAlKXgqqdQ7CL8MZqIuG5F38g==}
     peerDependencies:
       '@floating-ui/dom': 1.6.3
 
@@ -5860,7 +5860,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@warp-ds/core@1.1.1(@floating-ui/dom@1.6.3)':
+  '@warp-ds/core@1.1.2(@floating-ui/dom@1.6.3)':
     dependencies:
       '@floating-ui/dom': 1.6.3
 


### PR DESCRIPTION
Fixes Jira [WARP-527](https://nmp-jira.atlassian.net/browse/WARP-527)

- Update to latest version of @warp-ds/core dependency
- Add class `mr-8` to the callout example in `attention.html`.

**Note:**
- Unlike in [@warp-ds/react](https://github.com/warp-ds/react/pull/248) and [@warp-ds/vue](https://github.com/warp-ds/vue/pull/170), we do not need to create a default div for `targetEl`, since you always have to have  `slot="target"` defined for the attention-component in @warp-ds/elements, regardless of whether callout is `true` or `false`.

**Tested:**
- Tested in Chrome, Firefox and Safari
- Also tested in Server-side rendered app
