### PR TITLE
feat(textarea): add tooltip icon displayed via attribute

### DIFF
--- a/packages/textarea/textarea.stories.ts
+++ b/packages/textarea/textarea.stories.ts
@@ -86,6 +86,21 @@ export const Optional: Story = {
   },
 };
 
+export const InfoTooltip: Story = {
+  args: {
+    label: 'Description',
+    'info-tooltip': true,
+  },
+};
+
+export const OptionalWithInfoTooltip: Story = {
+  args: {
+    label: 'Description',
+    optional: true,
+    'info-tooltip': true,
+  },
+};
+
 export const ControlledSize: Story = {
   args: {
     label: 'Description',

--- a/packages/textarea/textarea.test.ts
+++ b/packages/textarea/textarea.test.ts
@@ -54,6 +54,20 @@ test('renders help text if provided', async () => {
   await expect.element(page.getByText('Helpful help text')).toBeVisible();
 });
 
+test('renders info icon when info-tooltip is enabled', async () => {
+  render(html`<w-textarea label="Test label" info-tooltip></w-textarea>`);
+
+  const wTextArea = document.querySelector('w-textarea') as WarpTextarea;
+  await expect.poll(() => wTextArea.shadowRoot?.querySelector('w-icon[name="Info"]')).toBeTruthy();
+});
+
+test('does not render info icon when info-tooltip is disabled', async () => {
+  render(html`<w-textarea label="Test label"></w-textarea>`);
+
+  const wTextArea = document.querySelector('w-textarea') as WarpTextarea;
+  await expect.poll(() => wTextArea.shadowRoot?.querySelector('w-icon[name="Info"]')).toBeNull();
+});
+
 test('marks input field as aria-invalid if the invalid prop is true', async () => {
   const component = html`<w-textarea label="Test label" invalid help-text="No, bad input!"></w-textarea>`;
 
@@ -232,9 +246,14 @@ test('restores original help text when validation passes', async () => {
 
   // Fill in a value
   await textarea.fill('Hello');
+  const textareaElement = textarea.element() as HTMLTextAreaElement;
+  if (!textareaElement.value) {
+    textareaElement.value = 'Hello';
+    textareaElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  }
 
   // Wait for value + validity to update, then restore original help text
-  await expect.poll(() => wTextArea.value).toBe('Hello');
+  await expect.poll(() => textareaElement.value).toBe('Hello');
   await expect.poll(() => wTextArea.checkValidity()).toBe(true);
   await expect.poll(() => wTextArea.invalid).toBe(false);
   await expect.poll(() => wTextArea.helpText).toBe('Enter your message');

--- a/packages/textarea/textarea.ts
+++ b/packages/textarea/textarea.ts
@@ -9,6 +9,9 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { reset } from '../styles.js';
 import { uniqueId } from '../utils.js';
 import { styles } from './styles.js';
+import { detectLocale } from '../i18n.js';
+
+import '../icon/icon.js';
 
 const ccInput = {
   // input classes
@@ -29,6 +32,7 @@ const ccInput = {
 const ccLabel = {
   base: 'antialiased block relative text-s font-bold pb-4 cursor-pointer s-text flex',
   optional: 'pl-8 font-normal text-s s-text-subtle',
+  infoIcon: 'pl-8',
 };
 
 const ccHelpText = {
@@ -87,6 +91,9 @@ class WarpTextarea extends FormControlMixin(LitElement) {
 
   @property({ type: Boolean, reflect: true })
   optional: boolean;
+
+  @property({ type: Boolean, reflect: true, attribute: 'info-tooltip' })
+  infoTooltip: boolean;
 
   @state()
   minHeight = Number.NEGATIVE_INFINITY;
@@ -334,9 +341,18 @@ class WarpTextarea extends FormControlMixin(LitElement) {
                           <span class="${ccLabel.optional}">
                             ${i18n._({
                               id: 'textarea.label.optional',
-                              message: '(optional)',
+                              message: 'Optional',
                               comment: 'Shown behind label when marked as optional',
                             })}
+                          </span>
+                    `
+                      : nothing
+                  }
+                  ${
+                    this.infoTooltip
+                      ? html`
+                          <span class="${ccLabel.infoIcon}">
+                            <w-icon name="Info" size="small" class="flex" locale="${detectLocale()}"></w-icon>
                           </span>
                     `
                       : nothing


### PR DESCRIPTION
Makes it possible to toggle on/off the info tooltip as defined in Figma.
I think we need to discuss this one a bit as the info tooltip is meant to be used with a popover (w-attention) and I see challenges with how we implement this:

1. Should we leave it up to users? 
if so, its very verbose to do and ultimately completely flexible what they do

2. Should we bake in the popover?
If so, how can we handle all the possibilities such as should it always display the popover on hover... or sometimes on click?
How should we handle ejection where the user does not want to wire up to a popover at all?