### PR TITLE
chore: drop the vite lib build that esbuild overwrites

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:docs": "lingui compile && vite build",
     "build:eik": "node build.js eik",
     "build:npm": "node build.js npm",
-    "build": "rimraf dist && rimraf eik && lingui compile && tsc && vite build --mode lib && pnpm run build:npm && pnpm build:eik",
+    "build": "rimraf dist && rimraf eik && lingui compile && tsc && pnpm run build:npm && pnpm build:eik",
     "commit": "cz",
     "dev": "vite",
     "lint:check": "eslint .",

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,112 +53,95 @@ export default ({ mode }) => {
         },
       });
     }
-    if (mode === 'lib') {
-      return defineConfig({
-        build: {
-          emptyOutDir: false,
-          lib: {
-            formats: ['es'],
-            entry: './index.js',
-            fileName: 'index',
-          },
-          rollupOptions: {
-            external: ['elements', 'lit', '@warp-ds/elements-core', /^lit\/.*/],
-          },
-        },
-      });
-    }
   }
 
   return {
     base: isProduction ? '/elements/' : '',
     plugins: [
-      mode !== 'lib' &&
-        uno({
-          presets: [presetWarp()],
-        }),
+      uno({
+        presets: [presetWarp()],
+      }),
       mode === 'development' &&
         uno({
           mode: 'shadow-dom',
           presets: [presetWarp()],
           safelist: classes,
         }),
-      mode !== 'lib' &&
-        createHtmlPlugin({
-          minify: false,
-          pages: [
-            {
-              filename: 'button.html',
-              template: 'pages/components/button.html',
-              injectOptions,
-            },
-            {
-              filename: 'pill.html',
-              template: 'pages/components/pill.html',
-              injectOptions,
-            },
-            {
-              filename: 'alert.html',
-              template: 'pages/components/alert.html',
-              injectOptions,
-            },
-            {
-              filename: 'select.html',
-              template: 'pages/components/select.html',
-              injectOptions,
-            },
-            {
-              filename: 'attention.html',
-              template: 'pages/components/attention.html',
-              injectOptions,
-            },
-            {
-              filename: 'badge.html',
-              template: 'pages/components/badge.html',
-              injectOptions,
-            },
-            {
-              filename: 'box.html',
-              template: 'pages/components/box.html',
-              injectOptions,
-            },
-            {
-              filename: 'breadcrumbs.html',
-              template: 'pages/components/breadcrumbs.html',
-              injectOptions,
-            },
-            {
-              filename: 'card.html',
-              template: 'pages/components/card.html',
-              injectOptions,
-            },
-            {
-              filename: 'modal.html',
-              template: 'pages/components/modal.html',
-              injectOptions,
-            },
-            {
-              filename: 'toast.html',
-              template: 'pages/components/toast.html',
-              injectOptions,
-            },
-            {
-              filename: 'textfield.html',
-              template: 'pages/components/textfield.html',
-              injectOptions,
-            },
-            {
-              filename: 'expandable.html',
-              template: 'pages/components/expandable.html',
-              injectOptions,
-            },
-            {
-              filename: 'index.html',
-              template: 'index.html',
-              injectOptions,
-            },
-          ],
-        }),
+      createHtmlPlugin({
+        minify: false,
+        pages: [
+          {
+            filename: 'button.html',
+            template: 'pages/components/button.html',
+            injectOptions,
+          },
+          {
+            filename: 'pill.html',
+            template: 'pages/components/pill.html',
+            injectOptions,
+          },
+          {
+            filename: 'alert.html',
+            template: 'pages/components/alert.html',
+            injectOptions,
+          },
+          {
+            filename: 'select.html',
+            template: 'pages/components/select.html',
+            injectOptions,
+          },
+          {
+            filename: 'attention.html',
+            template: 'pages/components/attention.html',
+            injectOptions,
+          },
+          {
+            filename: 'badge.html',
+            template: 'pages/components/badge.html',
+            injectOptions,
+          },
+          {
+            filename: 'box.html',
+            template: 'pages/components/box.html',
+            injectOptions,
+          },
+          {
+            filename: 'breadcrumbs.html',
+            template: 'pages/components/breadcrumbs.html',
+            injectOptions,
+          },
+          {
+            filename: 'card.html',
+            template: 'pages/components/card.html',
+            injectOptions,
+          },
+          {
+            filename: 'modal.html',
+            template: 'pages/components/modal.html',
+            injectOptions,
+          },
+          {
+            filename: 'toast.html',
+            template: 'pages/components/toast.html',
+            injectOptions,
+          },
+          {
+            filename: 'textfield.html',
+            template: 'pages/components/textfield.html',
+            injectOptions,
+          },
+          {
+            filename: 'expandable.html',
+            template: 'pages/components/expandable.html',
+            injectOptions,
+          },
+          {
+            filename: 'index.html',
+            template: 'index.html',
+            injectOptions,
+          },
+        ],
+      }),
       isProduction && basePathFix(),
       mode === 'development' &&
         topLevelAwait({


### PR DESCRIPTION
The dist/index.js file built by vite gets immediately replaced by the esbuild npm step.