### PR TITLE
fix: add missing components back into build

### DIFF
--- a/packages/checkbox/checkbox-group.ts
+++ b/packages/checkbox/checkbox-group.ts
@@ -12,6 +12,10 @@ export class WCheckboxGroup extends LitElement {
   }
 }
 
+if (!customElements.get('w-checkbox-group')) {
+  customElements.define('w-checkbox-group', WCheckboxGroup);
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'w-checkbox-group': WCheckboxGroup;

--- a/packages/checkbox/checkbox.ts
+++ b/packages/checkbox/checkbox.ts
@@ -207,6 +207,10 @@ export class WCheckbox extends BaseFormAssociatedElement {
   }
 }
 
+if (!customElements.get('w-checkbox')) {
+  customElements.define('w-checkbox', WCheckbox);
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'w-checkbox': WCheckbox;

--- a/packages/checkbox/index.ts
+++ b/packages/checkbox/index.ts
@@ -1,7 +1,3 @@
-import { WCheckbox } from './checkbox';
-import { WCheckboxGroup } from './checkbox-group';
+export { WCheckbox } from './checkbox';
+export { WCheckboxGroup } from './checkbox-group';
 
-if (!customElements.get('w-checkbox')) {
-  customElements.define('w-checkbox', WCheckbox);
-  customElements.define('w-checkbox-group', WCheckboxGroup);
-}

--- a/packages/radio/index.ts
+++ b/packages/radio/index.ts
@@ -1,7 +1,2 @@
-import { WRadio } from './radio';
-import { WRadioGroup } from './radio-group';
-
-if (!customElements.get('w-radio')) {
-  customElements.define('w-radio', WRadio);
-  customElements.define('w-radio-group', WRadioGroup);
-}
+export { WRadio } from './radio';
+export { WRadioGroup } from './radio-group';

--- a/packages/radio/radio-group.ts
+++ b/packages/radio/radio-group.ts
@@ -356,6 +356,10 @@ export class WRadioGroup extends BaseFormAssociatedElement {
   }
 }
 
+if (!customElements.get('w-radio-group')) {
+  customElements.define('w-radio-group', WRadioGroup);
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'w-radio-group': WRadioGroup;

--- a/packages/radio/radio.ts
+++ b/packages/radio/radio.ts
@@ -106,6 +106,10 @@ export class WRadio extends BaseFormAssociatedElement {
   }
 }
 
+if (!customElements.get('w-radio')) {
+  customElements.define('w-radio', WRadio);
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'w-radio': WRadio;


### PR DESCRIPTION
Moves the component defines into the respective components as this was inconsistent and causing some components to not be present in the build