### PR TITLE
fix(types): add react wrapper .js extension when importing

### DIFF
--- a/packages/affix/react.ts
+++ b/packages/affix/react.ts
@@ -2,7 +2,7 @@ import { createComponent } from '@lit/react';
 import { LitElement } from 'lit';
 import React from 'react';
 
-import { WarpAffix } from './index';
+import { WarpAffix } from './index.js';
 
 // We do this in order to prevent users from bundling in the CE implementation when
 // they should be getting it from Eik.

--- a/packages/alert/react.ts
+++ b/packages/alert/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpAlert } from '.';
+import { WarpAlert } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/attention/react.ts
+++ b/packages/attention/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpAttention } from './index';
+import { WarpAttention } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/badge/react.ts
+++ b/packages/badge/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpBadge } from '.';
+import { WarpBadge } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/box/react.ts
+++ b/packages/box/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpBox } from '.';
+import { WarpBox } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/breadcrumbs/react.ts
+++ b/packages/breadcrumbs/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpBreadcrumbs } from '.';
+import { WarpBreadcrumbs } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/button/react.ts
+++ b/packages/button/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpButton } from './index';
+import { WarpButton } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/card/react.ts
+++ b/packages/card/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpCard } from '.';
+import { WarpCard } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/combobox/react.ts
+++ b/packages/combobox/react.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { createComponent } from '@lit/react';
 
-import { WarpCombobox } from '.';
+import { WarpCombobox } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/datepicker/react.ts
+++ b/packages/datepicker/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpDatepicker } from './datepicker';
+import { WarpDatepicker } from './datepicker.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/dead-toggle/react.ts
+++ b/packages/dead-toggle/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpDeadToggle } from '.';
+import { WarpDeadToggle } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/expandable/react.ts
+++ b/packages/expandable/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpExpandable } from '.';
+import { WarpExpandable } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/link/react.ts
+++ b/packages/link/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpLink } from '.';
+import { WarpLink } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/modal/react.ts
+++ b/packages/modal/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpModalFooter, WarpModal, WarpModalHeader } from '.';
+import { WarpModalFooter, WarpModal, WarpModalHeader } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/pageindicator/react.ts
+++ b/packages/pageindicator/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpPageIndicator } from '.';
+import { WarpPageIndicator } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/pagination/react.ts
+++ b/packages/pagination/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpPagination } from '.';
+import { WarpPagination } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/pill/react.ts
+++ b/packages/pill/react.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { createComponent } from '@lit/react';
 
-import { WarpPill } from '.';
+import { WarpPill } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/rip-and-tear-checkbox/react.ts
+++ b/packages/rip-and-tear-checkbox/react.ts
@@ -2,7 +2,7 @@ import { createComponent } from '@lit/react';
 import { LitElement } from 'lit';
 import React from 'react';
 
-import { WCheckbox } from './checkbox';
+import { WCheckbox } from './checkbox.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/rip-and-tear-radio/react.ts
+++ b/packages/rip-and-tear-radio/react.ts
@@ -3,8 +3,8 @@ import React from 'react';
 
 import { createComponent } from '@lit/react';
 
-import { WRadio } from './radio';
-import { WRadioGroup } from './radio-group';
+import { WRadio } from './radio.js';
+import { WRadioGroup } from './radio-group.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/select/react.ts
+++ b/packages/select/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpSelect } from '.';
+import { WarpSelect } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/slider/react.ts
+++ b/packages/slider/react.ts
@@ -3,8 +3,8 @@ import React from 'react';
 
 import { createComponent, EventName } from '@lit/react';
 
-import { WarpSlider } from './slider';
-import { WarpSliderThumb } from './slider-thumb';
+import { WarpSlider } from './slider.js';
+import { WarpSliderThumb } from './slider-thumb.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/switch/react.ts
+++ b/packages/switch/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpSwitch } from '.';
+import { WarpSwitch } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}

--- a/packages/textfield/react.ts
+++ b/packages/textfield/react.ts
@@ -2,7 +2,7 @@ import { LitElement } from 'lit';
 import { createComponent } from '@lit/react';
 import React from 'react';
 
-import { WarpTextField } from '.';
+import { WarpTextField } from './index.js';
 
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}


### PR DESCRIPTION
Fixes an issue where if users have their tsconfig module resolution set to node next then types didnt work.