### PR TITLE
fix: icon alignments and button full-width

### DIFF
--- a/packages/button/index.ts
+++ b/packages/button/index.ts
@@ -3,7 +3,7 @@
 import { classNames } from '@chbphone55/classnames';
 import { i18n } from '@lingui/core';
 import { FormControlMixin } from '@open-wc/form-control';
-import { html, LitElement, PropertyValues } from 'lit';
+import { html, LitElement, PropertyValues, css } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { activateI18n } from '../i18n';
@@ -198,7 +198,7 @@ class WarpButton extends FormControlMixin(LitElement) {
   /** @internal */
   ariaValueTextLoading: string;
 
-  static styles = [reset, styles];
+  static styles = [reset, styles, css`:host([full-width]) { width: 100%; }`];
 
   updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('value')) {

--- a/packages/expandable/index.ts
+++ b/packages/expandable/index.ts
@@ -150,8 +150,8 @@ class WarpExpandable extends LitElement {
     ]);
 
     return this._showChevronUp
-      ? html`<w-icon-chevron-up-16 class="${upClasses}"></w-icon-chevron-up-16>`
-      : html`<w-icon-chevron-down-16 class="${downClasses}"></w-icon-chevron-down-16>`;
+      ? html`<w-icon-chevron-up-16 style="display: flex;" class="${upClasses}"></w-icon-chevron-up-16>`
+      : html`<w-icon-chevron-down-16 style="display: flex;" class="${downClasses}"></w-icon-chevron-down-16>`;
   }
 
   get #contentClasses() {

--- a/packages/modal/modal-header.ts
+++ b/packages/modal/modal-header.ts
@@ -76,7 +76,7 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
           })}"
           class="header-button header-button-left"
           @click="${this.emitBack}">
-          <w-icon-arrow-left-16></w-icon-arrow-left-16>
+          <w-icon-arrow-left-16 style="display: flex;"></w-icon-arrow-left-16>
         </button>`
       : nothing;
   }
@@ -91,7 +91,7 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
       })}"
       class="header-button ${this._hasTopContent ? 'header-close-button-on-image' : 'header-close-button'}"
       @click="${this.close}">
-      <w-icon-close-16></w-icon-close-16>
+      <w-icon-close-16 style="display: flex;"></w-icon-close-16>
     </button>`;
   }
   emitBack() {
@@ -104,9 +104,6 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   static styles = [
     reset,
     css`
-      w-icon-close-16, w-icon-arrow-left-16 {
-        display: flex;
-      }
       .header {
         position: relative;
         padding-bottom: 0.8rem;


### PR DESCRIPTION
Closes #368

This seems like a problem with the Icons. Not sure if these icons are the future or if the `@warp/components/icons` should be used here instead?

<img width="528" height="220" alt="Screenshot 2025-10-29 at 10 23 59" src="https://github.com/user-attachments/assets/e803e0ed-638f-4261-a9d2-70a3158d78cf" />
<img width="685" height="397" alt="Screenshot 2025-10-29 at 10 23 51" src="https://github.com/user-attachments/assets/45a40154-6d66-4234-b9bc-426064697f34" />
