### PR TITLE
test: get Lit to render shadow root

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "@types/node": "20.14.10",
+    "@vitest/browser": "^3.2.4",
+    "@vitest/utils": "^3.2.4",
     "@warp-ds/eslint-config": "1.1.0",
     "@warp-ds/uno": "2.1.0",
     "cz-conventional-changelog": "3.3.0",

--- a/packages/button/button.test.ts
+++ b/packages/button/button.test.ts
@@ -1,13 +1,14 @@
 import { html } from 'lit';
 
+import { page } from '@vitest/browser/context';
 import { expect, test } from 'vitest';
-import { render } from 'vitest-browser-lit';
 import './index.js';
 
 test('renders the slotted label', async () => {
   const component = html`<w-button>This is a button</w-button>`;
 
-  const screen = render(component);
+  const screen = await page.render(component);
+  screen.debug();
   await expect.element(screen.getByText('This is a button')).toBeVisible();
   await expect.element(screen.getByRole('button')).toBeVisible();
 });
@@ -15,6 +16,7 @@ test('renders the slotted label', async () => {
 test('by default button type is button', async () => {
   const component = html`<w-button>This is a button</w-button>`;
 
-  const screen = render(component);
+  const screen = await page.render(component);
+  screen.debug();
   await expect.element(screen.getByRole('button')).toHaveAttribute('type', 'button');
 });

--- a/packages/card/card.test.ts
+++ b/packages/card/card.test.ts
@@ -1,12 +1,12 @@
 import { html } from 'lit';
 
+import { page } from '@vitest/browser/context';
 import { expect, test } from 'vitest';
-import { render } from 'vitest-browser-lit';
 import './index.js';
 
 test('renders the slotted text', async () => {
   const component = html`<w-card>This is a card</w-card>`;
 
-  const screen = render(component);
+  const screen = await page.render(component);
   await expect.element(screen.getByText('This is a card')).toBeVisible();
 });

--- a/packages/expandable/expandable.test.ts
+++ b/packages/expandable/expandable.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 
+import { page } from '@vitest/browser/context';
 import { expect, test } from 'vitest';
-import { render } from 'vitest-browser-lit';
 import './index.js';
 
 test('renders the given title prop and hides the slotted content', async () => {
@@ -11,7 +11,7 @@ test('renders the given title prop and hides the slotted content', async () => {
     </w-expandable>
   `;
 
-  const screen = render(component);
+  const screen = await page.render(component);
   await expect.element(screen.getByText("I'm expandable")).toBeVisible();
   await expect.element(screen.getByText('with expanded content')).not.toBeVisible();
 });
@@ -23,7 +23,7 @@ test('clicking the expandable shows the slotted content', async () => {
     </w-expandable>
   `;
 
-  const screen = render(component);
+  const screen = await page.render(component);
   await screen.getByRole('button').click();
   await expect.element(screen.getByText('with expanded content')).toBeVisible();
 });

--- a/patches/vitest-browser-lit.patch
+++ b/patches/vitest-browser-lit.patch
@@ -1,0 +1,62 @@
+diff --git a/dist/chunk-C44SADVH.js b/dist/chunk-C44SADVH.js
+index a5dc5f5a2542f9531e876b35a81b1ddc2712d2a0..a895ebeb6c544885b1248d6d40a51ffe526d9aed 100644
+--- a/dist/chunk-C44SADVH.js
++++ b/dist/chunk-C44SADVH.js
+@@ -1,24 +1,36 @@
+ // src/pure.ts
+-import { debug, getElementLocatorSelectors } from "@vitest/browser/utils";
++import { debug as viteDebug, getElementLocatorSelectors } from "@vitest/browser/utils";
+ import { render as litRender } from "lit";
+ var containers = /* @__PURE__ */ new Set();
+-function render(template, {
++async function render(template, {
+   baseElement = document.body,
+   container = baseElement.appendChild(document.createElement("div")),
+   ...options
+ } = {}) {
+   containers.add(container);
+   litRender(template, container, options);
++  // Let Lit components finish rendering
++  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+   return {
+     container,
+     baseElement,
+-    debug,
++    debug(...args) {
++      viteDebug(...args);
++      for (const el of baseElement.querySelectorAll("*")) {
++        if (el.shadowRoot) {
++          for (const shel of el.shadowRoot.children) {
++            viteDebug(shel, undefined);
++          }
++        }
++      }
++    },
+     unmount() {
+       containers.delete(container);
+       container.remove();
+     },
+-    rerender(newTemplate) {
++    async rerender(newTemplate) {
+       litRender(newTemplate, container, options);
++      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+     },
+     asFragment() {
+       return document.createRange().createContextualFragment(container.innerHTML);
+diff --git a/dist/pure.d.ts b/dist/pure.d.ts
+index ebd3ac24afe257f3c51153ff23d88decb5a5182d..8819736283c0045b4be28e4811ac518037b6bf8d 100644
+--- a/dist/pure.d.ts
++++ b/dist/pure.d.ts
+@@ -11,10 +11,10 @@ interface RenderResult extends LocatorSelectors {
+     baseElement: HTMLElement;
+     debug: typeof debug;
+     unmount: () => void;
+-    rerender: (template: unknown) => void;
++    rerender: (template: unknown) => Promise<void>;
+     asFragment: () => DocumentFragment;
+ }
+-declare function render(template: unknown, { baseElement, container, ...options }?: ComponentRenderOptions): RenderResult;
++declare function render(template: unknown, { baseElement, container, ...options }?: ComponentRenderOptions): Promise<RenderResult>;
+ declare function cleanup(): void;
+
+ export { type ComponentRenderOptions, type RenderResult, cleanup, render };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vitest-browser-lit:
+    hash: 8b3b5312440278f7beddb8f84e004f782cd98c94fc82bf4b0ef6e626d5124fd1
+    path: patches/vitest-browser-lit.patch
+
 importers:
 
   .:
@@ -66,6 +71,9 @@ importers:
       '@types/node':
         specifier: 20.14.10
         version: 20.14.10
+      '@vitest/utils':
+        specifier: ^3.2.4
+        version: 3.2.4
       '@warp-ds/eslint-config':
         specifier: 1.1.0
         version: 1.1.0(@eslint/js@9.16.0)(eslint-config-prettier@9.1.0(eslint@9.16.0(jiti@1.21.7)))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.41.0(eslint@9.16.0(jiti@1.21.7))(typescript@5.5.3))(eslint@9.16.0(jiti@1.21.7)))(eslint-plugin-prettier@5.5.4(eslint-config-prettier@9.1.0(eslint@9.16.0(jiti@1.21.7)))(eslint@9.16.0(jiti@1.21.7))(prettier@3.3.2))(eslint@9.16.0(jiti@1.21.7))(globals@15.13.0)
@@ -146,7 +154,7 @@ importers:
         version: 3.2.4(@types/node@20.14.10)(@vitest/browser@3.2.4)(terser@5.37.0)
       vitest-browser-lit:
         specifier: ^0.1.0
-        version: 0.1.0(@vitest/browser@3.2.4)(lit@3.2.0)(vitest@3.2.4)
+        version: 0.1.0(patch_hash=8b3b5312440278f7beddb8f84e004f782cd98c94fc82bf4b0ef6e626d5124fd1)(@vitest/browser@3.2.4)(lit@3.2.0)(vitest@3.2.4)
 
 packages:
 
@@ -5164,7 +5172,7 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/parser@7.25.3':
     dependencies:
@@ -5225,7 +5233,7 @@ snapshots:
 
   '@babel/template@7.25.0':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@babel/parser': 7.25.3
       '@babel/types': 7.25.2
 
@@ -5237,7 +5245,7 @@ snapshots:
 
   '@babel/traverse@7.25.3':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       '@babel/generator': 7.25.0
       '@babel/parser': 7.25.3
       '@babel/template': 7.25.0
@@ -6424,7 +6432,7 @@ snapshots:
   '@unocss/rule-utils@0.62.0':
     dependencies:
       '@unocss/core': 0.62.0
-      magic-string: 0.30.11
+      magic-string: 0.30.17
 
   '@unocss/rule-utils@0.65.4':
     dependencies:
@@ -8976,7 +8984,7 @@ snapshots:
 
   parse-json@8.1.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.26.2
       index-to-position: 0.1.2
       type-fest: 4.24.0
 
@@ -9912,7 +9920,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.3
       escalade: 3.1.2
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.2(browserslist@4.24.4):
     dependencies:
@@ -9996,7 +10004,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.37.0
 
-  vitest-browser-lit@0.1.0(@vitest/browser@3.2.4)(lit@3.2.0)(vitest@3.2.4):
+  vitest-browser-lit@0.1.0(patch_hash=8b3b5312440278f7beddb8f84e004f782cd98c94fc82bf4b0ef6e626d5124fd1)(@vitest/browser@3.2.4)(lit@3.2.0)(vitest@3.2.4):
     dependencies:
       '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@5.3.3(@types/node@20.14.10)(terser@5.37.0))(vitest@3.2.4)
       lit: 3.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  vitest-browser-lit: patches/vitest-browser-lit.patch

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["packages", "index.js"],
+  "include": ["packages", "index.js", "setup-tests.ts"],
   "compilerOptions": {
     "target": "ES2022",
     "experimentalDecorators": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="@vitest/browser/matchers" />
 import topLevelAwait from 'vite-plugin-top-level-await';
 import { defineConfig } from 'vitest/config';
 


### PR DESCRIPTION
Lit rendering is async, the recommendation seems to be to wait for the next tick in the event loop (https://github.com/lit/lit/discussions/4756). This patches the vitest browser lit dependency with that await and improvements to its debug (so it prints, albeit not "in place", the shadow root).