### PR TITLE
fix: adding setup test script for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ dist
 site/
 eik
 .tap
-
+__screenshots__
 # # i18n related files
 packages/*/locales/*/*.mjs

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@lingui/core": "5.2.0",
     "@open-wc/form-control": "^1.0.0",
+    "@vitest/browser": "^3.2.4",
     "@warp-ds/core": "1.1.8",
     "@warp-ds/css": "2.1.1",
     "@warp-ds/elements-core": "2.0.1",

--- a/packages/alert/alert.test.ts
+++ b/packages/alert/alert.test.ts
@@ -1,25 +1,21 @@
 import { html } from 'lit';
 
-import { expect, test, assert } from 'vitest';
-import { render } from 'vitest-browser-lit';
+import { page } from '@vitest/browser/context';
+import { expect, test } from 'vitest';
+
 import './index.js';
 
-test('renders an info ', async () => {
-  const component = html`<w-alert variant="info" show data-testid="infoMessage">This is information</w-alert>`;
+test('renders an info', async () => {
+  const screen = await page.render(html`<w-alert variant="info" show data-testid="infoMessage">This is information</w-alert>`);
 
-  const screen = render(component);
-
-  assert.equal(screen.getByTestId('infoMessage').element().attributes['variant'].value, 'info');
+  // Verify the icon correct icon is rendered
+  await expect.element(screen.getByTestId('infoMessage').element().shadowRoot.querySelector('w-icon-info-16')).toBeVisible();
   await expect.element(screen.getByTestId('infoMessage')).toBeVisible();
   await expect.element(screen.getByText('This is information')).toBeVisible();
 });
 
-test('renders a warning ', async () => {
-  const component = html`<w-alert variant="warning" show data-testid="warningMessage">This is a warning</w-alert>`;
-
-  const screen = render(component);
-
-  assert.equal(screen.getByTestId('warningMessage').element().attributes['variant'].value, 'warning');
-  await expect.element(screen.getByTestId('warningMessage')).toBeVisible();
-  await expect.element(screen.getByText('This is a warning')).toBeVisible();
+test('does not render when "show" is not set / or not true', async () => {
+  const component = html`<w-alert variant="warning" data-testid="warningMessage">This is a warning</w-alert>`;
+  const screen = await page.render(component);
+  await expect.element(screen.container.querySelector('w-alert')).not.toHaveAttribute('show');
 });

--- a/packages/alert/index.ts
+++ b/packages/alert/index.ts
@@ -23,7 +23,7 @@ class WarpAlert extends LitElement {
   @property({ reflect: true })
   variant: AlertVariants = 'info';
 
-  @property({ reflect: true })
+  @property({ type: Boolean, reflect: true })
   show: boolean = true;
 
   @property({ reflect: true })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@open-wc/form-control':
         specifier: ^1.0.0
         version: 1.0.0
+      '@vitest/browser':
+        specifier: ^3.2.4
+        version: 3.2.4(playwright@1.55.0)(vite@5.3.3(@types/node@20.14.10)(terser@5.37.0))(vitest@3.2.4)
       '@warp-ds/core':
         specifier: 1.1.8
         version: 1.1.8(@floating-ui/dom@1.6.13)

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -1,0 +1,1 @@
+import 'vitest-browser-lit';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       if (log.includes('Multiple versions of Lit loaded.')) return false;
       if (log.includes('Overriding ReactiveElement.createProperty() is deprecated.')) return false;
     },
+    setupFiles: ['./setup-tests.ts'],
     browser: {
       provider: 'playwright',
       enabled: true,


### PR DESCRIPTION
in order to look inside the shadowDom we need to make additions to the vitest setup.

`setup-tests.ts` contains what is needed for tests similar to those in `alert.test.js`