### PR TITLE
fix: Improve attention component styling

### DIFF
--- a/packages/attention/index.js
+++ b/packages/attention/index.js
@@ -98,7 +98,11 @@ class WarpAttention extends kebabCaseAttributes(WarpElement) {
     }
 
     // Fix FOUC effect issues
-    setTimeout(() => this.requestUpdate(), 0);
+    setTimeout(() => {
+      this.requestUpdate();
+      this.handleDone(); // Run handleDone initially, to compute correct arrow position etc. directly.
+    }, 0);
+
     if (!this.callout) {
       window.addEventListener('click', this.handleDone);
       window.addEventListener('scroll', this.handleDone);


### PR DESCRIPTION
Improve attention component by running the recompute function on render.
Ensures that arrow/highlight position is computed correctly on first render, giving correct styling if the highlight is shown by default.