### PR TITLE
chore: add CSS parts to components

### DIFF
--- a/packages/alert/alert.ts
+++ b/packages/alert/alert.ts
@@ -123,9 +123,9 @@ class WarpAlert extends LitElement {
   render() {
     return html`
       <w-expand-transition ?show=${this.show}>
-        <div role=${this.role} class=${this._wrapperClasses}>
-          <div class=${this._iconClasses}>${this._icon}</div>
-          <div class=${ccAlert.textWrapper}>
+        <div role=${this.role} class=${this._wrapperClasses} part="alert">
+          <div class=${this._iconClasses} part="alert-icon">${this._icon}</div>
+          <div class=${ccAlert.textWrapper} part="alert-content">
             <slot></slot>
           </div>
         </div>

--- a/packages/attention/attention.ts
+++ b/packages/attention/attention.ts
@@ -483,21 +483,39 @@ class WarpAttention extends LitElement {
           this.placement === 'bottom' ||
           this.placement === 'bottom-end' // Attention's and its arrow's visual position should be reflected in the DOM
             ? html`
-              <slot name="target"></slot>
+              <slot name="target" part="attention-target"></slot>
 
-              <div id="attention" class="${this._wrapperClasses}">
-                <div role="${this.tooltip ? 'tooltip' : 'img'}" aria-label="${this.defaultAriaLabel()}">${this._arrowHtml}</div>
-                <slot name="message"></slot>
+              <div
+                id="attention"
+                class="${this._wrapperClasses}"
+                part="attention"
+              >
+                <div
+                  role="${this.tooltip ? 'tooltip' : 'img'}"
+                  aria-label="${this.defaultAriaLabel()}"
+                >
+                  ${this._arrowHtml}
+                </div>
+                <slot name="message" part="attention-message"></slot>
                 ${this.canClose ? this._closeBtnHtml : nothing}
               </div>
             `
             : html`
-              <div id="attention" class="${this._wrapperClasses}">
-                <slot name="message"></slot>
-                <div role="${this.tooltip ? 'tooltip' : 'img'}" aria-label="${this.defaultAriaLabel()}">${this._arrowHtml}</div>
+              <div
+                id="attention"
+                class="${this._wrapperClasses}"
+                part="attention"
+              >
+                <slot name="message" part="attention-message"></slot>
+                <div
+                  role="${this.tooltip ? 'tooltip' : 'img'}"
+                  aria-label="${this.defaultAriaLabel()}"
+                >
+                  ${this._arrowHtml}
+                </div>
                 ${this.canClose ? this._closeBtnHtml : nothing}
               </div>
-              <slot name="target"></slot>
+              <slot name="target" part="attention-target"></slot>
             `
         }
       </div>

--- a/packages/badge/badge.ts
+++ b/packages/badge/badge.ts
@@ -44,8 +44,8 @@ class WarpBadge extends LitElement {
 
   render() {
     return html`
-      <div class="${this._class}">
-        <slot></slot>
+      <div class="${this._class}" part="badge">
+        <slot part="badge-content"></slot>
       </div>
     `;
   }

--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -64,8 +64,12 @@ class WarpBox extends LitElement {
 
   render() {
     return html`
-      <div role="${this._optOutRoleWithDefault}" class="${this._class}">
-        <slot></slot>
+      <div
+        role="${this._optOutRoleWithDefault}"
+        class="${this._class}"
+        part="box"
+      >
+        <slot part="box-content"></slot>
       </div>
     `;
   }

--- a/packages/button/button.ts
+++ b/packages/button/button.ts
@@ -204,8 +204,19 @@ class WarpButton extends FormControlMixin(LitElement) {
   static styles = [
     reset,
     styles,
-    css`:host([full-width]) { width: 100%; }`,
-    css`.rounded-radius-default{border-radius:var(--w-button-radius-default,8px);}.rounded-radius-utility{border-radius:var(--w-button-radius-utility,4px);}`,
+    css`
+      :host([full-width]) {
+        width: 100%;
+      }
+    `,
+    css`
+      .rounded-radius-default {
+        border-radius: var(--w-button-radius-default, 8px);
+      }
+      .rounded-radius-utility {
+        border-radius: var(--w-button-radius-utility, 4px);
+      }
+    `,
   ];
 
   updated(changedProperties: PropertyValues<this>) {
@@ -339,16 +350,27 @@ class WarpButton extends FormControlMixin(LitElement) {
           ?autofocus=${this.autofocus}
           ?full-width=${this.fullWidth}
           class=${this.buttonClass}
-          rel=${this.target === '_blank' ? this.rel || 'noopener' : undefined}>
-          <slot></slot>
+          rel=${this.target === '_blank' ? this.rel || 'noopener' : undefined}
+        >
+          <slot part="button-content"></slot>
         </w-link>`
-        : html`<button type=${this.type || 'button'} class=${this._classes} @click="${this._handleButtonClick}">
-          <slot></slot>
+        : html`<button
+          type=${this.type || 'button'}
+          class=${this._classes}
+          part="button"
+          @click="${this._handleButtonClick}"
+        >
+          <slot part="button-content"></slot>
         </button>`
     }
     ${
       this.loading
-        ? html`<span class="sr-only" role="progressbar" aria-valuenow="{0}" aria-valuetext=${this.ariaValueTextLoading}></span>`
+        ? html`<span
+          class="sr-only"
+          role="progressbar"
+          aria-valuenow="{0}"
+          aria-valuetext=${this.ariaValueTextLoading}
+        ></span>`
         : null
     }`;
   }

--- a/packages/card/card.ts
+++ b/packages/card/card.ts
@@ -47,7 +47,7 @@ class WarpCard extends LitElement {
     styles,
     css`
       a::after {
-        content: '';
+        content: "";
         position: absolute;
         top: 0;
         right: 0;
@@ -101,8 +101,19 @@ class WarpCard extends LitElement {
   /** @internal */
   get _interactiveElement() {
     const renderButton = () =>
-      html`<button class="${ccCard.a11y}" aria-pressed="${this.selected}" tabindex="-1">${this.buttonText}</button>`;
-    const renderSpan = () => html`<span role="checkbox" aria-checked="true" aria-disabled="true"></span>`;
+      html`<button
+        class="${ccCard.a11y}"
+        aria-pressed="${this.selected}"
+        tabindex="-1"
+      >
+        ${this.buttonText}
+      </button>`;
+    const renderSpan = () =>
+      html`<span
+        role="checkbox"
+        aria-checked="true"
+        aria-disabled="true"
+      ></span>`;
 
     return this.clickable ? renderButton() : this.selected ? renderSpan() : '';
   }
@@ -117,9 +128,22 @@ class WarpCard extends LitElement {
 
   render() {
     return html`
-      <div tabindex=${ifDefined(this.clickable ? '0' : undefined)} class="${this._containerClasses}" @keydown=${this.keypressed}>
-        ${this._interactiveElement} ${this.flat ? '' : html`<div class="${this._outlineClasses}"></div>`}
-        <slot></slot>
+      <div
+        tabindex=${ifDefined(this.clickable ? '0' : undefined)}
+        class="${this._containerClasses}"
+        part="card"
+        @keydown=${this.keypressed}
+      >
+        ${this._interactiveElement}
+        ${
+          this.flat
+            ? ''
+            : html`<div
+              class="${this._outlineClasses}"
+              part="card-outline"
+            ></div>`
+        }
+        <slot part="card-content"></slot>
       </div>
     `;
   }

--- a/packages/expandable/expandable.ts
+++ b/packages/expandable/expandable.ts
@@ -150,8 +150,14 @@ class WarpExpandable extends LitElement {
     ]);
 
     return this._showChevronUp
-      ? html`<w-icon-chevron-up-16 style="display: flex;" class="${upClasses}"></w-icon-chevron-up-16>`
-      : html`<w-icon-chevron-down-16 style="display: flex;" class="${downClasses}"></w-icon-chevron-down-16>`;
+      ? html`<w-icon-chevron-up-16
+          style="display: flex;"
+          class="${upClasses}"
+        ></w-icon-chevron-up-16>`
+      : html`<w-icon-chevron-down-16
+          style="display: flex;"
+          class="${downClasses}"
+        ></w-icon-chevron-down-16>`;
   }
 
   get #contentClasses() {
@@ -168,7 +174,10 @@ class WarpExpandable extends LitElement {
 
   /** @internal */
   get _expandableSlot() {
-    return html`<div class="${this.#contentClasses}" part="expandable-content ${this.expanded ? 'expanded' : 'collapsed'}">
+    return html`<div
+      class="${this.#contentClasses}"
+      part="expandable-content ${this.expanded ? 'expanded' : 'collapsed'}"
+    >
       <slot></slot>
     </div>`;
   }
@@ -182,11 +191,24 @@ class WarpExpandable extends LitElement {
               type="button"
               aria-expanded="${this.expanded}"
               class="${this.#buttonClasses}"
-              @click=${() => (this.expanded = !this.expanded)}>
-              part="expandable-button ${this.expanded ? 'expanded' : 'collapsed'}"
-              <div class="${ccExpandable.title}">
-                ${this.title ? html`<span class="${ccExpandable.titleType}">${this.title}</span>` : html`<slot name="title"></slot>`}
-                ${this.noChevron ? '' : html`<div class="${this.#chevronClasses}">${this.#chevronIcon}</div>`}
+              part="expandable-button"
+              @click=${() => (this.expanded = !this.expanded)}
+            >
+              <div class="${ccExpandable.title}" part="expandable-title">
+                ${
+                  this.title
+                    ? html`<span class="${ccExpandable.titleType}"
+                      >${this.title}</span
+                    >`
+                    : html`<slot name="title" part="title-slot"></slot>`
+                }
+                ${
+                  this.noChevron
+                    ? ''
+                    : html`<div class="${this.#chevronClasses}">
+                      ${this.#chevronIcon}
+                    </div>`
+                }
               </div>
             </button>
           </w-unstyled-heading>`
@@ -194,8 +216,13 @@ class WarpExpandable extends LitElement {
       }
       ${
         this.animated
-          ? html`<w-expand-transition ?show=${this.expanded}> ${this._expandableSlot} </w-expand-transition>`
-          : html`<div class="${this.#expansionClasses}" aria-hidden=${ifDefined(!this.expanded ? true : undefined)}>
+          ? html`<w-expand-transition ?show=${this.expanded}>
+            ${this._expandableSlot}
+          </w-expand-transition>`
+          : html`<div
+            class="${this.#expansionClasses}"
+            aria-hidden=${ifDefined(!this.expanded ? true : undefined)}
+          >
             ${this._expandableSlot}
           </div>`
       }

--- a/packages/link/link.ts
+++ b/packages/link/link.ts
@@ -108,8 +108,10 @@ class WarpLink extends LitElement {
       href=${this.href}
       target=${this.target}
       rel=${this.target === '_blank' ? this.rel || 'noopener' : undefined}
-      class=${classMap(classes)}>
-      <slot></slot>
+      part="link"
+      class=${classMap(classes)}
+    >
+      <slot part="link-content"></slot>
     </a>`;
   }
 }

--- a/packages/modal-footer/modal-footer.ts
+++ b/packages/modal-footer/modal-footer.ts
@@ -10,8 +10,11 @@ import { reset } from '../styles.js';
 export class ModalFooter extends CanCloseMixin(ProvidesCanCloseToSlotsMixin(LitElement)) {
   render() {
     return html`
-      <div class="footer">
-        <slot @slotchange="${this.handleSlotChange}"></slot>
+      <div class="footer" part="footer">
+        <slot
+          part="footer-content"
+          @slotchange="${this.handleSlotChange}"
+        ></slot>
       </div>
     `;
   }

--- a/packages/modal-header/modal-header.ts
+++ b/packages/modal-header/modal-header.ts
@@ -36,11 +36,20 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   }
   render() {
     return html`
-      <div class="header">
-        <slot name="top" @slotchange=${this.handleTopSlotChange}></slot>
-        <div class="${this._hasTopContent ? '' : 'header-title-bar'}">
+      <div class="header" part="header">
+        <slot
+          name="top"
+          part="header-top"
+          @slotchange=${this.handleTopSlotChange}
+        ></slot>
+        <div
+          class="${this._hasTopContent ? '' : 'header-title-bar'}"
+          part="header-title-bar"
+        >
           ${this.backButton}
-          <h1 class="title-el ${this.titleClasses}">${this.title}</h1>
+          <h1 class="title-el ${this.titleClasses}" part="header-title">
+            ${this.title}
+          </h1>
           ${this.closeButton}
         </div>
       </div>
@@ -74,7 +83,8 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
             comment: 'Aria label for the back button in modal',
           })}"
           class="header-button header-button-left"
-          @click="${this.emitBack}">
+          @click="${this.emitBack}"
+        >
           <w-icon-arrow-left-16 style="display: flex;"></w-icon-arrow-left-16>
         </button>`
       : nothing;
@@ -82,18 +92,19 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   get closeButton() {
     if (this.noClose) return nothing;
     return html`<div class="header-close-button-container">
-        <w-button
-            type="button"
-            aria-label="${i18n._({
-              id: 'modal.aria.close',
-              message: 'Close',
-              comment: 'Aria label for the close button in modal',
-            })}"
-            variant="pill"
-            small=""
-            @click="${this.close}">
-                <w-icon-close-16 style="display: flex;"></w-icon-close-16>
-        </w-button>
+      <w-button
+        type="button"
+        aria-label="${i18n._({
+          id: 'modal.aria.close',
+          message: 'Close',
+          comment: 'Aria label for the close button in modal',
+        })}"
+        variant="pill"
+        small=""
+        @click="${this.close}"
+      >
+        <w-icon-close-16 style="display: flex;"></w-icon-close-16>
+      </w-button>
     </div>`;
   }
   emitBack() {
@@ -160,7 +171,8 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
         min-width: 40px;
         padding: 0.4rem;
         font-weight: 700;
-        transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+        transition-property: color, background-color, border-color,
+          text-decoration-color, fill, stroke;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 150ms;
         font-size: var(--w-font-size-m);

--- a/packages/modal/modal.ts
+++ b/packages/modal/modal.ts
@@ -19,7 +19,8 @@ import { ProvidesCanCloseToSlotsMixin } from './util.js';
 export class ModalMain extends ProvidesCanCloseToSlotsMixin(LitElement) {
   @property({ type: Boolean }) show: boolean;
   @property({ type: String, attribute: 'content-id' }) contentId: string;
-  @property({ type: Boolean, attribute: 'ignore-backdrop-clicks' }) ignoreBackdropClicks: boolean;
+  @property({ type: Boolean, attribute: 'ignore-backdrop-clicks' })
+  ignoreBackdropClicks: boolean;
 
   @query('.dialog-el') dialogEl: HTMLDialogElement;
   @query('.dialog-inner-el') dialogInnerEl: HTMLElement;
@@ -59,13 +60,21 @@ export class ModalMain extends ProvidesCanCloseToSlotsMixin(LitElement) {
 
   render() {
     return html`
-      <dialog class="dialog-el">
-        <div class="dialog-inner-el">
-          <slot name="header" @slotchange="${this.handleSlotChange}"></slot>
-          <div class="content-el" id=${this.contentId}>
+      <dialog class="dialog-el" part="dialog">
+        <div class="dialog-inner-el" part="dialog-inner">
+          <slot
+            name="header"
+            part="modal-header"
+            @slotchange="${this.handleSlotChange}"
+          ></slot>
+          <div class="content-el" part="modal-content" id=${this.contentId}>
             <slot name="content" @slotchange="${this.handleSlotChange}"></slot>
           </div>
-          <slot name="footer" @slotchange="${this.handleSlotChange}"></slot>
+          <slot
+            name="footer"
+            part="modal-footer"
+            @slotchange="${this.handleSlotChange}"
+          ></slot>
         </div>
       </dialog>
     `;

--- a/packages/pill/pill.ts
+++ b/packages/pill/pill.ts
@@ -43,12 +43,14 @@ class WarpPill extends LitElement {
    * @deprecated Used "open-arial-label" instead.
    */
   @property({ attribute: 'open-sr-label', type: String }) openSrLabel: string;
-  @property({ attribute: 'open-aria-label', type: String }) openAriaLabel: string;
+  @property({ attribute: 'open-aria-label', type: String })
+  openAriaLabel: string;
   /**
    * @deprecated Used "close-arial-label" instead.
    */
   @property({ attribute: 'close-sr-label', type: String }) closeSrLabel: string;
-  @property({ attribute: 'close-aria-label', type: String }) closeAriaLabel: string;
+  @property({ attribute: 'close-aria-label', type: String })
+  closeAriaLabel: string;
 
   /** @internal */
   openFilterSrText: string;
@@ -117,16 +119,32 @@ class WarpPill extends LitElement {
 
   render() {
     return html`
-      <div class="${pillStyles.wrapper}">
-        <button type="button" class="${this._labelClasses}" @click="${this._onClick}">
-          <span class="${pillStyles.a11y}">${this.openAriaLabel ? this.openAriaLabel : this.openFilterSrText}</span>
-          <slot></slot>
+      <div class="${pillStyles.wrapper}" part="pill-wrapper">
+        <button
+          type="button"
+          class="${this._labelClasses}"
+          part="pill-button"
+          @click="${this._onClick}"
+        >
+          <span class="${pillStyles.a11y}"
+            >${this.openAriaLabel ? this.openAriaLabel : this.openFilterSrText}</span
+          >
+          <slot part="pill-content"></slot>
         </button>
         ${
           this.canClose
-            ? html` <button type="button" class="${this._closeClasses}" @click="${this._onClose}">
-              <span class="${pillStyles.a11y}">${this.closeAriaLabel ? this.closeAriaLabel : this.removeFilterSrText}</span>
-              <w-icon-close-16 class="${pillStyles.closeIcon}"></w-icon-close-16>
+            ? html` <button
+              type="button"
+              class="${this._closeClasses}"
+              part="pill-close"
+              @click="${this._onClose}"
+            >
+              <span class="${pillStyles.a11y}"
+                >${this.closeAriaLabel ? this.closeAriaLabel : this.removeFilterSrText}</span
+              >
+              <w-icon-close-16
+                class="${pillStyles.closeIcon}"
+              ></w-icon-close-16>
             </button>`
             : null
         }

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -286,28 +286,35 @@ class WarpSlider extends LitElement {
       >
         ${
           this.label
-            ? html`<legend class="w-slider__label">
+            ? html`<legend class="w-slider__label" part="slider-label">
               <slot id="label" name="label">${this.label}</slot>
             </legend>`
             : nothing
         }
-        <slot class="w-slider__description" name="description"></slot>
-        ${this.markers ? html`<div class="w-slider__markers"></div>` : nothing}
-        <div class="w-slider__range">
-          <div class="w-slider__active-range"></div>
+        <slot
+          class="w-slider__description"
+          name="description"
+          part="slider-description"
+        ></slot>
+        ${this.markers ? html`<div class="w-slider__markers" part="slider-markers"></div>` : nothing}
+        <div class="w-slider__range" part="slider-range">
+          <div class="w-slider__active-range" part="slider-active-range"></div>
         </div>
         <slot
           class="w-slider__slider"
+          part="slider-thumb"
           @slotchange=${this.#syncSliderThumbs}
         ></slot>
         <slot
           class="w-slider__slider"
           name="from"
+          part="slider-from"
           @slotchange=${this.#syncSliderThumbs}
         ></slot>
         <slot
           class="w-slider__slider"
           name="to"
+          part="slider-to"
           @slotchange=${this.#syncSliderThumbs}
         ></slot>
         ${

--- a/packages/step-indicator/step-indicator.ts
+++ b/packages/step-indicator/step-indicator.ts
@@ -48,8 +48,13 @@ export class WarpStepIndicator extends LitElement {
     const classes = classNames([ccSteps.wrapper, this.horizontal && ccSteps.horizontal]);
 
     return html`
-      <div role="list" class=${classes} ${this.horizontal && `style='display: grid; grid-auto-rows: 1fr;grid-template-columns: 1fr;'`}>
-        <slot></slot>
+      <div
+        role="list"
+        part="step-list"
+        class=${classes}
+        ${this.horizontal && `style='display: grid; grid-auto-rows: 1fr;grid-template-columns: 1fr;'`}
+      >
+        <slot part="steps"></slot>
       </div>
     `;
   }

--- a/packages/step/step.ts
+++ b/packages/step/step.ts
@@ -7,13 +7,13 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import '@warp-ds/icons/elements/check-16';
 
 import { activateI18n } from '../i18n.js';
+import { styles } from '../step-indicator/styles.js';
+import { reset } from '../styles.js';
 import { messages as daMessages } from './locales/da/messages.mjs';
 import { messages as enMessages } from './locales/en/messages.mjs';
 import { messages as fiMessages } from './locales/fi/messages.mjs';
 import { messages as nbMessages } from './locales/nb/messages.mjs';
 import { messages as svMessages } from './locales/sv/messages.mjs';
-import { styles } from '../step-indicator/styles.js';
-import { reset } from '../styles.js';
 
 const ccStep = {
   base: 'group/step',
@@ -60,7 +60,12 @@ export class WarpStep extends LitElement {
   completed = false;
 
   @state()
-  private _context: StepsContext = { horizontal: false, right: false, isLast: false, isFirst: false };
+  private _context: StepsContext = {
+    horizontal: false,
+    right: false,
+    isLast: false,
+    isFirst: false,
+  };
 
   static styles = [reset, styles];
 
@@ -140,13 +145,31 @@ export class WarpStep extends LitElement {
     ]);
 
     return html`
-      <div class="${stepClasses}" style=${ifDefined(this._context.horizontal ? 'height: 100%;' : undefined)}>
+      <div
+        class="${stepClasses}"
+        style=${ifDefined(this._context.horizontal ? 'height: 100%;' : undefined)}
+      >
         ${!vertical ? html`<div class=${lineHorizontalClasses}></div>` : nothing}
-        <div class=${dotClasses} role="img" aria-label=${this.getAriaLabel()} aria-current=${this.active ? 'step' : nothing}>
-          ${this.completed ? html`<w-icon-check-16 data-testid="completed-icon"></w-icon-check-16>` : nothing}
+        <div
+          class=${dotClasses}
+          role="img"
+          aria-label=${this.getAriaLabel()}
+          aria-current=${this.active ? 'step' : nothing}
+        >
+          ${
+            this.completed
+              ? html`<w-icon-check-16
+                data-testid="completed-icon"
+              ></w-icon-check-16>`
+              : nothing
+          }
         </div>
         <div class=${lineClasses}></div>
-        <div class=${contentClasses} style=${ifDefined(this._context.horizontal ? 'height: 100%;' : undefined)}>
+        <div
+          class=${contentClasses}
+          part="step-content"
+          style=${ifDefined(this._context.horizontal ? 'height: 100%;' : undefined)}
+        >
           <slot></slot>
         </div>
       </div>

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -38,7 +38,7 @@ export class WarpTabPanel extends LitElement {
   }
 
   render() {
-    return html`<slot></slot>`;
+    return html`<slot part="panel-content"></slot>`;
   }
 }
 

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -23,7 +23,15 @@ const ccButtonReset = 'focus:outline-none appearance-none cursor-pointer bg-tran
  * [See Storybook for usage examples](https://warp-ds.github.io/elements/?path=/docs/tabs--docs)
  */
 export class WarpTab extends LitElement {
-  static styles = [reset, styles, css`::slotted([slot="icon"]){display:flex}`];
+  static styles = [
+    reset,
+    styles,
+    css`
+      ::slotted([slot="icon"]) {
+        display: flex;
+      }
+    `,
+  ];
 
   @property({ attribute: 'for', reflect: true })
   for = '';
@@ -53,24 +61,30 @@ export class WarpTab extends LitElement {
         aria-controls="${this.for}"
         id="warp-tab-${this.for}"
         class="${this._classes}"
+        part="tab-button"
         tabindex="${/* This needs to be -1 to prevent the auto-focus on buttons, messing up tab order */ -1}"
         @click="${(e) => {
           e.tab = this;
         }}"
-        style="height: 100%">
+        style="height: 100%"
+      >
         ${
           !hasIcon
-            ? html`<span class="${ccTab.contentUnderlined}"><slot></slot></span>`
+            ? html`<span class="${ccTab.contentUnderlined}" part="tab-content"
+              ><slot></slot
+            ></span>`
             : this.over
               ? html`
-                <span class="${ccTab.icon}">
+                <span class="${ccTab.icon}" part="tab-icon">
                   <slot name="icon"></slot>
                 </span>
-                <span class="${ccTab.contentUnderlined}"><slot></slot></span>
+                <span class="${ccTab.contentUnderlined}" part="tab-content"
+                  ><slot></slot
+                ></span>
               `
               : html`
-                <div class="${ccTab.content}">
-                  <slot name="icon"></slot>
+                <div class="${ccTab.content}" part="tab-content">
+                  <slot name="icon" part="tab-icon"></slot>
                   <slot></slot>
                 </div>
               `

--- a/packages/tabs/tabs.ts
+++ b/packages/tabs/tabs.ts
@@ -280,13 +280,30 @@ export class WarpTabs extends LitElement {
     const divClasses = classNames([ccTabs.base, this._gridClass]);
 
     return html`
-      <div class="${navClasses}">
-        <div role="tablist" class="${divClasses}" @keydown="${this._handleKeyDown}">
-          <slot name="tabs" @slotchange="${this._assignSlots}"></slot>
-          <span class="selection-indicator ${ccTabs.selectionIndicator}" data-testid="selection-indicator"></span>
+      <div class="${navClasses}" part="tabs-wrapper">
+        <div
+          role="tablist"
+          class="${divClasses}"
+          part="tablist"
+          @keydown="${this._handleKeyDown}"
+        >
+          <slot
+            name="tabs"
+            part="tabs"
+            @slotchange="${this._assignSlots}"
+          ></slot>
+          <span
+            class="selection-indicator ${ccTabs.selectionIndicator}"
+            part="selection-indicator"
+            data-testid="selection-indicator"
+          ></span>
         </div>
       </div>
-      <slot name="panels" @slotchange="${this._assignSlots}"></slot>
+      <slot
+        name="panels"
+        part="panels"
+        @slotchange="${this._assignSlots}"
+      ></slot>
       <slot @slotchange="${this._assignSlots}"></slot>
     `;
   }

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -184,7 +184,9 @@ class WarpTextField extends FormControlMixin(LitElement) {
   /** @internal */
   get _label() {
     if (this.label) {
-      return html`<label for="${this._id}" class=${ccLabel.base}>${this.label}</label>`;
+      return html`<label for="${this._id}" class=${ccLabel.base}
+        >${this.label}</label
+      >`;
     }
     return undefined;
   }
@@ -235,14 +237,20 @@ class WarpTextField extends FormControlMixin(LitElement) {
     return html`
       ${this._label}
       <div
+        part="textfield"
         class="${classMap({
           'w-textfield': true,
           // This could likely be replaced in the future by
           // https://developer.mozilla.org/en-US/docs/Web/CSS/:has-slotted
           'w-textfield--has-prefix': this._hasPrefix,
           'w-textfield--has-suffix': this._hasSuffix,
-        })}">
-        <slot @slotchange="${this.prefixSlotChange}" name="prefix"></slot>
+        })}"
+      >
+        <slot
+          @slotchange="${this.prefixSlotChange}"
+          name="prefix"
+          part="prefix"
+        ></slot>
         <div class="w-textfield__input-wrapper">
           ${this.formatter ? html`<div class="w-textfield__mask"></div>` : nothing}
           <input
@@ -269,12 +277,22 @@ class WarpTextField extends FormControlMixin(LitElement) {
             @blur="${this.handler}"
             @change="${this.handler}"
             @input="${this.handler}"
-            @focus="${this.handler}" />
+            @focus="${this.handler}"
+          />
         </div>
-        <slot @slotchange="${this.suffixSlotChange}" name="suffix"></slot>
+        <slot
+          @slotchange="${this.suffixSlotChange}"
+          name="suffix"
+          part="suffix"
+        ></slot>
       </div>
       <span class="sr-only" id="aria-description">${this.ariaDescription}</span>
-      ${this.helpText && html`<div class="${this._helptextstyles}" id="${this._helpId}">${this.helpText}</div>`}
+      ${
+        this.helpText &&
+        html`<div class="${this._helptextstyles}" id="${this._helpId}">
+        ${this.helpText}
+      </div>`
+      }
     `;
   }
 }


### PR DESCRIPTION
I was trying to style Expandable's button today via `button-class` and it doesn't work anymore (I think due to being wrapped by the unstyled-heading element).

I added `part` to Expandable and then got AI to do the same for other components.

If the formatting the bot applied needs reverted I'm happy to go through and do that, overall it seems to align with some of the less-terse styling I've seen applied elsewhere though.