### PR TITLE
fix: ensure w-step is loaded before setContext is used

### DIFF
--- a/packages/steps/index.ts
+++ b/packages/steps/index.ts
@@ -69,11 +69,6 @@ class WarpSteps extends LitElement {
     activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.updateStepsContext();
-  }
-
   updated() {
     this.updateStepsContext();
   }


### PR DESCRIPTION
If w-step is not defined before of w-steps, setContext does not exist when this connectedCallback is called.