### PR TITLE
fix(switch): properly enable keyboard navigation and labelling

### DIFF
--- a/packages/switch/switch.a11y.test.ts
+++ b/packages/switch/switch.a11y.test.ts
@@ -74,7 +74,8 @@ describe('w-switch accessibility (WCAG 2.2)', () => {
       const beforeButton = page.getByRole('button', { name: 'Before' });
 
       await wSwitch.updateComplete;
-      beforeButton.element().focus();
+      const beforeButtonEl = beforeButton.element() as HTMLButtonElement;
+      beforeButtonEl.focus();
       await expect.element(beforeButton).toHaveFocus();
 
       await userEvent.tab();

--- a/packages/switch/switch.a11y.test.ts
+++ b/packages/switch/switch.a11y.test.ts
@@ -1,0 +1,102 @@
+import { userEvent } from '@vitest/browser/context';
+import { html } from 'lit';
+import { describe, expect, test } from 'vitest';
+import { render } from 'vitest-browser-lit';
+
+import './switch.js';
+
+describe('w-switch accessibility (WCAG 2.2)', () => {
+  describe('axe-core automated checks', () => {
+    test('default state has no violations', async () => {
+      const page = render(html`<w-switch aria-label="Enable notifications"></w-switch>`);
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('checked state has no violations', async () => {
+      const page = render(html`<w-switch checked aria-label="Enable notifications"></w-switch>`);
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('disabled state has no violations', async () => {
+      const page = render(html`<w-switch disabled aria-label="Enable notifications"></w-switch>`);
+      await expect(page).toHaveNoAxeViolations();
+    });
+  });
+
+  describe('WCAG 1.3.1 - Info and Relationships', () => {
+    test('switch has accessible name via aria-labelledby', async () => {
+      const page = render(html`
+        <div>
+          <span id="switch-label">Enable notifications</span>
+          <w-switch aria-labelledby="switch-label"></w-switch>
+        </div>
+      `);
+
+      await expect.element(page.getByRole('switch', { name: 'Enable notifications' })).toBeVisible();
+    });
+  });
+
+  describe('WCAG 4.1.2 - Name, Role, Value', () => {
+    test('switch exposes role and checked state', async () => {
+      const page = render(html`<w-switch aria-label="Enable notifications"></w-switch>`);
+      const wSwitch = page.container.querySelector('w-switch') as HTMLElement & {
+        checked: boolean;
+        updateComplete: Promise<unknown>;
+      };
+
+      await expect.element(page.getByRole('switch', { name: 'Enable notifications' })).toBeVisible();
+      await expect.element(wSwitch).toHaveAttribute('aria-checked', 'false');
+
+      wSwitch.checked = true;
+      await wSwitch.updateComplete;
+
+      await expect.element(wSwitch).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('disabled state is exposed', async () => {
+      const page = render(html`<w-switch disabled aria-label="Enable notifications"></w-switch>`);
+      const wSwitch = page.container.querySelector('w-switch');
+      await expect.element(wSwitch).toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('WCAG 2.1.1 - Keyboard', () => {
+    test('switch is reachable by tab and can be toggled with keyboard', async () => {
+      const page = render(html`
+        <button type="button">Before</button>
+        <w-switch aria-label="Enable notifications"></w-switch>
+        <button type="button">After</button>
+      `);
+      const wSwitch = page.container.querySelector('w-switch') as HTMLElement & {
+        checked: boolean;
+        updateComplete: Promise<unknown>;
+      };
+      const beforeButton = page.getByRole('button', { name: 'Before' });
+
+      await wSwitch.updateComplete;
+      beforeButton.element().focus();
+      await expect.element(beforeButton).toHaveFocus();
+
+      await userEvent.tab();
+      await expect.element(wSwitch).toHaveFocus();
+
+      await userEvent.keyboard(' ');
+      await wSwitch.updateComplete;
+
+      expect(wSwitch.checked).toBe(true);
+      await expect.element(wSwitch).toHaveAttribute('aria-checked', 'true');
+
+      await userEvent.keyboard('{Enter}');
+      await wSwitch.updateComplete;
+      expect(wSwitch.checked).toBe(false);
+
+      wSwitch.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', altKey: true, bubbles: true }));
+      await wSwitch.updateComplete;
+      expect(wSwitch.checked).toBe(false);
+
+      wSwitch.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', shiftKey: true, bubbles: true }));
+      await wSwitch.updateComplete;
+      expect(wSwitch.checked).toBe(false);
+    });
+  });
+});

--- a/packages/switch/switch.stories.ts
+++ b/packages/switch/switch.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
 
 import './switch.js';
 
@@ -40,5 +41,59 @@ export const DisabledChecked: Story = {
   args: {
     checked: true,
     disabled: true,
+  },
+};
+
+export const WithLabel: Story = {
+  render: () => html`
+    <div style="display: inline-flex; align-items: center; gap: 8px;">
+      <span id="switch-label">Enable notifications</span>
+      <w-switch aria-labelledby="switch-label"></w-switch>
+    </div>
+  `,
+};
+
+export const NativeLabel: Story = {
+  render: () => html`
+    <div style="display: inline-flex; align-items: center; gap: 8px;">
+      <label for="native-label-switch">Enable notifications</label>
+      <w-switch
+        id="native-label-switch"
+        name="notifications"
+        value="enabled"
+      ></w-switch>
+    </div>
+  `,
+};
+
+export const SwitchFormAssociated: Story = {
+  render: () => {
+    const handleSubmit = (event: Event) => {
+      event.preventDefault();
+      const form = event.currentTarget as HTMLFormElement;
+      const status = form.querySelector('[data-status]') as HTMLElement | null;
+      if (!status) return;
+
+      const data = new FormData(form);
+      const name = 'notifications';
+      const value = data.get(name);
+      status.textContent =
+        value === null ? 'Submitted: no switch value captured.' : `Submitted: ${name}=${String(value)}`;
+    };
+
+    return html`
+      <form @submit=${handleSubmit} style="display: grid; gap: 12px; max-width: 320px;">
+        <div style="display: inline-flex; align-items: center; gap: 8px;">
+          <span id="switch-form-label">Enable notifications</span>
+          <w-switch
+            aria-labelledby="switch-form-label"
+            name="notifications"
+            value="enabled"
+          ></w-switch>
+        </div>
+        <button type="submit">Submit</button>
+        <div data-status aria-live="polite"></div>
+      </form>
+    `;
   },
 };

--- a/packages/switch/switch.test.ts
+++ b/packages/switch/switch.test.ts
@@ -53,3 +53,56 @@ test('can reset switch by resetting surrounding form', async () => {
   const data3 = new FormData(form);
   expect(Array.from(data3.entries()).length).toBe(1);
 });
+
+test('mouse click toggles switch once', async () => {
+  render(html`<w-switch aria-label="Enable notifications"></w-switch>`);
+
+  const wSwitch = document.querySelector('w-switch') as HTMLElement & {
+    checked: boolean;
+    updateComplete: Promise<undefined>;
+    shadowRoot: ShadowRoot;
+  };
+
+  await wSwitch.updateComplete;
+  const button = wSwitch.shadowRoot.querySelector('button') as HTMLButtonElement;
+
+  expect(wSwitch.checked).toBe(false);
+  expect(wSwitch.getAttribute('aria-checked')).toBe('false');
+
+  button.click();
+  await wSwitch.updateComplete;
+
+  expect(wSwitch.checked).toBe(true);
+  expect(wSwitch.getAttribute('aria-checked')).toBe('true');
+});
+
+test('native label click toggles switch', async () => {
+  render(html`
+    <label for="native-label-switch">Enable notifications</label>
+    <w-switch
+      id="native-label-switch"
+      name="notifications"
+      value="enabled"
+    ></w-switch>
+  `);
+
+  const label = document.querySelector('label') as HTMLLabelElement;
+  const wSwitch = document.querySelector('w-switch') as HTMLElement & {
+    checked: boolean;
+    updateComplete: Promise<undefined>;
+  };
+
+  await wSwitch.updateComplete;
+  expect(wSwitch.checked).toBe(false);
+  expect(wSwitch.getAttribute('aria-checked')).toBe('false');
+
+  label.click();
+  await wSwitch.updateComplete;
+  expect(wSwitch.checked).toBe(true);
+  expect(wSwitch.getAttribute('aria-checked')).toBe('true');
+
+  label.click();
+  await wSwitch.updateComplete;
+  expect(wSwitch.checked).toBe(false);
+  expect(wSwitch.getAttribute('aria-checked')).toBe('false');
+});

--- a/packages/switch/switch.ts
+++ b/packages/switch/switch.ts
@@ -2,7 +2,7 @@
 
 import { classNames } from '@chbphone55/classnames';
 import { FormControlMixin } from '@open-wc/form-control';
-import { html, LitElement } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import { reset } from '../styles';
@@ -51,7 +51,30 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
   // capture the initial state using connectedCallback and #initialState
   #initialState: boolean | null = null;
 
-  static styles = [reset, styles];
+  static styles = [
+    reset,
+    styles,
+    css`
+      :host {
+        display: inline-block;
+      }
+
+      :host(:focus),
+      :host(:focus-visible) {
+        outline: none;
+      }
+
+      :host(:focus) button,
+      :host(:focus-visible) button {
+        outline: 2px solid var(--w-s-color-border-focus);
+        outline-offset: var(--w-outline-offset, 1px);
+      }
+
+      :host(:focus:not(:focus-visible)) button {
+        outline: none;
+      }
+    `,
+  ];
 
   /** @internal */
   get _baseClasses() {

--- a/packages/switch/switch.ts
+++ b/packages/switch/switch.ts
@@ -102,12 +102,53 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
     }
   }
 
+  /** @internal */
+  _handleHostClick = (event: MouseEvent) => {
+    if (this.disabled) return;
+    if (event.composedPath()[0] === this) {
+      this._handleClick();
+    }
+  };
+
+  /** @internal */
+  _handleKeyDown = (event: KeyboardEvent) => {
+    if (this.disabled) return;
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+
+    if (event.key === ' ' || event.key === 'Enter') {
+      event.preventDefault();
+      this._handleClick();
+    }
+  };
+
+  /** @internal */
+  _syncA11yState() {
+    this.setAttribute('aria-checked', String(this.checked));
+    this.tabIndex = this.disabled ? -1 : 0;
+    if (this.disabled) {
+      this.setAttribute('aria-disabled', 'true');
+      return;
+    }
+    this.removeAttribute('aria-disabled');
+  }
+
   connectedCallback(): void {
     this.#initialState = this.checked;
     super.connectedCallback();
+    this.setAttribute('role', 'switch');
     if (!this.disabled) {
       this.setValue(this.checked && this.value ? this.value : null);
     }
+
+    this._syncA11yState();
+    this.addEventListener('click', this._handleHostClick);
+    this.addEventListener('keydown', this._handleKeyDown);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener('click', this._handleHostClick);
+    this.removeEventListener('keydown', this._handleKeyDown);
+    super.disconnectedCallback();
   }
 
   willUpdate(changedProperties) {
@@ -115,6 +156,9 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
       if (!this.disabled) {
         this.setValue(this.checked && this.value ? this.value : null);
       }
+    }
+    if (changedProperties.has('checked') || changedProperties.has('disabled')) {
+      this._syncA11yState();
     }
   }
 
@@ -127,10 +171,9 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
       <div>
         <button
           type="button"
-          role="switch"
-          aria-checked=${this.checked}
+          role="none"
+          tabindex="-1"
           class=${this._baseClasses}
-          aria-disabled=${this.disabled}
           ?disabled=${this.disabled}
           @click=${this._handleClick}
         >


### PR DESCRIPTION
Switch labelling and keyboard navigation weren't working. This PR addresses that.