### PR TITLE
fix: update release.yml to include retry for semantic-release and only if succesful will it publish to eik

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: |
+          for i in {1..3}; do
+            npx semantic-release && break || sleep 30
+          done
       - name: Eik login and publish
+        if: success()
         run: pnpm eik login -k $EIK_TOKEN && pnpm eik publish || true
         env:
           EIK_TOKEN: ${{ secrets.EIK_TOKEN }}


### PR DESCRIPTION
Sometimes we get this error when trying to make a semantic release after having merged a PR: 
`"An error occurred while running semantic-release: RequestError [HttpError]: You have exceeded a secondary rate limit. Please wait a few minutes before you try again."`

This PR updates the `release.yml` file so that it will try 3 times to make a semantic release, and only if it has successfully made a semantic-release will it publish to EIK.