### PR TITLE
fix: Add select element change event

### DIFF
--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -93,8 +93,8 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
   }
 
   // Fire a custom 'change' event, used when the dropdown changes state.
-  onChange() {
-    let event = new CustomEvent('change', { detail: 'change' });
+  onChange(value) {
+    let event = new CustomEvent('change', { detail: value });
 
     this.dispatchEvent(event);
   }
@@ -128,7 +128,7 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
           aria-invalid="${ifDefined(this.invalid)}"
           aria-errormessage="${ifDefined(this.invalid && this.#helpId)}"
           @keydown=${this.handleKeyDown}
-          @change=${this.onChange}>
+          @change=${(e) => this.onChange(e.target.value)}>
           ${unsafeHTML(this._options)}
         </select>
         <div class="${this.#chevronClasses}">

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -94,7 +94,7 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
 
   // Fire a custom 'change' event, used when the dropdown changes state.
   onChange(value) {
-    let event = new CustomEvent('change', { detail: value });
+    const event = new CustomEvent('change', { detail: value });
 
     this.dispatchEvent(event);
   }

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -92,6 +92,13 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
     return this.hint ? `${this.#id}__hint` : undefined;
   }
 
+  // Fire a custom 'change' event, used when the dropdown changes state.
+  onChange() {
+    let event = new CustomEvent('change', { detail: 'change' });
+
+    this.dispatchEvent(event);
+  }
+
   render() {
     return html`<div class="${ccSelect.wrapper}">
       ${when(
@@ -120,7 +127,8 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
           aria-describedby="${ifDefined(this.#helpId)}"
           aria-invalid="${ifDefined(this.invalid)}"
           aria-errormessage="${ifDefined(this.invalid && this.#helpId)}"
-          @keydown=${this.handleKeyDown}>
+          @keydown=${this.handleKeyDown}
+          @change=${this.onChange}>
           ${unsafeHTML(this._options)}
         </select>
         <div class="${this.#chevronClasses}">

--- a/packages/select/index.js
+++ b/packages/select/index.js
@@ -93,8 +93,8 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
   }
 
   // Fire a custom 'change' event, used when the dropdown changes state.
-  onChange(value) {
-    const event = new CustomEvent('change', { detail: value });
+  onChange({ target }) {
+    const event = new CustomEvent('change', { detail: target.value });
 
     this.dispatchEvent(event);
   }
@@ -128,7 +128,7 @@ export class WarpSelect extends kebabCaseAttributes(WarpElement) {
           aria-invalid="${ifDefined(this.invalid)}"
           aria-errormessage="${ifDefined(this.invalid && this.#helpId)}"
           @keydown=${this.handleKeyDown}
-          @change=${(e) => this.onChange(e.target.value)}>
+          @change=${this.onChange}>
           ${unsafeHTML(this._options)}
         </select>
         <div class="${this.#chevronClasses}">


### PR DESCRIPTION
https://nmp-jira.atlassian.net/browse/WARP-647.

Adds a custom change event to the select component, which fires on dropdown change.

The dropdown value is available on the `detail` field.

To use in Svelte and other libraries (without a wrapper), add event listeners manually (using addEventListener).