### PR TITLE
fix: ease strictness of warp-ds/css peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@warp-ds/css": "2.0.0",
+    "@warp-ds/css": "2.x",
     "@warp-ds/elements-core": "2.x",
     "lit": "3.x"
   },


### PR DESCRIPTION
Allow any 2.x

Fixes a peer dependency warning when I have `2.0.1`

```
 WARN  Issues with peer dependencies found
.
└─┬ @warp-ds/elements 2.0.1
  └── ✕ unmet peer @warp-ds/css@2.0.0: found 2.0.1
```