### PR TITLE
fix(select): preserve framework-set value in firstUpdated

### DIFF
--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -255,7 +255,13 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 
   firstUpdated() {
     // Reconcile once after initial render for restored/autofilled values.
-    this.#syncFromNativeSelect();
+    // First, ensure the native <select> reflects the current value property
+    // (which may have been set by a framework like React before first render).
+    if (this.value) {
+      this.#syncNativeOptionSelection(this.value);
+    }
+    // Then reconcile for any browser-restored or autofilled values.
+    this.#syncFromNativeSelect({ allowDefaultFirstOption: false });
   }
 
   formStateRestoreCallback(state: string | File | FormData | null, _reason: 'autocomplete' | 'restore') {


### PR DESCRIPTION
WARP's firstUpdated calls #syncFromNativeSelect which reads the native <select> value (browser defaults to 1st option) before the native select has been synced with the host's value property. This overwrites framework-set values (e.g. React's value prop). Fix: sync native select with host value before reconciling.