### PR TITLE
fix(badge): remove deprecated 'notification' example

### DIFF
--- a/packages/badge/index.js
+++ b/packages/badge/index.js
@@ -7,7 +7,7 @@ import WarpElement from '@warp-ds/elements-core';
 class WarpBadge extends WarpElement {
   static properties = {
     variant: {
-      type: 'neutral' | 'info' | 'positive' | 'warning' | 'negative' | 'disabled' | 'notification' | 'price',
+      type: 'neutral' | 'info' | 'positive' | 'warning' | 'negative' | 'disabled' | 'price',
     },
     position: {
       type: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left',

--- a/pages/components/badge.html
+++ b/pages/components/badge.html
@@ -20,7 +20,7 @@
           <tbody class="align-top">
             <tr>
               <td>variant</td>
-              <td>'neutral' | 'info' | 'positive' | 'warning' |'negative' | 'disabled' | 'notification' | 'price'</td>
+              <td>'neutral' | 'info' | 'positive' | 'warning' |'negative' | 'disabled' | 'price'</td>
               <td>'neutral'</td>
             </tr>
             <tr>
@@ -53,7 +53,6 @@
           <w-badge variant="warning">warning badge</w-badge>
           <w-badge variant="negative">negative badge</w-badge>
           <w-badge variant="disabled">disabled badge</w-badge>
-          <w-badge variant="notification">notification badge</w-badge>
           <w-badge variant="price">price badge</w-badge>
         </syntax-highlight>
         <div class="example">
@@ -64,7 +63,6 @@
             <li><w-badge variant="warning">warning badge</w-badge></li>
             <li><w-badge variant="negative">negative badge</w-badge></li>
             <li><w-badge variant="disabled">disabled badge</w-badge></li>
-            <li><w-badge variant="notification">notification badge</w-badge></li>
             <li><w-badge variant="price">price badge</w-badge></li>
           </ul>
         </div>


### PR DESCRIPTION
The notification variant of Badge is no longer supported in Warp and a corresponding token was removed from @warp-ds/css v2.0.0. This PR removes "notification" variant from Badge properties and cleans up the docs examples.