### PR TITLE
fix(modal): add aria labels to back and close buttons

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -33,6 +33,11 @@ files:
       "translation": "/packages/attention/locales/%two_letters_code%/messages.po",
     },
     {
+      "source": "/packages/modal/locales/en/messages.po",
+      "dest": "elements/packages/modal/messages.po",
+      "translation": "/packages/modal/locales/%two_letters_code%/messages.po",
+    },
+    {
       "source": "/packages/toast/locales/en/messages.po",
       "dest": "elements/packages/toast/messages.po",
       "translation": "/packages/toast/locales/%two_letters_code%/messages.po",

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -25,6 +25,10 @@ const config: LinguiConfig = {
       path: 'packages/attention/locales/{locale}/messages',
     },
     {
+      include: ['packages/modal/modal-header.js'],
+      path: 'packages/modal/locales/{locale}/messages',
+    },
+    {
       include: ['packages/toast/toast.js'],
       path: 'packages/toast/locales/{locale}/messages',
     },

--- a/packages/modal/locales/da/messages.mjs
+++ b/packages/modal/locales/da/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"modal.aria.back\":\"Tilbage\",\"modal.aria.close\":\"Luk\"}");

--- a/packages/modal/locales/da/messages.po
+++ b/packages/modal/locales/da/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2024-08-15 10:40+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: da\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Aria label for the back button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:69
+msgid "modal.aria.back"
+msgstr "Tilbage"
+
+#. Aria label for the close button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:84
+msgid "modal.aria.close"
+msgstr "Luk"

--- a/packages/modal/locales/en/messages.mjs
+++ b/packages/modal/locales/en/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"modal.aria.back\":\"Back\",\"modal.aria.close\":\"Close\"}");

--- a/packages/modal/locales/en/messages.po
+++ b/packages/modal/locales/en/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2024-08-15 10:40+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Aria label for the back button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:69
+msgid "modal.aria.back"
+msgstr "Back"
+
+#. Aria label for the close button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:84
+msgid "modal.aria.close"
+msgstr "Close"

--- a/packages/modal/locales/fi/messages.mjs
+++ b/packages/modal/locales/fi/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"modal.aria.back\":\"Takaisin\",\"modal.aria.close\":\"Sulje\"}");

--- a/packages/modal/locales/fi/messages.po
+++ b/packages/modal/locales/fi/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2024-08-15 10:40+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Aria label for the back button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:69
+msgid "modal.aria.back"
+msgstr "Takaisin"
+
+#. Aria label for the close button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:84
+msgid "modal.aria.close"
+msgstr "Sulje"

--- a/packages/modal/locales/nb/messages.mjs
+++ b/packages/modal/locales/nb/messages.mjs
@@ -1,0 +1,1 @@
+/*eslint-disable*/export const messages=JSON.parse("{\"modal.aria.back\":\"Tilbake\",\"modal.aria.close\":\"Lukk\"}");

--- a/packages/modal/locales/nb/messages.po
+++ b/packages/modal/locales/nb/messages.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2024-08-15 10:40+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: nb\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. Aria label for the back button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:69
+msgid "modal.aria.back"
+msgstr "Tilbake"
+
+#. Aria label for the close button in modal
+#. js-lingui-explicit-id
+#: packages/modal/modal-header.js:84
+msgid "modal.aria.close"
+msgstr "Lukk"

--- a/packages/modal/modal-header.js
+++ b/packages/modal/modal-header.js
@@ -1,12 +1,19 @@
 import { html, nothing } from 'lit';
 
 import { Move } from '@itsy/animate/move';
+import { i18n } from '@lingui/core';
 import { modalElement as ccModal } from '@warp-ds/css/component-classes';
 import '@warp-ds/icons/elements/arrow-left-16';
 import '@warp-ds/icons/elements/close-16';
 import WarpElement from '@warp-ds/elements-core';
 import { createRef, ref } from 'lit/directives/ref.js';
 
+import { activateI18n } from '../i18n';
+
+import { messages as daMessages } from './locales/da/messages.mjs';
+import { messages as enMessages } from './locales/en/messages.mjs';
+import { messages as fiMessages } from './locales/fi/messages.mjs';
+import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { CanCloseMixin } from './util.js';
 
 const NO_CLOSE_BUTTON = 'no-close';
@@ -22,6 +29,8 @@ export class ModalHeader extends CanCloseMixin(WarpElement) {
   };
   constructor() {
     super();
+    activateI18n(enMessages, nbMessages, fiMessages, daMessages);
+
     this._hasTopContent = false;
   }
   render() {
@@ -55,15 +64,28 @@ export class ModalHeader extends CanCloseMixin(WarpElement) {
 
   get backButton() {
     return this.back && !this._hasTopContent // Not showing back button when there is a top image
-      ? html` <button type="button" class="${ccModal.headerButton} ${ccModal.headerButtonLeft}" @click="${this.emitBack}">
+      ? html`<button
+          type="button"
+          aria-label="${i18n._({
+            id: 'modal.aria.back',
+            message: 'Back',
+            comment: 'Aria label for the back button in modal',
+          })}"
+          class="${ccModal.headerButton} ${ccModal.headerButtonLeft}"
+          @click="${this.emitBack}">
           <w-icon-arrow-left-16></w-icon-arrow-left-16>
         </button>`
       : nothing;
   }
   get closeButton() {
     if (this[NO_CLOSE_BUTTON]) return nothing;
-    return html` <button
+    return html`<button
       type="button"
+      aria-label="${i18n._({
+        id: 'modal.aria.close',
+        message: 'Close',
+        comment: 'Aria label for the close button in modal',
+      })}"
       class="${ccModal.headerButton} ${this._hasTopContent ? ccModal.headerCloseButtonOnImage : ccModal.headerCloseButton}"
       @click="${this.close}">
       <w-icon-close-16></w-icon-close-16>


### PR DESCRIPTION
## Description
This change aligns Modal Element with React/Vue Modal implementations, but above all helps screen reader users understand what's the purpose of the modal header navigation buttons. The translations for Danish, Finnish and Norwegian were copied over from [React Modal locales](https://github.com/warp-ds/react/tree/next/packages/modal/src/locales).

## Testing
- works with VoiceOver on Chrome/Safari/Firefox
- the translations are applied correctly in all language versions of a running test app