### PR TITLE
fix(select): add bubbles and composed to change CustomEvent for framework compatibility

### DIFF
--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -330,7 +330,7 @@ export class WarpSelect extends FormControlMixin(LitElement) {
     this._setValue(nextValue);
     this.#syncNativeOptionSelection(nextValue);
 
-    this.dispatchEvent(new CustomEvent('change', { detail: nextValue }));
+    this.dispatchEvent(new CustomEvent('change', { detail: nextValue, bubbles: true, composed: true }));
   }
 
   render() {


### PR DESCRIPTION
## Summary

The `<w-select>` component dispatches a `CustomEvent('change', { detail: value })` in its `onChange` method, but `CustomEvent` defaults to `bubbles: false` per the [DOM spec](https://dom.spec.whatwg.org/#dom-event-bubbles).

This breaks React's event delegation model, which listens for events on an ancestor element and relies on event bubbling to catch them. As a result, `onChange` handlers on `<w-select>` in React never fire.

## Changes

- Added `bubbles: true` to the `CustomEvent` constructor options so the event propagates up the DOM tree, enabling React (and other frameworks using event delegation) to detect the change.
- Added `composed: true` as best practice, allowing the event to cross shadow DOM boundaries.

## Why this is not a breaking change

- The `detail` property (carrying the selected value) is preserved — existing consumers reading `event.detail` are unaffected.
- Native `<select>` change events bubble by default, so this aligns `<w-select>` behavior with native semantics.
- Any listeners attached directly on the `<w-select>` element continue to work as before.

## References

- [DOM Living Standard — Event.bubbles](https://dom.spec.whatwg.org/#dom-event-bubbles)
- [React Event Delegation](https://legacy.reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation)
- [MDN — Event.composed](https://developer.mozilla.org/en-US/docs/Web/API/Event/composed)

## Demo

![wselect-bubbles-fix-demo](https://github.com/user-attachments/assets/61265fc5-4894-403e-9ece-b308dd046793)

