### PR TITLE
fix: set default boolean property values

### DIFF
--- a/packages/attention/attention.ts
+++ b/packages/attention/attention.ts
@@ -91,29 +91,29 @@ const ccAttention = {
 
 class WarpAttention extends LitElement {
   @property({ type: Boolean, reflect: true })
-  show: boolean;
+  show = false;
 
   @property({ type: String, reflect: true })
   placement: Directions;
 
   @property({ type: Boolean, reflect: true })
-  tooltip: boolean;
+  tooltip = false;
 
   @property({ type: Boolean, reflect: true })
-  callout: boolean;
+  callout = false;
 
   @property({ type: Boolean, reflect: true })
   // @ts-expect-error This was introduced before native HTML popover
   popover: boolean;
 
   @property({ type: Boolean, reflect: true })
-  highlight: boolean;
+  highlight = false;
 
   @property({ attribute: 'can-close', type: Boolean, reflect: true })
-  canClose: boolean;
+  canClose = false;
 
   @property({ attribute: 'no-arrow', type: Boolean, reflect: true })
-  noArrow: boolean;
+  noArrow = false;
 
   @property({ type: Number, reflect: true })
   distance: number;
@@ -122,10 +122,10 @@ class WarpAttention extends LitElement {
   skidding: number;
 
   @property({ type: Boolean, reflect: true })
-  flip: boolean;
+  flip = false;
 
   @property({ attribute: 'cross-axis', type: Boolean, reflect: true })
-  crossAxis: boolean;
+  crossAxis = false;
 
   @property({ attribute: 'fallback-placements', type: Array, reflect: true })
   fallbackPlacements: Directions[];

--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -15,16 +15,16 @@ import { styles } from './styles';
  */
 class WarpBox extends LitElement {
   @property({ type: Boolean, reflect: true })
-  bleed: boolean;
+  bleed = false;
 
   @property({ type: Boolean, reflect: true })
-  bordered: boolean;
+  bordered = false;
 
   @property({ type: Boolean, reflect: true })
-  info: boolean;
+  info = false;
 
   @property({ type: Boolean, reflect: true })
-  neutral: boolean;
+  neutral = false;
 
   @property({ type: String, reflect: true })
   role: string;

--- a/packages/button/button.ts
+++ b/packages/button/button.ts
@@ -157,7 +157,7 @@ class WarpButton extends FormControlMixin(LitElement) {
   type: ButtonType = 'button';
 
   @property({ type: Boolean, reflect: true })
-  autofocus: boolean;
+  autofocus = false;
 
   @property({ reflect: true })
   variant: ButtonVariant;
@@ -166,13 +166,13 @@ class WarpButton extends FormControlMixin(LitElement) {
    * @type {boolean}
    */
   @property({ type: Boolean, reflect: true })
-  quiet: boolean;
+  quiet = false;
 
   @property({ type: Boolean, reflect: true })
-  small: boolean;
+  small = false;
 
   @property({ type: Boolean, reflect: true })
-  loading: boolean;
+  loading = false;
 
   @property({ reflect: true })
   href: string;
@@ -184,7 +184,7 @@ class WarpButton extends FormControlMixin(LitElement) {
   rel: string;
 
   @property({ attribute: 'full-width', type: Boolean, reflect: true })
-  fullWidth: boolean;
+  fullWidth = false;
 
   @property({ attribute: 'button-class', reflect: true })
   buttonClass: string;

--- a/packages/checkbox-group/checkbox-group.ts
+++ b/packages/checkbox-group/checkbox-group.ts
@@ -30,18 +30,18 @@ export class WCheckboxGroup extends FormControlMixin(LitElement) {
 
   /** Whether to show optional text next to the label. */
   @property({ type: Boolean, reflect: true })
-  optional: boolean;
+  optional = false;
 
   @property({ type: String, reflect: true, attribute: 'help-text' })
   helpText: string;
 
   /** Makes the checkbox group required. */
   @property({ type: Boolean, reflect: true })
-  required: boolean;
+  required = false;
 
   /** Marks the checkbox group as invalid. */
   @property({ type: Boolean, reflect: true })
-  invalid: boolean;
+  invalid = false;
 
   // Track whether the user has interacted with the group.
   #hasInteracted = false;

--- a/packages/link/link.ts
+++ b/packages/link/link.ts
@@ -46,19 +46,19 @@ class WarpLink extends LitElement {
   };
 
   @property({ type: Boolean, reflect: true })
-  autofocus: boolean;
+  autofocus = false;
 
   @property({ reflect: true })
   variant: ButtonVariant = 'secondary';
 
   @property({ type: Boolean, reflect: true })
-  small: boolean;
+  small = false;
 
   @property({ reflect: true })
   href: string;
 
   @property({ type: Boolean, reflect: true })
-  disabled: boolean;
+  disabled = false;
 
   @property({ reflect: true })
   target: string;
@@ -67,7 +67,7 @@ class WarpLink extends LitElement {
   rel: string;
 
   @property({ attribute: 'full-width', type: Boolean, reflect: true })
-  fullWidth: boolean;
+  fullWidth = false;
 
   static styles = [reset, styles];
 

--- a/packages/modal-header/modal-header.ts
+++ b/packages/modal-header/modal-header.ts
@@ -22,8 +22,8 @@ import { reset } from '../styles.js';
  */
 export class ModalHeader extends CanCloseMixin(LitElement) {
   @property({ type: String }) title: string;
-  @property({ type: Boolean }) back: boolean;
-  @property({ type: Boolean, attribute: 'no-close' }) noClose: boolean;
+  @property({ type: Boolean }) back = false;
+  @property({ type: Boolean, attribute: 'no-close' }) noClose = false;
   /** @internal */
   @state() private _hasTopContent = false;
 

--- a/packages/modal/modal.ts
+++ b/packages/modal/modal.ts
@@ -17,9 +17,9 @@ import { ProvidesCanCloseToSlotsMixin } from './util.js';
  * @slot footer - Typically where you would use the `w-modal-footer` component, for things like actions.
  */
 export class ModalMain extends ProvidesCanCloseToSlotsMixin(LitElement) {
-  @property({ type: Boolean }) show: boolean;
+  @property({ type: Boolean }) show = false;
   @property({ type: String, attribute: 'content-id' }) contentId: string;
-  @property({ type: Boolean, attribute: 'ignore-backdrop-clicks' }) ignoreBackdropClicks: boolean;
+  @property({ type: Boolean, attribute: 'ignore-backdrop-clicks' }) ignoreBackdropClicks = false;
 
   @query('.dialog-el') dialogEl: HTMLDialogElement;
   @query('.dialog-inner-el') dialogInnerEl: HTMLElement;

--- a/packages/pill/pill.ts
+++ b/packages/pill/pill.ts
@@ -37,8 +37,8 @@ const pillStyles = {
  * [See Storybook for usage examples](https://warp-ds.github.io/elements/?path=/docs/buttons-pill--docs)
  */
 class WarpPill extends LitElement {
-  @property({ attribute: 'can-close', type: Boolean }) canClose: boolean;
-  @property({ attribute: 'suggestion', type: Boolean }) suggestion: boolean;
+  @property({ attribute: 'can-close', type: Boolean }) canClose = false;
+  @property({ attribute: 'suggestion', type: Boolean }) suggestion = false;
   /**
    * @deprecated Used "open-arial-label" instead.
    */

--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -57,11 +57,11 @@ export class WarpSelect extends FormControlMixin(LitElement) {
    * @deprecated Use the native `autofocus` attribute instead.
    */
   @property({ attribute: 'auto-focus', type: Boolean, reflect: true })
-  autoFocus: boolean;
+  autoFocus = false;
 
   /** Whether the element should receive focus on render */
   @property({ type: Boolean, reflect: true })
-  autofocus: boolean;
+  autofocus = false;
 
   /**
    * The content displayed as the help text. Paired with `invalid` to show the text as a validation error.
@@ -71,14 +71,14 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 
   /** Renders the field in an invalid state. Paired with `help-text` to provide feedback about the error. */
   @property({ type: Boolean, reflect: true })
-  invalid: boolean;
+  invalid = false;
 
   /**
    * Whether to always show a hint.
    * @deprecated Use `help-text` instead and only set it if you want to display the help text.
    */
   @property({ type: Boolean, reflect: true })
-  always: boolean;
+  always = false;
 
   /**
    * The content displayed as the help text.
@@ -93,22 +93,22 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 
   /** Whether to show optional text */
   @property({ type: Boolean, reflect: true })
-  optional: boolean;
+  optional = false;
 
   /** Renders the field in a disabled state. */
   @property({ type: Boolean, reflect: true })
-  disabled: boolean;
+  disabled = false;
 
   /**
    * Renders the field in a readonly state.
    * @deprecated Use the native readonly attribute instead.
    */
   @property({ attribute: 'read-only', type: Boolean, reflect: true })
-  readOnly: boolean;
+  readOnly = false;
 
   /** Renders the field in a readonly state. */
   @property({ type: Boolean, reflect: true })
-  readonly: boolean;
+  readonly = false;
 
   /** @internal */
   @property({ attribute: false, state: true })

--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -41,7 +41,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 
   /** @internal Set by `<w-slider>` */
   @property({ type: Boolean, reflect: true })
-  disabled: boolean;
+  disabled = false;
 
   /** @internal Set by `<w-slider>` */
   @property({ type: Boolean, reflect: true })

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -69,7 +69,8 @@ export class WarpTab extends LitElement {
     super.updated(changedProperties);
 
     // ensure the state is reflected also in light DOM for the accessibility tree
-    if (changedProperties.has('active')) {
+    // Only let deprecated `active` drive aria-selected when explicitly set by consumers.
+    if (changedProperties.has('active') && this.hasAttribute('active')) {
       this.setAttribute('aria-selected', this.active ? 'true' : 'false');
     }
     if (changedProperties.has('for')) {

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -41,7 +41,7 @@ export class WarpTab extends LitElement {
    * @deprecated Use `aria-selected="true"` instead
    */
   @property({ type: Boolean, reflect: true })
-  active: boolean;
+  active = false;
 
   @property({ type: Boolean, reflect: true })
   over = false;

--- a/packages/textarea/textarea.ts
+++ b/packages/textarea/textarea.ts
@@ -49,10 +49,10 @@ class WarpTextarea extends FormControlMixin(LitElement) {
   };
 
   @property({ type: Boolean, reflect: true })
-  disabled: boolean;
+  disabled = false;
 
   @property({ type: Boolean, reflect: true })
-  invalid: boolean;
+  invalid = false;
 
   @property({ type: String, reflect: true })
   label: string;
@@ -74,19 +74,19 @@ class WarpTextarea extends FormControlMixin(LitElement) {
 
   /** @deprecated Use the native readonly attribute instead. Here for API consistency with `w-textfield`. */
   @property({ type: Boolean, reflect: true, attribute: 'read-only' })
-  readOnly: boolean;
+  readOnly = false;
 
   @property({ type: Boolean, reflect: true })
-  readonly: boolean;
+  readonly = false;
 
   @property({ type: Boolean, reflect: true })
-  required: boolean;
+  required = false;
 
   @property({ type: String, reflect: true })
   value: string;
 
   @property({ type: Boolean, reflect: true })
-  optional: boolean;
+  optional = false;
 
   @state()
   minHeight = Number.NEGATIVE_INFINITY;

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -50,10 +50,10 @@ class WarpTextField extends FormControlMixin(LitElement) {
   };
 
   @property({ type: Boolean, reflect: true })
-  disabled: boolean;
+  disabled = false;
 
   @property({ type: Boolean, reflect: true })
-  invalid: boolean;
+  invalid = false;
 
   @property({ type: String, reflect: true })
   id: string;
@@ -87,13 +87,13 @@ class WarpTextField extends FormControlMixin(LitElement) {
 
   /** @deprecated Use the native readonly attribute instead. */
   @property({ type: Boolean, reflect: true, attribute: 'read-only' })
-  readOnly: boolean;
+  readOnly = false;
 
   @property({ type: Boolean, reflect: true })
-  readonly: boolean;
+  readonly = false;
 
   @property({ type: Boolean, reflect: true })
-  required: boolean;
+  required = false;
 
   @property({ type: String, reflect: true })
   type = 'text';


### PR DESCRIPTION
Based on @pearofducks investigation, setting these booleans with a default value fixes an issue where using the custom elements in Vue results in the attributes being set via properties as an empty string which results in them not being present in the html