### PR TITLE
fix(select): ensure native select, host and options are always in sync

### DIFF
--- a/packages/select/select.a11y.test.ts
+++ b/packages/select/select.a11y.test.ts
@@ -1,0 +1,146 @@
+import { html } from 'lit';
+import { describe, expect, test } from 'vitest';
+import { render } from 'vitest-browser-lit';
+
+import './select.js';
+
+describe('w-select accessibility (WCAG 2.2)', () => {
+  describe('axe-core automated checks', () => {
+    test('default state has no violations', async () => {
+      const page = render(html`
+        <w-select label="Berries">
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('with help text has no violations', async () => {
+      const page = render(html`
+        <w-select label="Berries" help-text="Choose your favorite">
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('invalid state has no violations', async () => {
+      const page = render(html`
+        <w-select label="Berries" invalid help-text="Selection required">
+          <option value="">Choose one</option>
+          <option value="strawberries">Strawberries</option>
+        </w-select>
+      `);
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('disabled state has no violations', async () => {
+      const page = render(html`
+        <w-select label="Berries" disabled>
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      await expect(page).toHaveNoAxeViolations();
+    });
+  });
+
+  describe('WCAG 1.3.1 - Info and Relationships', () => {
+    test('select has accessible name from label', async () => {
+      const page = render(html`
+        <w-select label="Berry choice">
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      await expect.element(page.getByLabelText('Berry choice')).toBeVisible();
+    });
+  });
+
+  describe('WCAG 3.3.1/3.3.2 - Errors and Instructions', () => {
+    test('invalid state is exposed through aria-invalid', async () => {
+      const page = render(html`
+        <w-select label="Berry choice" invalid>
+          <option value="">Choose one</option>
+          <option value="strawberries">Strawberries</option>
+        </w-select>
+      `);
+      await expect.element(page.getByLabelText('Berry choice')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    test('help text is associated as accessible description', async () => {
+      const page = render(html`
+        <w-select label="Berry choice" help-text="This appears in your profile">
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      await expect.element(page.getByLabelText('Berry choice')).toHaveAccessibleDescription(
+        'This appears in your profile',
+      );
+    });
+  });
+
+  describe('WCAG 4.1.2 - Name, Role, Value', () => {
+    test('disabled state is exposed', async () => {
+      const page = render(html`
+        <w-select label="Berry choice" disabled>
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      await expect.element(page.getByLabelText('Berry choice')).toBeDisabled();
+    });
+
+    test('value reflects selected option', async () => {
+      const page = render(html`
+        <w-select label="Berry choice">
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries" selected>Raspberries</option>
+        </w-select>
+      `);
+      await expect.element(page.getByLabelText('Berry choice')).toHaveValue('raspberries');
+    });
+
+    test('dynamic selected option updates are reflected accessibly', async () => {
+      const page = render(html`
+        <w-select label="Berry choice">
+          <option value="strawberries" selected>Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+
+      const wSelect = document.querySelector('w-select') as HTMLElement & {
+        updateComplete: Promise<unknown>;
+      };
+      await wSelect.updateComplete;
+
+      const lightOptions = Array.from(wSelect.querySelectorAll('option'));
+      lightOptions[0].removeAttribute('selected');
+      lightOptions[1].setAttribute('selected', '');
+
+      await expect.poll(() => (page.getByLabelText('Berry choice').element() as HTMLSelectElement).value).toBe(
+        'raspberries',
+      );
+      await expect(page).toHaveNoAxeViolations();
+    });
+  });
+
+  describe('WCAG 2.1.1 - Keyboard', () => {
+    test('select is focusable', async () => {
+      const page = render(html`
+        <w-select label="Berry choice">
+          <option value="strawberries">Strawberries</option>
+          <option value="raspberries">Raspberries</option>
+        </w-select>
+      `);
+      const select = page.getByLabelText('Berry choice');
+      await select.click();
+
+      const wSelect = document.querySelector('w-select');
+      await expect.poll(() => wSelect?.shadowRoot?.activeElement?.tagName).toBe('SELECT');
+    });
+  });
+});

--- a/packages/select/select.test.ts
+++ b/packages/select/select.test.ts
@@ -73,3 +73,255 @@ test('can reset select by resetting surrounding form', async () => {
   // Value should be reset back to "strawberries"
   expect(wSelect.value).toBe('strawberries');
 });
+
+test('change event target.value reflects the selected value', async () => {
+  render(html`
+    <w-select label="Fruit">
+      <option value="apples">Apples</option>
+      <option value="pears">Pears</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string;
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+  let observedTargetValue = '';
+
+  wSelect.addEventListener('change', (e) => {
+    observedTargetValue = ((e.target as HTMLElement & { value?: string }).value ?? '') as string;
+  });
+
+  nativeSelect.value = 'pears';
+  nativeSelect.dispatchEvent(new Event('change'));
+
+  expect(observedTargetValue).toBe('pears');
+});
+
+test('keeps native select in sync when host value changes', async () => {
+  render(html`
+    <w-select label="Gender" value="male">
+      <option value="male">Male</option>
+      <option value="female">Female</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string;
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+
+  wSelect.value = 'female';
+  await wSelect.updateComplete;
+
+  expect(nativeSelect.value).toBe('female');
+});
+
+test('syncs host value when native select value changes without firing change', async () => {
+  render(html`
+    <form>
+      <w-select label="Gender" name="gender">
+        <option value="">Choose</option>
+        <option value="male">Male</option>
+        <option value="female">Female</option>
+      </w-select>
+    </form>
+  `);
+
+  const form = document.querySelector('form') as HTMLFormElement;
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string;
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+
+  // Simulates browser session restore/autocomplete updating only the internal native select.
+  nativeSelect.value = 'female';
+  window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+
+  await expect.poll(() => wSelect.value).toBe('female');
+  expect(new FormData(form).get('gender')).toBe('female');
+});
+
+test('does not sync host value from the browser default first option', async () => {
+  render(html`
+    <w-select label="Default first option">
+      <option value="alpha">Alpha</option>
+      <option value="beta">Beta</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string | undefined;
+    updateComplete: Promise<unknown>;
+  };
+  await wSelect.updateComplete;
+
+  window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+
+  expect(wSelect.value ?? '').toBe('');
+});
+
+test('pageshow does not overwrite an intentionally empty host value', async () => {
+  render(html`
+    <w-select label="Intentional empty" value="">
+      <option value="male">Male</option>
+      <option value="female">Female</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string | undefined;
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+  expect(nativeSelect.value).toBe('');
+
+  window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+
+  expect(wSelect.value ?? '').toBe('');
+});
+
+test('formStateRestoreCallback syncs value from provided state', async () => {
+  render(html`
+    <form>
+      <w-select label="Restore state" name="gender">
+        <option value="">Choose</option>
+        <option value="male">Male</option>
+        <option value="female">Female</option>
+      </w-select>
+    </form>
+  `);
+
+  const form = document.querySelector('form') as HTMLFormElement;
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string;
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+    formStateRestoreCallback: (state: string | File | FormData | null, reason: 'autocomplete' | 'restore') => void;
+  };
+  await wSelect.updateComplete;
+
+  wSelect.formStateRestoreCallback('female', 'restore');
+
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+  expect(wSelect.value).toBe('female');
+  expect(nativeSelect.value).toBe('female');
+  expect(new FormData(form).get('gender')).toBe('female');
+});
+
+test('formStateRestoreCallback with null falls back to native value reconciliation', async () => {
+  render(html`
+    <form>
+      <w-select label="Restore fallback" name="gender">
+        <option value="">Choose</option>
+        <option value="male">Male</option>
+        <option value="female">Female</option>
+      </w-select>
+    </form>
+  `);
+
+  const form = document.querySelector('form') as HTMLFormElement;
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    value: string;
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+    formStateRestoreCallback: (state: string | File | FormData | null, reason: 'autocomplete' | 'restore') => void;
+  };
+  await wSelect.updateComplete;
+
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+  nativeSelect.value = 'female';
+
+  wSelect.formStateRestoreCallback(null, 'restore');
+
+  expect(wSelect.value).toBe('female');
+  expect(new FormData(form).get('gender')).toBe('female');
+});
+
+test('change event keeps backward compatibility by exposing detail', async () => {
+  render(html`
+    <w-select label="Legacy change detail">
+      <option value="alpha">Alpha</option>
+      <option value="beta">Beta</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+  let observedDetail: unknown;
+
+  wSelect.addEventListener('change', (event) => {
+    observedDetail = (event as CustomEvent).detail;
+  });
+
+  nativeSelect.value = 'beta';
+  nativeSelect.dispatchEvent(new Event('change'));
+
+  expect(observedDetail).toBe('beta');
+});
+
+test('emits a single host change event for one native change interaction', async () => {
+  render(html`
+    <w-select label="Single change event">
+      <option value="alpha">Alpha</option>
+      <option value="beta">Beta</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+
+  const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+  let changeCount = 0;
+  wSelect.addEventListener('change', () => {
+    changeCount += 1;
+  });
+
+  nativeSelect.value = 'beta';
+  nativeSelect.dispatchEvent(new Event('change'));
+
+  expect(changeCount).toBe(1);
+});
+
+test('reflects dynamic light-DOM option selected changes into native select', async () => {
+  render(html`
+    <w-select label="Dynamic options">
+      <option value="alpha">Alpha</option>
+      <option value="beta">Beta</option>
+    </w-select>
+  `);
+
+  const wSelect = document.querySelector('w-select') as HTMLElement & {
+    updateComplete: Promise<unknown>;
+    shadowRoot: ShadowRoot;
+  };
+  await wSelect.updateComplete;
+
+  const lightOptions = Array.from(wSelect.querySelectorAll('option'));
+  lightOptions[1].setAttribute('selected', '');
+
+  await expect.poll(() => {
+    const nativeSelect = wSelect.shadowRoot.querySelector('select') as HTMLSelectElement;
+    return nativeSelect.value;
+  }).toBe('beta');
+});

--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -316,7 +316,7 @@ export class WarpSelect extends FormControlMixin(LitElement) {
   }
 
   get #helpId() {
-    return this.hint ? `${this.#id}__hint` : undefined;
+    return this.helpText || this.hint ? `${this.#id}__hint` : undefined;
   }
 
   // // Fire a custom 'change' event, used when the dropdown changes state.

--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -3,7 +3,7 @@
 import { classNames } from '@chbphone55/classnames';
 import { i18n } from '@lingui/core';
 import { FormControlMixin } from '@open-wc/form-control';
-import { css, html, LitElement, TemplateResult } from 'lit';
+import { css, html, LitElement, PropertyValues, TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { when } from 'lit/directives/when.js';
@@ -122,6 +122,8 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 
   // capture the initial value using connectedCallback and #initialValue
   #initialValue: string | null = null;
+  #onPageShow = () => this.#syncFromNativeSelect();
+  #lightDomObserver?: MutationObserver;
 
   static styles = [
     reset,
@@ -151,6 +153,76 @@ export class WarpSelect extends FormControlMixin(LitElement) {
     this.setValue(value);
   };
 
+  #getOptionNodes() {
+    return Array.from(this.children).filter(
+      (child) => child.tagName.toLowerCase() === 'option' || child.tagName.toLowerCase() === 'w-option',
+    ) as HTMLElement[];
+  }
+
+  #getNativeSelect() {
+    return this.shadowRoot?.querySelector('select') as HTMLSelectElement | null;
+  }
+
+  #hasExplicitlySelectedOption() {
+    return this.#getOptionNodes().some((option) => option.hasAttribute('selected'));
+  }
+
+  #syncNativeOptionSelection(nextValue: string) {
+    const nativeSelect = this.#getNativeSelect();
+    if (!nativeSelect) return;
+
+    let selectedFound = false;
+    for (const option of Array.from(nativeSelect.options)) {
+      const selected = !selectedFound && option.value === nextValue;
+      option.selected = selected;
+      option.toggleAttribute('selected', selected);
+      if (selected) selectedFound = true;
+    }
+  }
+
+  #syncFromNativeSelect({ allowDefaultFirstOption = false }: { allowDefaultFirstOption?: boolean } = {}) {
+    const nativeSelect = this.#getNativeSelect();
+    if (!nativeSelect) return;
+
+    const nativeValue = nativeSelect.value;
+    if (!nativeValue || nativeValue === this.value) return;
+
+    // Browser default selection of first option should not become component value.
+    const isLikelyBrowserDefaultSelection =
+      !allowDefaultFirstOption &&
+      !this.value &&
+      !this.#hasExplicitlySelectedOption() &&
+      nativeSelect.selectedIndex === 0;
+
+    if (isLikelyBrowserDefaultSelection) return;
+
+    this._setValue(nativeValue);
+    this.#syncNativeOptionSelection(nativeValue);
+  }
+
+  #syncShadowOptionsFromLightDom({ syncValueFromSelected = false }: { syncValueFromSelected?: boolean } = {}) {
+    const optionNodes = this.#getOptionNodes();
+    let selectedValueFromLightDom: string | undefined;
+    const options = optionNodes.map((child: HTMLElement) => {
+      const value = child.getAttribute('value') ?? '';
+      const label = child.textContent ?? '';
+      const selected = child.hasAttribute('selected');
+      const disabled = child.hasAttribute('disabled');
+
+      if (syncValueFromSelected && selectedValueFromLightDom === undefined && selected) {
+        selectedValueFromLightDom = value;
+      }
+
+      return html`<option value="${value}" ?selected=${selected} ?disabled=${disabled}>${label}</option>`;
+    });
+
+    this._options = options;
+
+    if (syncValueFromSelected && selectedValueFromLightDom !== undefined && selectedValueFromLightDom !== this.value) {
+      this._setValue(selectedValueFromLightDom);
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -159,26 +231,57 @@ export class WarpSelect extends FormControlMixin(LitElement) {
     // autofocus doesn't seem to behave properly in Safari and FireFox, therefore we set the focus here:
     if (this.autofocus || this.autoFocus) this.shadowRoot.querySelector('select').focus();
 
-    // Gather both <option> and <w-option> children
-    const optionNodes = Array.from(this.children).filter(
-      (child) => child.tagName.toLowerCase() === 'option' || child.tagName.toLowerCase() === 'w-option',
-    );
+    this.#syncShadowOptionsFromLightDom({ syncValueFromSelected: true });
+    this.ownerDocument?.defaultView?.addEventListener('pageshow', this.#onPageShow);
 
-    // Convert them into HTML strings for the template
-    const options = optionNodes.map((child: HTMLElement) => {
-      const value = child.getAttribute('value') ?? '';
-      const label = child.textContent ?? '';
-      const selected = child.hasAttribute('selected');
-      const disabled = child.hasAttribute('disabled');
-
-      if (selected) {
-        this._setValue(value);
-      }
-
-      return html`<option value="${value}" ?selected=${selected} ?disabled=${disabled}>${label}</option>`;
+    // Keep mirrored shadow options in sync with dynamic light-DOM option changes.
+    this.#lightDomObserver = new MutationObserver(() => {
+      this.#syncShadowOptionsFromLightDom({ syncValueFromSelected: true });
     });
+    this.#lightDomObserver.observe(this, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['selected', 'disabled', 'value'],
+    });
+  }
 
-    this._options = options;
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.ownerDocument?.defaultView?.removeEventListener('pageshow', this.#onPageShow);
+    this.#lightDomObserver?.disconnect();
+  }
+
+  firstUpdated() {
+    // Reconcile once after initial render for restored/autofilled values.
+    this.#syncFromNativeSelect();
+  }
+
+  formStateRestoreCallback(state: string | File | FormData | null, _reason: 'autocomplete' | 'restore') {
+    if (typeof state === 'string' && state) {
+      this._setValue(state);
+      this.#syncNativeOptionSelection(state);
+      return;
+    }
+
+    this.#syncFromNativeSelect({ allowDefaultFirstOption: true });
+  }
+
+  willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('value')) {
+      this.setValue(this.value);
+    }
+  }
+
+  updated(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('value')) {
+      const nativeSelect = this.#getNativeSelect();
+      if (nativeSelect && nativeSelect.value !== this.value) {
+        nativeSelect.value = this.value ?? '';
+      }
+      this.#syncNativeOptionSelection(this.value ?? '');
+    }
   }
 
   handleKeyDown(event: KeyboardEvent) {
@@ -217,27 +320,17 @@ export class WarpSelect extends FormControlMixin(LitElement) {
   }
 
   // // Fire a custom 'change' event, used when the dropdown changes state.
-  onChange({ target }) {
-    this._setValue(target.value);
-    const event = new CustomEvent('change', { detail: target.value });
+  onChange(event: Event) {
+    const target = event.currentTarget as HTMLSelectElement;
+    const nextValue = target.value;
 
-    // Gather both <option> and <w-option> children to update the selected attribute
-    const optionNodes = Array.from(this.children).filter(
-      (child) => child.tagName.toLowerCase() === 'option' || child.tagName.toLowerCase() === 'w-option',
-    );
+    // Avoid forwarding the internal native change event and emitting two host events.
+    event.stopPropagation();
 
-    // Convert them into HTML strings for the template
-    const options = optionNodes.map((child: HTMLElement) => {
-      const value = child.getAttribute('value') ?? '';
-      const selected = value === target.value;
+    this._setValue(nextValue);
+    this.#syncNativeOptionSelection(nextValue);
 
-      const label = child.textContent ?? '';
-      const disabled = child.hasAttribute('disabled');
-      return html`<option value="${value}" ?selected=${selected} ?disabled=${disabled}>${label}</option>`;
-    });
-    this._options = options;
-
-    this.dispatchEvent(event);
+    this.dispatchEvent(new CustomEvent('change', { detail: nextValue }));
   }
 
   render() {


### PR DESCRIPTION
fixes #536 

Essentially, because we copy the option elements into the internal select element inside the shadow dom (we do this for a11y reasons, option tags need to be direct children of the select and be in the same shadow root, we need to do a bit of tedious sync work to ensure that if anything changes anywhere, it gets reflected to the internal stuff back out to the light dom stuff.

We could take a different approach to this. For example, we could have parent and child components w-select and w-option, throw away the native select and option usage and implement it all custom. This is what Web Awesome does. Our current approach I think isn't too bad though, we lean heavily on the native select and option tags and accept that this means we need to do some syncing between the light dom and shadow dom. My personal conclusion is that unless the designers start wanting more features in the options, then what we have now is the best solution.

Also added a bunch of tests and especially a11y tests as well.