### PR TITLE
fix(textfield): trim whitespace for type="email" inputs

### DIFF
--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -208,11 +208,12 @@ class WarpTextField extends FormControlMixin(LitElement) {
 
   handler(e: Event) {
     const { name, value } = e.currentTarget as HTMLInputElement;
-    this.value = value;
+    const sanitizedValue = this.type === 'email' ? value.trim() : value;
+    this.value = sanitizedValue;
     const event = new CustomEvent(e.type, {
       detail: {
         name,
-        value,
+        value: sanitizedValue,
         target: e.target,
       },
     });


### PR DESCRIPTION
Per the [HTML spec](https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)), native `<input type="email">` strips leading/trailing whitespace via its [value sanitization algorithm](https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm). Since `w-textfield` re-dispatches events via `CustomEvent` and exposes its own `.value` property, consumers (e.g. `react-hook-form` `Controller`) receive unsanitized values that may contain trailing whitespace from mobile keyboard autocomplete or paste, causing valid emails to fail regex-based validation.

This change adds `.trim()` for `type="email"` inputs in the `handler` method, matching the browser's native behavior.