### PR TITLE
fix: separate out Eik bundles by language

### DIFF
--- a/build/bundle-all-locales.js
+++ b/build/bundle-all-locales.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Build script that produces:
+ * 1. Per-language bundles: eik/{locale}/index.js for each supported locale
+ * 2. Backwards-compatible all-languages bundle: eik/index.js
+ *
+ * This runs the Rollup build multiple times with different WARP_LOCALE values.
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+
+const supportedLocales = ['en', 'nb', 'fi', 'da', 'sv'];
+const outdir = new URL('../eik', import.meta.url).pathname;
+
+// Ensure output directories exist
+for (const locale of supportedLocales) {
+  const localeDir = `${outdir}/${locale}`;
+  if (!existsSync(localeDir)) {
+    mkdirSync(localeDir, { recursive: true });
+  }
+}
+
+console.log('Building per-language bundles...\n');
+
+// Build per-language bundles
+for (const locale of supportedLocales) {
+  console.log(`Building bundle for locale: ${locale}`);
+  try {
+    execSync(`WARP_LOCALE=${locale} rollup -c ./build/bundle.js`, {
+      stdio: 'inherit',
+      cwd: new URL('..', import.meta.url).pathname,
+    });
+    console.log(`✓ Built eik/${locale}/index.js\n`);
+  } catch (error) {
+    console.error(`✗ Failed to build bundle for locale: ${locale}`);
+    process.exit(1);
+  }
+}
+
+// Build backwards-compatible all-languages bundle
+console.log('Building backwards-compatible all-languages bundle...');
+try {
+  execSync('rollup -c ./build/bundle.js', {
+    stdio: 'inherit',
+    cwd: new URL('..', import.meta.url).pathname,
+  });
+  console.log('✓ Built eik/index.js\n');
+} catch (error) {
+  console.error('✗ Failed to build all-languages bundle');
+  process.exit(1);
+}
+
+console.log('All bundles built successfully!');

--- a/build/bundle.js
+++ b/build/bundle.js
@@ -5,6 +5,10 @@
 // expects that we first compile TS to JS into .tmp with:
 // tsc --project tsconfig.json --outDir .tmp --declaration false --sourceMap true
 
+// Usage:
+// - Default (all languages): rollup -c ./build/bundle.js
+// - Per-language: WARP_LOCALE=nb rollup -c ./build/bundle.js
+
 import minifyHTML from '@lit-labs/rollup-plugin-minify-html-literals';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
@@ -12,30 +16,54 @@ import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
 
 import { generateEntrypointFile } from './entrypoint.js';
+import { localePlugin } from './rollup-plugin-locale.js';
 
 generateEntrypointFile();
 
 const tmpEntrypoint = new URL('../.tmp/entrypoint.js', import.meta.url).pathname;
 const outdir = new URL('../eik', import.meta.url).pathname;
 
+// Check for target locale from environment variable
+const targetLocale = process.env.WARP_LOCALE;
+const supportedLocales = ['en', 'nb', 'fi', 'da', 'sv'];
+
+if (targetLocale && !supportedLocales.includes(targetLocale)) {
+  throw new Error(`Invalid WARP_LOCALE: ${targetLocale}. Must be one of: ${supportedLocales.join(', ')}`);
+}
+
+// Determine output path based on locale
+const outputFile = targetLocale ? `${outdir}/${targetLocale}/index.js` : `${outdir}/index.js`;
+
+// Build plugins array
+const plugins = [
+  replace({
+    preventAssignment: true,
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    // For per-locale builds, bake in the locale; for all-languages build, leave undefined
+    ...(targetLocale
+      ? { '__WARP_LOCALE__': JSON.stringify(targetLocale) }
+      : { 'typeof __WARP_LOCALE__': JSON.stringify('undefined') }),
+  }),
+  resolve({
+    browser: true, // prefer browser-compatible versions
+    preferBuiltins: false, // don't use Node built-ins
+  }),
+  commonjs(),
+  minifyHTML(),
+  terser(),
+];
+
+// Add locale plugin for per-language builds (stubs out non-target locale messages)
+if (targetLocale) {
+  plugins.unshift(localePlugin({ targetLocale }));
+}
+
 export default {
   input: tmpEntrypoint,
   output: {
-    file: `${outdir}/index.js`,
+    file: outputFile,
     format: 'esm',
     sourcemap: true,
   },
-  plugins: [
-    replace({
-      preventAssignment: true,
-      'process.env.NODE_ENV': JSON.stringify('production'), // or "development"
-    }),
-    resolve({
-      browser: true, // prefer browser-compatible versions
-      preferBuiltins: false, // don't use Node built-ins
-    }),
-    commonjs(),
-    minifyHTML(),
-    terser(),
-  ],
+  plugins,
 };

--- a/build/rollup-plugin-locale.js
+++ b/build/rollup-plugin-locale.js
@@ -1,0 +1,46 @@
+/**
+ * Rollup plugin that stubs out message files for non-target locales.
+ * This ensures only the target language's translations are included in the bundle.
+ *
+ * @param {Object} options
+ * @param {string} options.targetLocale - The locale to keep (e.g., 'en', 'nb', 'fi', 'da', 'sv')
+ * @returns {import('rollup').Plugin}
+ */
+export function localePlugin({ targetLocale }) {
+  const supportedLocales = ['en', 'nb', 'fi', 'da', 'sv'];
+
+  if (!supportedLocales.includes(targetLocale)) {
+    throw new Error(`Invalid target locale: ${targetLocale}. Must be one of: ${supportedLocales.join(', ')}`);
+  }
+
+  // Match patterns like:
+  // - ./locales/da/messages.mjs
+  // - ../modal/locales/en/messages.mjs
+  // - /absolute/path/packages/button/locales/nb/messages.mjs
+  const localeMessagePattern = /locales\/([a-z]{2})\/messages\.mjs$/;
+
+  return {
+    name: 'warp-locale-plugin',
+
+    resolveId(source, importer) {
+      const match = source.match(localeMessagePattern);
+      if (match) {
+        const locale = match[1];
+        if (supportedLocales.includes(locale) && locale !== targetLocale) {
+          // Return a virtual module ID for non-target locales
+          return `\0empty-messages-${locale}`;
+        }
+      }
+      return null;
+    },
+
+    load(id) {
+      // Handle virtual empty message modules
+      if (id.startsWith('\0empty-messages-')) {
+        // Return an empty messages object that matches Lingui's compiled format
+        return 'export const messages = {};';
+      }
+      return null;
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -233,7 +233,8 @@
     "./dist/custom-elements.json"
   ],
   "scripts": {
-    "build:bundle": "tsc --project tsconfig.json --outDir .tmp --declaration false --sourceMap true && rollup -c ./build/bundle.js && rimraf .tmp",
+    "build:bundle": "tsc --project tsconfig.json --outDir .tmp --declaration false --sourceMap true && node ./build/bundle-all-locales.js && rimraf .tmp",
+    "build:bundle:locale": "tsc --project tsconfig.json --outDir .tmp --declaration false --sourceMap true && rollup -c ./build/bundle.js && rimraf .tmp",
     "build:cloak": "node ./build/cloak.js",
     "build:components": "node ./build/components.js",
     "build:eik-components-backwards-compat": "node ./build/components-eik.js",

--- a/packages/i18n.ts
+++ b/packages/i18n.ts
@@ -5,6 +5,15 @@ type SupportedLocale = (typeof supportedLocales)[number];
 
 export const defaultLocale = 'en';
 
+/**
+ * Build-time baked locale. When set via Rollup replace plugin during build,
+ * this locale will be used instead of runtime detection.
+ * For per-language bundles, this is set to the target locale.
+ * For the backwards-compatible all-languages bundle, this remains undefined.
+ */
+declare const __WARP_LOCALE__: SupportedLocale | undefined;
+const bakedLocale: SupportedLocale | undefined = typeof __WARP_LOCALE__ !== 'undefined' ? __WARP_LOCALE__ : undefined;
+
 export const getSupportedLocale = (usedLocale: string) => {
   return (
     supportedLocales.find((locale) => usedLocale === locale || usedLocale.toLowerCase().includes(locale)) ||
@@ -13,6 +22,11 @@ export const getSupportedLocale = (usedLocale: string) => {
 };
 
 export function detectLocale(): SupportedLocale {
+  // If we have a baked-in locale from build time, use it directly
+  if (bakedLocale) {
+    return bakedLocale;
+  }
+
   if (typeof window === 'undefined') {
     /**
      * Server locale detection. This requires e.g LANG environment variable to be set on the server.


### PR DESCRIPTION
**Full disclosure**: I tried out Claude Code to implement this. It was able to plan and implement the changes asked for. Whether the code is understandable or the approach is sound, I leave that to the astute reader to decide.

**What this PR does:**
Produce a bundle for each language as well as the original multi lingual bundle for backwards compatibility. Each language now has its own route. So the bundle files are now:
* /index.js - backwards compatibility, switches on html lang attr
* /en/index.js
* /nb/index.js
* /sv/index.js
* /da/index.js
* /fi/index.js

**How it does it:**
1. takes in language as an env var to the build, if not set, old behaviour is preserved.
2. adds a custom rollup plugin that stubs out all the languages that are not the desired language for the current build (so that things don't break)
3. modifies i18n file to use env vars and detectLocale to return short circuit and return locale from env var if provided.
4. uses the usual rollup method to inline env vars in the build
5. modify build commands to run a build for each language, setting the env var for each.

**Discussion:**
- 9kb saving in the per language bundles. It's not much but it's something. There is another 5kb potential savings if we were to switch to lit localise instead of lingui.
- the main decision point probably hangs off of whether switching language by url rather than html language tag is desired.