### PR TITLE
chore: accessibility refactor for screen readers

### DIFF
--- a/packages/button/button.test.ts
+++ b/packages/button/button.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'lit';
 
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-lit';
 
 import './index.js';
@@ -22,3 +22,13 @@ test('by default button type is button', async () => {
 test.todo('works in a form as type submit');
 
 test.todo('works in a form as type reset');
+
+test('calling focus on w-button focuses the button inside the shadow root', async () => {
+  const component = html`<w-button>This is a button</w-button>`;
+  const page = render(component);
+  await expect.element(page.getByRole('button')).toBeVisible();
+
+  page.container.querySelector('w-button').focus();
+
+  await vi.waitFor(() => page.container.querySelector(':focus').tagName === 'BUTTON');
+});

--- a/packages/datepicker/DatePicker.test.tsx
+++ b/packages/datepicker/DatePicker.test.tsx
@@ -14,7 +14,7 @@ test('renders the date picker component', async () => {
     </form>,
   );
 
-  await expect.element(page.getByLabelText('From date')).toBeInTheDocument();
+  await expect.element(page.getByLabelText('From date')).toBeVisible();
 });
 
 test('can pick a date using a pointer', async () => {
@@ -45,7 +45,7 @@ test('can pick a date using keyboard', async () => {
 
   await expect.element(page.getByLabelText('From date')).not.toHaveValue();
 
-  await expect.element(page.getByTestId('calendar').query()).not.toBeInTheDocument();
+  await expect.element(page.getByTestId('calendar').query()).not.toBeVisible();
 
   const toggle = page.getByRole('button').element() as HTMLButtonElement;
   toggle.focus();
@@ -58,7 +58,7 @@ test('can pick a date using keyboard', async () => {
 
   await expect
     .element(page.getByTestId('calendar').query(), { message: 'expected calendar to close after clicking a date' })
-    .not.toBeInTheDocument();
+    .not.toBeVisible();
 
   await expect.element(page.getByLabelText('From date')).toHaveValue();
 

--- a/packages/datepicker/datepicker.test.ts
+++ b/packages/datepicker/datepicker.test.ts
@@ -18,7 +18,7 @@ test('can pick a date using a pointer', async () => {
 
   await expect.element(page.getByLabelText('From date')).not.toHaveValue();
 
-  await expect.element(page.getByTestId('calendar').query()).not.toBeInTheDocument();
+  await expect.element(page.getByTestId('calendar').query()).not.toBeVisible();
   await page.getByRole('button').click({ force: true });
 
   await expect.element(page.getByTestId('calendar')).toBeVisible();
@@ -27,7 +27,7 @@ test('can pick a date using a pointer', async () => {
 
   await expect
     .element(page.getByTestId('calendar').query(), { message: 'expected calendar to close after clicking a date' })
-    .not.toBeInTheDocument();
+    .not.toBeVisible();
 
   await expect.element(page.getByLabelText('From date')).toHaveValue();
 
@@ -46,7 +46,7 @@ test('can pick a date using a keyboard', async () => {
 
   await expect.element(page.getByLabelText('From date')).not.toHaveValue();
 
-  await expect.element(page.getByTestId('calendar').query()).not.toBeInTheDocument();
+  await expect.element(page.getByTestId('calendar').query()).not.toBeVisible();
 
   const toggle = page.getByRole('button').element() as HTMLButtonElement;
   toggle.focus();
@@ -59,7 +59,7 @@ test('can pick a date using a keyboard', async () => {
 
   await expect
     .element(page.getByTestId('calendar').query(), { message: 'expected calendar to close after clicking a date' })
-    .not.toBeInTheDocument();
+    .not.toBeVisible();
 
   await expect.element(page.getByLabelText('From date')).toHaveValue();
 


### PR DESCRIPTION
The calendar is rewritten as a focus-trapped modal to have it announced (in my opinion) in a better way for screen readers. This is in line with the example from the ARIA Author Practices Guide

https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/

For the announcement to work correctly we can't conditionally render the calendar, it must be present in the document. We toggle its presence both visual and in the accessibility tree with display: none;