### PR TITLE
fix(card): clean up classes

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -18,6 +18,11 @@ files:
       "translation": "/packages/button/locales/%two_letters_code%/messages.po",
     },
     {
+      "source": "/packages/card/locales/en/messages.po",
+      "dest": "elements/packages/card/messages.po",
+      "translation": "/packages/card/locales/%two_letters_code%/messages.po",
+    },
+    {
       "source": "/packages/select/locales/en/messages.po",
       "dest": "elements/packages/select/messages.po",
       "translation": "/packages/select/locales/%two_letters_code%/messages.po",

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -13,6 +13,10 @@ const config: LinguiConfig = {
       path: 'packages/button/locales/{locale}/messages',
     },
     {
+      include: ['packages/card/index.js'],
+      path: 'packages/card/locales/{locale}/messages',
+    },
+    {
       include: ['packages/select/index.js'],
       path: 'packages/select/locales/{locale}/messages',
     },

--- a/packages/attention/locales/da/messages.po
+++ b/packages/attention/locales/da/messages.po
@@ -15,58 +15,58 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: da\n"
 "X-Crowdin-File-ID: 12402\n"
+"PO-Revision-Date: \n"
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:175
+#: packages/attention/index.js:296
 msgid "attention.aria.callout"
 msgstr "En grøn taleboble der introducerer noget nyt"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/index.js:231
+#: packages/attention/index.js:203
 msgid "attention.aria.close"
 msgstr "Luk"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:189
+#: packages/attention/index.js:308
 msgid "attention.aria.highlight"
 msgstr "En opmærksomhedsskabende taleboble med vigtig information"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:147
+#: packages/attention/index.js:269
 msgid "attention.aria.pointingDown"
 msgstr "peger nedad"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:154
+#: packages/attention/index.js:277
 msgid "attention.aria.pointingLeft"
 msgstr "peger til venstre"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:140
+#: packages/attention/index.js:261
 msgid "attention.aria.pointingRight"
 msgstr "peger til højre"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:133
+#: packages/attention/index.js:253
 msgid "attention.aria.pointingUp"
 msgstr "peger opad"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:182
+#: packages/attention/index.js:302
 msgid "attention.aria.popover"
 msgstr "En hvid taleboble med mere information"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:168
+#: packages/attention/index.js:290
 msgid "attention.aria.tooltip"
 msgstr "En sort taleboble med flere oplysninger"
-

--- a/packages/attention/locales/en/messages.po
+++ b/packages/attention/locales/en/messages.po
@@ -16,55 +16,54 @@ msgstr ""
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:175
+#: packages/attention/index.js:296
 msgid "attention.aria.callout"
 msgstr "A green speech bubble introducing something new"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/index.js:231
+#: packages/attention/index.js:203
 msgid "attention.aria.close"
 msgstr "Close"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:189
+#: packages/attention/index.js:308
 msgid "attention.aria.highlight"
 msgstr "An attention speech bubble with important information"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:147
+#: packages/attention/index.js:269
 msgid "attention.aria.pointingDown"
 msgstr "pointing down"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:154
+#: packages/attention/index.js:277
 msgid "attention.aria.pointingLeft"
 msgstr "pointing left"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:140
+#: packages/attention/index.js:261
 msgid "attention.aria.pointingRight"
 msgstr "pointing right"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:133
+#: packages/attention/index.js:253
 msgid "attention.aria.pointingUp"
 msgstr "pointing up"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:182
+#: packages/attention/index.js:302
 msgid "attention.aria.popover"
 msgstr "A white speech bubble providing additional information"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:168
+#: packages/attention/index.js:290
 msgid "attention.aria.tooltip"
 msgstr "A black speech bubble providing complementary information"
-

--- a/packages/attention/locales/fi/messages.po
+++ b/packages/attention/locales/fi/messages.po
@@ -15,58 +15,58 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: fi\n"
 "X-Crowdin-File-ID: 12402\n"
+"PO-Revision-Date: \n"
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:175
+#: packages/attention/index.js:296
 msgid "attention.aria.callout"
 msgstr "Vihreä puhekupla, joka esittelee jotain uutta"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/index.js:231
+#: packages/attention/index.js:203
 msgid "attention.aria.close"
 msgstr "Sulje"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:189
+#: packages/attention/index.js:308
 msgid "attention.aria.highlight"
 msgstr "Puhekupla, joka sisältää tärkeää tietoa"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:147
+#: packages/attention/index.js:269
 msgid "attention.aria.pointingDown"
 msgstr "osoittaa alas"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:154
+#: packages/attention/index.js:277
 msgid "attention.aria.pointingLeft"
 msgstr "osoittaa vasemmalle"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:140
+#: packages/attention/index.js:261
 msgid "attention.aria.pointingRight"
 msgstr "osoittaa oikealle"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:133
+#: packages/attention/index.js:253
 msgid "attention.aria.pointingUp"
 msgstr "osoittaa ylös"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:182
+#: packages/attention/index.js:302
 msgid "attention.aria.popover"
 msgstr "Valkoinen puhekupla, joka tarjoaa lisätietoa"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:168
+#: packages/attention/index.js:290
 msgid "attention.aria.tooltip"
 msgstr "Musta puhekupla, joka tarjoaa täydentävää tietoa"
-

--- a/packages/attention/locales/nb/messages.po
+++ b/packages/attention/locales/nb/messages.po
@@ -15,58 +15,58 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: nb\n"
 "X-Crowdin-File-ID: 12402\n"
+"PO-Revision-Date: \n"
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:175
+#: packages/attention/index.js:296
 msgid "attention.aria.callout"
 msgstr "Grønn taleboble som introduserer noe nytt"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/index.js:231
+#: packages/attention/index.js:203
 msgid "attention.aria.close"
 msgstr "Lukk"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:189
+#: packages/attention/index.js:308
 msgid "attention.aria.highlight"
 msgstr "En uthevet taleboble med viktig informasjon"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:147
+#: packages/attention/index.js:269
 msgid "attention.aria.pointingDown"
 msgstr "peker ned"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:154
+#: packages/attention/index.js:277
 msgid "attention.aria.pointingLeft"
 msgstr "peker til venstre"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:140
+#: packages/attention/index.js:261
 msgid "attention.aria.pointingRight"
 msgstr "peker til høyre"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:133
+#: packages/attention/index.js:253
 msgid "attention.aria.pointingUp"
 msgstr "peker opp"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:182
+#: packages/attention/index.js:302
 msgid "attention.aria.popover"
 msgstr "En hvit taleboble som gir tilleggsinformasjon"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/index.js:168
+#: packages/attention/index.js:290
 msgid "attention.aria.tooltip"
 msgstr "En svart taleboble som forklarer konteksten"
-

--- a/packages/breadcrumbs/locales/da/messages.po
+++ b/packages/breadcrumbs/locales/da/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: da\n"
 "X-Crowdin-File-ID: 1446\n"
+"PO-Revision-Date: \n"
 
 #. Default screenreader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/index.js:26
+#: packages/breadcrumbs/index.js:29
 msgid "breadcrumbs.ariaLabel"
 msgstr "Du er her"
-

--- a/packages/breadcrumbs/locales/en/messages.po
+++ b/packages/breadcrumbs/locales/en/messages.po
@@ -16,7 +16,6 @@ msgstr ""
 
 #. Default screenreader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/index.js:26
+#: packages/breadcrumbs/index.js:29
 msgid "breadcrumbs.ariaLabel"
 msgstr "You are here"
-

--- a/packages/breadcrumbs/locales/fi/messages.po
+++ b/packages/breadcrumbs/locales/fi/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: fi\n"
 "X-Crowdin-File-ID: 1446\n"
+"PO-Revision-Date: \n"
 
 #. Default screenreader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/index.js:26
+#: packages/breadcrumbs/index.js:29
 msgid "breadcrumbs.ariaLabel"
 msgstr "Olet tässä"
-

--- a/packages/breadcrumbs/locales/nb/messages.po
+++ b/packages/breadcrumbs/locales/nb/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: nb\n"
 "X-Crowdin-File-ID: 1446\n"
+"PO-Revision-Date: \n"
 
 #. Default screenreader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/index.js:26
+#: packages/breadcrumbs/index.js:29
 msgid "breadcrumbs.ariaLabel"
 msgstr "Her er du"
-

--- a/packages/button/locales/da/messages.po
+++ b/packages/button/locales/da/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: da\n"
 "X-Crowdin-File-ID: 1450\n"
+"PO-Revision-Date: \n"
 
 #. Screenreader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/index.js:48
+#: packages/button/index.js:45
 msgid "button.aria.loading"
 msgstr "Indlæser..."
-

--- a/packages/button/locales/en/messages.po
+++ b/packages/button/locales/en/messages.po
@@ -16,7 +16,6 @@ msgstr ""
 
 #. Screenreader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/index.js:48
+#: packages/button/index.js:45
 msgid "button.aria.loading"
 msgstr "Loading..."
-

--- a/packages/button/locales/fi/messages.po
+++ b/packages/button/locales/fi/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: fi\n"
 "X-Crowdin-File-ID: 1450\n"
+"PO-Revision-Date: \n"
 
 #. Screenreader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/index.js:48
+#: packages/button/index.js:45
 msgid "button.aria.loading"
 msgstr "Ladataan..."
-

--- a/packages/button/locales/nb/messages.po
+++ b/packages/button/locales/nb/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: nb\n"
 "X-Crowdin-File-ID: 1450\n"
+"PO-Revision-Date: \n"
 
 #. Screenreader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/index.js:48
+#: packages/button/index.js:45
 msgid "button.aria.loading"
 msgstr "Laster..."
-

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -75,7 +75,7 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
       html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">${this.buttonText}</button>`;
     const renderSpan = () => html`<span role="checkbox" aria-checked="true" aria-disabled="true"></span>`;
 
-    return this.clickable ? renderButton() : !this.clickable && this.selected ? renderSpan() : '';
+    return this.clickable ? renderButton() : this.selected ? renderSpan() : '';
   }
 
   keypressed(e) {
@@ -89,7 +89,7 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
   render() {
     return html`
       <div tabindex=${ifDefined(this.clickable ? '0' : undefined)} class="${this._containerClasses}" @keydown=${this.keypressed}>
-        ${this._interactiveElement} ${!this.flat ? html`<div class="${this._outlineClasses}"></div>` : ''}
+        ${this._interactiveElement} ${this.flat ? '' : html`<div class="${this._outlineClasses}"></div>`}
         <slot></slot>
       </div>
     `;

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -1,17 +1,45 @@
 import { html, css } from 'lit';
 
+import { classNames } from '@chbphone55/classnames';
+import { i18n } from '@lingui/core';
 import { card as ccCard } from '@warp-ds/css/component-classes';
 import WarpElement from '@warp-ds/elements-core';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-import { fclasses } from '../utils';
+import { activateI18n } from '../i18n';
+import { kebabCaseAttributes } from '../utils';
+
+import { messages as daMessages } from './locales/da/messages.mjs';
+import { messages as enMessages } from './locales/en/messages.mjs';
+import { messages as fiMessages } from './locales/fi/messages.mjs';
+import { messages as nbMessages } from './locales/nb/messages.mjs';
 
 const keys = {
   ENTER: 'Enter',
   SPACE: ' ',
 };
 
-class WarpCard extends WarpElement {
+class WarpCard extends kebabCaseAttributes(WarpElement) {
+  static properties = {
+    selected: { type: Boolean, reflect: true },
+    flat: { type: Boolean },
+    clickable: { type: Boolean },
+  };
+
+  constructor() {
+    super();
+    activateI18n(enMessages, nbMessages, fiMessages, daMessages);
+
+    this.selected = false;
+    this.flat = false;
+    this.clickable = false;
+    this.buttonText = i18n._({
+      id: 'card.button.text',
+      message: 'Select',
+      comment: 'Screenreader message to indicate that the card is clickable',
+    });
+  }
+
   static styles = [
     WarpElement.styles,
     css`
@@ -29,42 +57,27 @@ class WarpCard extends WarpElement {
     `,
   ];
 
-  static properties = {
-    selected: { type: Boolean, reflect: true },
-    flat: { type: Boolean },
-    clickable: { type: Boolean },
-  };
-
-  constructor() {
-    super();
-    this.selected = false;
-    this.flat = false;
-    this.clickable = false;
-  }
-
   get _containerClasses() {
-    return fclasses({
-      [ccCard.card]: true,
-      [ccCard.cardShadow]: !this.flat,
-      [ccCard.cardSelected]: !this.flat && this.selected,
-      [ccCard.cardFlat]: this.flat,
-      [this.selected ? ccCard.cardFlatSelected : ccCard.cardFlatUnselected]: this.flat,
-    });
+    let backgroundClass;
+    if (this.selected) {
+      backgroundClass = this.flat ? ccCard.cardFlatSelected : ccCard.cardSelected;
+    } else {
+      backgroundClass = this.flat ? ccCard.cardFlatUnselected : ccCard.cardShadowBackground;
+    }
+
+    return classNames([ccCard.card, this.flat ? ccCard.cardFlat : ccCard.cardShadow, backgroundClass]);
   }
 
   get _outlineClasses() {
-    return fclasses({
-      [ccCard.cardOutline]: true,
-      [this.selected ? ccCard.cardOutlineSelected : ccCard.cardOutlineUnselected]: true,
-    });
+    return classNames([ccCard.cardOutline, this.selected ? ccCard.cardOutlineSelected : ccCard.cardOutlineUnselected]);
   }
 
-  get uuButton() {
-    return html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">Velg</button>`;
-  }
+  get _interactiveElement() {
+    const renderButton = () =>
+      html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">${this.buttonText}</button>`;
+    const renderSpan = () => html`<span role="checkbox" aria-checked="true" aria-disabled="true"></span>`;
 
-  get uuSpan() {
-    return html`<span role="checkbox" aria-checked="true" aria-disabled="true"></span>`;
+    return this.clickable ? renderButton() : !this.clickable && this.selected && renderSpan();
   }
 
   keypressed(e) {
@@ -78,7 +91,7 @@ class WarpCard extends WarpElement {
   render() {
     return html`
       <div tabindex=${ifDefined(this.clickable ? '0' : undefined)} class="${this._containerClasses}" @keydown=${this.keypressed}>
-        ${this.clickable ? this.uuButton : ''} ${!this.clickable && this.selected ? this.uuSpan : ''}
+        ${this._interactiveElement}
         <div class="${this._outlineClasses}"></div>
         <slot></slot>
       </div>

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -58,18 +58,15 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
   ];
 
   get _containerClasses() {
-    let backgroundClass;
-    if (this.selected) {
-      backgroundClass = this.flat ? ccCard.cardFlatSelected : ccCard.cardSelected;
-    } else {
-      backgroundClass = this.flat ? ccCard.cardFlatUnselected : ccCard.cardShadowBackground;
-    }
-
-    return classNames([ccCard.card, this.flat ? ccCard.cardFlat : ccCard.cardShadow, backgroundClass]);
+    return classNames([
+      ccCard.base,
+      this.flat ? ccCard.flat : ccCard.shadow,
+      this.selected ? (this.flat ? ccCard.flatSelected : ccCard.selected) : this.flat && ccCard.flatUnselected,
+    ]);
   }
 
   get _outlineClasses() {
-    return classNames([ccCard.cardOutline, this.selected ? ccCard.cardOutlineSelected : ccCard.cardOutlineUnselected]);
+    return classNames([ccCard.outline, this.selected ? ccCard.outlineSelected : ccCard.outlineUnselected]);
   }
 
   get _interactiveElement() {
@@ -77,7 +74,7 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
       html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">${this.buttonText}</button>`;
     const renderSpan = () => html`<span role="checkbox" aria-checked="true" aria-disabled="true"></span>`;
 
-    return this.clickable ? renderButton() : !this.clickable && this.selected && renderSpan();
+    return this.clickable ? renderButton() : (!this.clickable && this.selected) ? renderSpan() : '';
   }
 
   keypressed(e) {

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -74,7 +74,7 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
       html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">${this.buttonText}</button>`;
     const renderSpan = () => html`<span role="checkbox" aria-checked="true" aria-disabled="true"></span>`;
 
-    return this.clickable ? renderButton() : (!this.clickable && this.selected) ? renderSpan() : '';
+    return this.clickable ? renderButton() : !this.clickable && this.selected ? renderSpan() : '';
   }
 
   keypressed(e) {

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -88,8 +88,7 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
   render() {
     return html`
       <div tabindex=${ifDefined(this.clickable ? '0' : undefined)} class="${this._containerClasses}" @keydown=${this.keypressed}>
-        ${this._interactiveElement}
-        <div class="${this._outlineClasses}"></div>
+        ${this._interactiveElement} ${!this.flat ? html`<div class="${this._outlineClasses}"></div>` : ''}
         <slot></slot>
       </div>
     `;

--- a/packages/card/index.js
+++ b/packages/card/index.js
@@ -61,7 +61,8 @@ class WarpCard extends kebabCaseAttributes(WarpElement) {
     return classNames([
       ccCard.base,
       this.flat ? ccCard.flat : ccCard.shadow,
-      this.selected ? (this.flat ? ccCard.flatSelected : ccCard.selected) : this.flat && ccCard.flatUnselected,
+      this.selected && !this.flat && ccCard.selected,
+      this.selected && this.flat ? ccCard.flatSelected : ccCard.flatUnselected,
     ]);
   }
 

--- a/packages/card/locales/da/messages.mjs
+++ b/packages/card/locales/da/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"card.button.text\":\"Select\"}");

--- a/packages/card/locales/da/messages.po
+++ b/packages/card/locales/da/messages.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-09-21 08:13+0100\n"
+"POT-Creation-Date: 2024-07-30 14:45+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: en\n"
+"Language: da\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
-"X-Crowdin-SourceKey: msgstr\n"
 
-#. Shown behind label when marked as optional
+#. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/select/index.js:105
-msgid "select.label.optional"
-msgstr "(optional)"
+#: packages/card/index.js:34
+msgid "card.button.text"
+msgstr ""

--- a/packages/card/locales/en/messages.mjs
+++ b/packages/card/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"card.button.text\":\"Select\"}");

--- a/packages/card/locales/en/messages.po
+++ b/packages/card/locales/en/messages.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-09-21 08:13+0100\n"
+"POT-Creation-Date: 2024-07-30 14:45+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -12,10 +12,9 @@ msgstr ""
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
-"X-Crowdin-SourceKey: msgstr\n"
 
-#. Shown behind label when marked as optional
+#. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/select/index.js:105
-msgid "select.label.optional"
-msgstr "(optional)"
+#: packages/card/index.js:34
+msgid "card.button.text"
+msgstr "Select"

--- a/packages/card/locales/fi/messages.mjs
+++ b/packages/card/locales/fi/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"card.button.text\":\"Select\"}");

--- a/packages/card/locales/fi/messages.po
+++ b/packages/card/locales/fi/messages.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-09-21 08:13+0100\n"
+"POT-Creation-Date: 2024-07-30 14:45+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: en\n"
+"Language: fi\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
-"X-Crowdin-SourceKey: msgstr\n"
 
-#. Shown behind label when marked as optional
+#. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/select/index.js:105
-msgid "select.label.optional"
-msgstr "(optional)"
+#: packages/card/index.js:34
+msgid "card.button.text"
+msgstr ""

--- a/packages/card/locales/nb/messages.mjs
+++ b/packages/card/locales/nb/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"card.button.text\":\"Select\"}");

--- a/packages/card/locales/nb/messages.po
+++ b/packages/card/locales/nb/messages.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-09-21 08:13+0100\n"
+"POT-Creation-Date: 2024-07-30 14:45+0200\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: en\n"
+"Language: nb\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Plural-Forms: \n"
-"X-Crowdin-SourceKey: msgstr\n"
 
-#. Shown behind label when marked as optional
+#. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/select/index.js:105
-msgid "select.label.optional"
-msgstr "(optional)"
+#: packages/card/index.js:34
+msgid "card.button.text"
+msgstr ""

--- a/packages/pill/locales/da/messages.po
+++ b/packages/pill/locales/da/messages.po
@@ -15,16 +15,16 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: da\n"
 "X-Crowdin-File-ID: 16174\n"
+"PO-Revision-Date: \n"
 
 #. Fallback screenreader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:28
+#: packages/pill/index.js:34
 msgid "pill.aria.openFilter"
 msgstr "Åbn filter"
 
 #. Fallback screenreader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:53
+#: packages/pill/index.js:40
 msgid "pill.aria.removeFilter"
 msgstr "Fjern filter {label}"
-

--- a/packages/pill/locales/en/messages.po
+++ b/packages/pill/locales/en/messages.po
@@ -16,13 +16,12 @@ msgstr ""
 
 #. Fallback screenreader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:28
+#: packages/pill/index.js:34
 msgid "pill.aria.openFilter"
 msgstr "Open filter"
 
 #. Fallback screenreader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:53
+#: packages/pill/index.js:40
 msgid "pill.aria.removeFilter"
 msgstr "Remove filter {label}"
-

--- a/packages/pill/locales/fi/messages.po
+++ b/packages/pill/locales/fi/messages.po
@@ -15,16 +15,16 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: fi\n"
 "X-Crowdin-File-ID: 16174\n"
+"PO-Revision-Date: \n"
 
 #. Fallback screenreader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:28
+#: packages/pill/index.js:34
 msgid "pill.aria.openFilter"
 msgstr "Avaa suodatin"
 
 #. Fallback screenreader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:53
+#: packages/pill/index.js:40
 msgid "pill.aria.removeFilter"
 msgstr "Tyhjennä suodatin {label}"
-

--- a/packages/pill/locales/nb/messages.po
+++ b/packages/pill/locales/nb/messages.po
@@ -15,16 +15,16 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: nb\n"
 "X-Crowdin-File-ID: 16174\n"
+"PO-Revision-Date: \n"
 
 #. Fallback screenreader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:28
+#: packages/pill/index.js:34
 msgid "pill.aria.openFilter"
 msgstr "Åpne filter"
 
 #. Fallback screenreader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/src/component.tsx:53
+#: packages/pill/index.js:40
 msgid "pill.aria.removeFilter"
 msgstr "Fjern filter {label}"
-

--- a/packages/select/locales/da/messages.po
+++ b/packages/select/locales/da/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: da\n"
 "X-Crowdin-File-ID: 1454\n"
+"PO-Revision-Date: \n"
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/index.js:99
+#: packages/select/index.js:105
 msgid "select.label.optional"
 msgstr "(valgfrit)"
-

--- a/packages/select/locales/fi/messages.po
+++ b/packages/select/locales/fi/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: fi\n"
 "X-Crowdin-File-ID: 1454\n"
+"PO-Revision-Date: \n"
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/index.js:99
+#: packages/select/index.js:105
 msgid "select.label.optional"
 msgstr "(vapaaehtoinen)"
-

--- a/packages/select/locales/nb/messages.po
+++ b/packages/select/locales/nb/messages.po
@@ -15,10 +15,10 @@ msgstr ""
 "X-Crowdin-Project-ID: 141\n"
 "X-Crowdin-Language: nb\n"
 "X-Crowdin-File-ID: 1454\n"
+"PO-Revision-Date: \n"
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/index.js:99
+#: packages/select/index.js:105
 msgid "select.label.optional"
 msgstr "(valgfritt)"
-

--- a/packages/toast/locales/da/messages.po
+++ b/packages/toast/locales/da/messages.po
@@ -13,22 +13,24 @@ msgstr ""
 "X-Crowdin-File-ID: 15496\n"
 "Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
 "Language-Team: Danish\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:112
+#: packages/toast/toast.js:108
 msgid "toast.aria.error"
 msgstr "Fejl"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:118
+#: packages/toast/toast.js:114
 msgid "toast.aria.successful"
 msgstr "Fuldført"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:106
+#: packages/toast/toast.js:101
 msgid "toast.aria.warning"
 msgstr "Advarsel"
-

--- a/packages/toast/locales/en/messages.po
+++ b/packages/toast/locales/en/messages.po
@@ -7,22 +7,27 @@ msgstr ""
 "X-Generator: @lingui/cli\n"
 "Language: e\n"
 "X-Crowdin-SourceKey: msgstr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:112
+#: packages/toast/toast.js:108
 msgid "toast.aria.error"
 msgstr "Error"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:118
+#: packages/toast/toast.js:114
 msgid "toast.aria.successful"
 msgstr "Successful"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:106
+#: packages/toast/toast.js:101
 msgid "toast.aria.warning"
 msgstr "Warning"
-

--- a/packages/toast/locales/fi/messages.po
+++ b/packages/toast/locales/fi/messages.po
@@ -13,22 +13,24 @@ msgstr ""
 "X-Crowdin-File-ID: 15496\n"
 "Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
 "Language-Team: Finnish\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:112
+#: packages/toast/toast.js:108
 msgid "toast.aria.error"
 msgstr "Virhe"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:118
+#: packages/toast/toast.js:114
 msgid "toast.aria.successful"
 msgstr "Onnistui"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:106
+#: packages/toast/toast.js:101
 msgid "toast.aria.warning"
 msgstr "Varoitus"
-

--- a/packages/toast/locales/nb/messages.po
+++ b/packages/toast/locales/nb/messages.po
@@ -13,22 +13,24 @@ msgstr ""
 "X-Crowdin-File-ID: 15496\n"
 "Project-Id-Version: 2853b3c41d7b7a59e7cd64c0153b540a\n"
 "Language-Team: Norwegian Bokmal\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:112
+#: packages/toast/toast.js:108
 msgid "toast.aria.error"
 msgstr "Feil"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:118
+#: packages/toast/toast.js:114
 msgid "toast.aria.successful"
 msgstr "Vellykket"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.js:106
+#: packages/toast/toast.js:101
 msgid "toast.aria.warning"
 msgstr "Advarsel"
-

--- a/pages/components/card.html
+++ b/pages/components/card.html
@@ -77,6 +77,19 @@
           </w-card>
         </div>
 
+        <h4>Flat Selected</h4>
+
+        <syntax-highlight>
+          <w-card flat selected>
+            <div class="m-20">This example shows content with a flat selected look</div>
+          </w-card>
+        </syntax-highlight>
+        <div class="example">
+          <w-card flat selected>
+            <div class="m-20">This example shows content with a flat selected look</div>
+          </w-card>
+        </div>
+
 
         <h2 class="mt-24 mb-16">Examples</h2>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.1.5(@floating-ui/dom@1.6.8)
       '@warp-ds/css':
         specifier: github:warp-ds/css#component-classes-cleanup
-        version: https://codeload.github.com/warp-ds/css/tar.gz/06fbe09b2b18a5d12e9d8c8b9af2e0ef0f1cc1ae(@warp-ds/uno@2.0.0(unocss@0.61.8(postcss@8.4.40)(rollup@4.19.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.3))))
+        version: https://codeload.github.com/warp-ds/css/tar.gz/3661360d2274faf0601d74bccd93306080cb6a53(@warp-ds/uno@2.0.0(unocss@0.61.8(postcss@8.4.40)(rollup@4.19.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.3))))
       '@warp-ds/elements-core':
         specifier: 2.x
         version: 2.0.1
@@ -220,8 +220,8 @@ packages:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.25.0':
-    resolution: {integrity: sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==}
+  '@babel/parser@7.25.3':
+    resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -263,8 +263,8 @@ packages:
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.25.2':
-    resolution: {integrity: sha512-s4/r+a7xTnny2O6FcZzqgT6nE4/GHEdcqj4qAeglbUOh0TeglEfmNJFAd/OLoVtGd6ZhAO8GCVvCNUO5t/VJVQ==}
+  '@babel/traverse@7.25.3':
+    resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.25.2':
@@ -1553,8 +1553,8 @@ packages:
     peerDependencies:
       '@floating-ui/dom': 1.6.x
 
-  '@warp-ds/css@https://codeload.github.com/warp-ds/css/tar.gz/06fbe09b2b18a5d12e9d8c8b9af2e0ef0f1cc1ae':
-    resolution: {tarball: https://codeload.github.com/warp-ds/css/tar.gz/06fbe09b2b18a5d12e9d8c8b9af2e0ef0f1cc1ae}
+  '@warp-ds/css@https://codeload.github.com/warp-ds/css/tar.gz/3661360d2274faf0601d74bccd93306080cb6a53':
+    resolution: {tarball: https://codeload.github.com/warp-ds/css/tar.gz/3661360d2274faf0601d74bccd93306080cb6a53}
     version: 2.0.0-next.4
     peerDependencies:
       '@warp-ds/uno': 2.x
@@ -1837,8 +1837,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001644:
-    resolution: {integrity: sha512-YGvlOZB4QhZuiis+ETS0VXR+MExbFf4fZYYeMTEE0aTQd/RdIjkTyZjLrbYVKnHzppDvnOhritRVv+i7Go6mHw==}
+  caniuse-lite@1.0.30001645:
+    resolution: {integrity: sha512-GFtY2+qt91kzyMk6j48dJcwJVq5uTkk71XxE3RtScx7XWRLsO7bU44LOFkOZYR8w9YMS0UhPSYpN/6rAMImmLw==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2268,8 +2268,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.3:
-    resolution: {integrity: sha512-QNdYSS5i8D9axWp/6XIezRObRHqaav/ur9z1VzCDUCH1XIFOr9WQk5xmgunhsTpjjgDy3oLxO/WMOVZlpUQrlA==}
+  electron-to-chromium@1.5.4:
+    resolution: {integrity: sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==}
 
   element-collapse@1.1.0:
     resolution: {integrity: sha512-jgwpetB8NlM/Z7DI1y3/zw0rWEQqxKc3rzooBtzzCwaEVlUzPquoxvE3J2r6cJahYjMXUAm/KKBD6lpyzva4+Q==}
@@ -4633,8 +4633,8 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
-  tsx@4.16.2:
-    resolution: {integrity: sha512-C1uWweJDgdtX2x600HjaFaucXTilT7tgUZHbOE4+ypskZ1OP8CRCSDkCxG6Vya9EwaFIVagWwpaVAn5wzypaqQ==}
+  tsx@4.16.3:
+    resolution: {integrity: sha512-MP8AEUxVnboD2rCC6kDLxnpDBNWN9k3BSVU/0/nNxgm70bPBnfn+yCKcnOsIVPQwdkbKYoFOlKjjWZWJ2XCXUg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -5018,9 +5018,9 @@ snapshots:
       '@babel/helper-compilation-targets': 7.25.2
       '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
       '@babel/helpers': 7.25.0
-      '@babel/parser': 7.25.0
+      '@babel/parser': 7.25.3
       '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
       convert-source-map: 2.0.0
       debug: 4.3.6
@@ -5057,21 +5057,21 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.24.7
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-member-expression-to-functions@7.24.8':
     dependencies:
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
     transitivePeerDependencies:
       - supports-color
@@ -5082,7 +5082,7 @@ snapshots:
       '@babel/helper-module-imports': 7.24.7
       '@babel/helper-simple-access': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5097,20 +5097,20 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-member-expression-to-functions': 7.24.8
       '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-simple-access@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     dependencies:
-      '@babel/traverse': 7.25.2
+      '@babel/traverse': 7.25.3
       '@babel/types': 7.25.2
     transitivePeerDependencies:
       - supports-color
@@ -5133,7 +5133,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.0.1
 
-  '@babel/parser@7.25.0':
+  '@babel/parser@7.25.3':
     dependencies:
       '@babel/types': 7.25.2
 
@@ -5185,14 +5185,14 @@ snapshots:
   '@babel/template@7.25.0':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.25.0
+      '@babel/parser': 7.25.3
       '@babel/types': 7.25.2
 
-  '@babel/traverse@7.25.2':
+  '@babel/traverse@7.25.3':
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/generator': 7.25.0
-      '@babel/parser': 7.25.0
+      '@babel/parser': 7.25.3
       '@babel/template': 7.25.0
       '@babel/types': 7.25.2
       debug: 4.3.6
@@ -5650,7 +5650,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/generator': 7.25.0
-      '@babel/parser': 7.25.0
+      '@babel/parser': 7.25.3
       '@babel/runtime': 7.25.0
       '@babel/types': 7.25.2
       '@lingui/babel-plugin-extract-messages': 4.11.2
@@ -6601,7 +6601,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.6.8
 
-  '@warp-ds/css@https://codeload.github.com/warp-ds/css/tar.gz/06fbe09b2b18a5d12e9d8c8b9af2e0ef0f1cc1ae(@warp-ds/uno@2.0.0(unocss@0.61.8(postcss@8.4.40)(rollup@4.19.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.3))))':
+  '@warp-ds/css@https://codeload.github.com/warp-ds/css/tar.gz/3661360d2274faf0601d74bccd93306080cb6a53(@warp-ds/uno@2.0.0(unocss@0.61.8(postcss@8.4.40)(rollup@4.19.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.3))))':
     dependencies:
       '@warp-ds/uno': 2.0.0(unocss@0.61.8(postcss@8.4.40)(rollup@4.19.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.3)))
 
@@ -6858,8 +6858,8 @@ snapshots:
 
   browserslist@4.23.2:
     dependencies:
-      caniuse-lite: 1.0.30001644
-      electron-to-chromium: 1.5.3
+      caniuse-lite: 1.0.30001645
+      electron-to-chromium: 1.5.4
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
 
@@ -6931,7 +6931,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001644: {}
+  caniuse-lite@1.0.30001645: {}
 
   chalk@2.4.2:
     dependencies:
@@ -7361,7 +7361,7 @@ snapshots:
     dependencies:
       jake: 10.9.2
 
-  electron-to-chromium@1.5.3: {}
+  electron-to-chromium@1.5.4: {}
 
   element-collapse@1.1.0: {}
 
@@ -8232,7 +8232,7 @@ snapshots:
       jiti-v1: jiti@1.21.6
       pathe: 1.1.2
       pkg-types: 1.1.3
-      tsx: 4.16.2
+      tsx: 4.16.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9994,7 +9994,7 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  tsx@4.16.2:
+  tsx@4.16.3:
     dependencies:
       esbuild: 0.21.5
       get-tsconfig: 4.7.6


### PR DESCRIPTION
## Description
This PR ensures no classes styling the same CSS properties are being set on the same HTML element in the `Card` component.

**Changes:**
- Refactor classes in `Card` component
- Replace `ccCard.card` with `ccCard.base`
- Add translation to replace hardcoded button text
- Only render `<div class="${this._outlineClasses}"></div>` when `this.flat` is false, like we also do in react and vue
- Add another example to showcase how the card looks like when both `flat` and `selected` are true

## How to test
Either link this branch with @warp-ds/css (`fix/cleanup-card-classes` branch) or replace this for @warp-ds/css dependency in package.json: `github:warp-ds/css#component-classes-cleanup` with this  `github:warp-ds/css#fix/cleanup-card-classes`