### PR TITLE
chore: fix Lit syntax before using `spread`

### DIFF
--- a/.storybook/utilities.ts
+++ b/.storybook/utilities.ts
@@ -30,8 +30,24 @@ export function prespread(args: Record<string, unknown>): Record<string, unknown
     ...args,
   };
   for (const field of Object.keys(newArgs)) {
-    // allow the number value 0 which is falsy in JS
-    if (typeof newArgs[field] !== 'number' && !newArgs[field]) {
+    const value = args[field];
+
+    // Add Lit syntax for boolean attributes
+    if (typeof value === 'boolean') {
+      newArgs[`?${field}`] = value;
+      delete newArgs[field];
+    }
+
+    // Add Lit syntax for complex properties
+    if (typeof value === 'object') {
+      newArgs[`.${field}`] = value;
+      delete newArgs[field];
+    }
+
+    // The manifest has a bunch of default empty strings (which we should probably investigate)
+    // that turn on features that should be off in Storybook canvases.
+    // Remove the empty strings.
+    if (newArgs[field] === '') {
       delete newArgs[field];
     }
   }

--- a/packages/dead-toggle/dead-toggle.stories.ts
+++ b/packages/dead-toggle/dead-toggle.stories.ts
@@ -1,7 +1,10 @@
 import { html } from 'lit';
 
+import { spread } from '@open-wc/lit-helpers';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
+
+import { prespread } from '../../.storybook/utilities.js';
 
 import type { WarpDeadToggle } from './index.js';
 import './index.js';
@@ -11,11 +14,7 @@ const { events, args, argTypes } = getStorybookHelpers<WarpDeadToggle>('w-dead-t
 const meta: Meta<typeof args> = {
   title: 'Forms/Dead toggle',
   render(args) {
-    return html`<w-dead-toggle
-      ?checked=${args.checked}
-      ?indeterminate=${args.indeterminate}
-      ?invalid=${args.invalid}
-      type=${args.type}></w-dead-toggle>`;
+    return html`<w-dead-toggle ${spread(prespread(args))}></w-dead-toggle>`;
   },
   args,
   argTypes,


### PR DESCRIPTION
Fixes the issue we saw of boolean controls not turning off from #304 for example