### PR TITLE
fix: add .js extension to window-exists import in toast/api.ts

### DIFF
--- a/packages/toast/api.ts
+++ b/packages/toast/api.ts
@@ -1,5 +1,5 @@
 import { WarpToastContainer } from '../toast-container/toast-container.js';
-import { windowExists } from '../utils/window-exists';
+import { windowExists } from '../utils/window-exists.js';
 import type { ToastInternal, ToastOptions } from './types';
 
 function getToastContainer() {

--- a/tests/module-resolution/import-test.ts
+++ b/tests/module-resolution/import-test.ts
@@ -23,6 +23,7 @@ import { Switch } from '@warp-ds/elements/react/switch';
 import { Tab, TabPanel, Tabs } from '@warp-ds/elements/react/tabs';
 import { Textarea } from '@warp-ds/elements/react/textarea';
 import { TextField } from '@warp-ds/elements/react/textfield';
+import { toast } from '@warp-ds/elements/toast';
 
 // unreleased
 // import { Checkbox } from '@warp-ds/elements/react/checkbox';
@@ -58,6 +59,7 @@ const _tabPanel: typeof TabPanel = TabPanel;
 const _tabs: typeof Tabs = Tabs;
 const _textarea: typeof Textarea = Textarea;
 const _textField: typeof TextField = TextField;
+const _toast: typeof toast = toast;
 
 // unreleased
 // const _deadToggle: typeof DeadToggle = DeadToggle;


### PR DESCRIPTION
- Adds missing `.js` extension to the `window-exists` import in `packages/toast/api.ts`, fixing `ERR_MODULE_NOT_FOUND` in strict ESM resolvers
  (e.g. Vitest) when importing `@warp-ds/elements/components/toast`
- Adds runtime Node ESM import tests to `tests/module-resolution/test.sh` that verify package exports actually resolve
- Adds `@warp-ds/elements/toast` to the TypeScript module resolution import test