### PR TITLE
fix(link): add missing variant, remove link variant

### DIFF
--- a/packages/link/Link.mdx
+++ b/packages/link/Link.mdx
@@ -27,7 +27,6 @@ The negative button is for emphasizing actions that can be destructive or have n
 <Canvas of={LinkStories.Negative} />
 
 <Canvas of={LinkStories.Utility} />
-<Canvas of={LinkStories.Link} />
 
 All of the above buttons have a small variant.
 

--- a/packages/link/index.ts
+++ b/packages/link/index.ts
@@ -12,7 +12,6 @@ type ButtonVariant =
   | 'negative'
   | 'negativeQuiet'
   | 'utility'
-  | 'link'
   | 'quiet'
   | 'utilityQuiet'
   | 'overlay'
@@ -75,6 +74,7 @@ class WarpLink extends LitElement {
 
   render() {
     const classes = {
+      // @ts-expect-error link should be removed so we hide it from types until we can do so
       'w-button': this.variant !== 'link',
       'w-button--primary': this.variant === 'primary',
       'w-button--secondary': this.variant === 'secondary',

--- a/packages/link/link.react.stories.tsx
+++ b/packages/link/link.react.stories.tsx
@@ -62,14 +62,6 @@ export const UtilityQuiet: Story = {
   },
 };
 
-export const AsALink: Story = {
-  args: {
-    variant: 'link',
-    href: 'http://developer.mozilla.org',
-    target: '_new',
-  },
-};
-
 export const Quiet: Story = {
   args: {
     variant: 'quiet',

--- a/packages/link/link.stories.ts
+++ b/packages/link/link.stories.ts
@@ -75,14 +75,6 @@ export const UtilityQuiet: Story = {
   },
 };
 
-export const Link: Story = {
-  args: {
-    variant: 'link',
-    href: 'http://developer.mozilla.org',
-    target: '_new',
-  },
-};
-
 export const Quiet: Story = {
   args: {
     variant: 'quiet',


### PR DESCRIPTION
* Add quiet to variants (it had been missed)
* remove evidence of link variant (while not actually removing the feature)

Link should not have a link variant but w-button currently uses it so in order to prevent adding an instantly deprecated feature, we remove it from types, stories and docs