### PR TITLE
fix(build): hotfix, set correct filename for backwards compatible paths

### DIFF
--- a/build/components-eik.js
+++ b/build/components-eik.js
@@ -44,9 +44,11 @@ if (!existsSync(outdir)) {
 
 modules.map(async (item) => {
   try {
+    // Extract the directory path (e.g., "packages/affix" from "packages/affix/affix.ts")
+    const dir = item.substring(0, item.lastIndexOf('/'));
     await esbuild.build({
       entryPoints: [item],
-      outfile: `${outdir}/${item.replace('.ts', '.js')}`,
+      outfile: `${outdir}/${dir}/index.js`,
       ...esbuildDefaults,
     });
   } catch (err) {


### PR DESCRIPTION
After updating the Eik alias this week, it was discovered that we had broken the backwards compatibility paths in a recent refactor. This addresses that so that https://assets.finn.no/pkg/@warp-ds/elements/v2/packages/attention/attention.js (which is incorrect, will be https://assets.finn.no/pkg/@warp-ds/elements/v2/packages/attention/index.js as before.