### PR TITLE
revert(textfield): remove redundant .trim() for email inputs

### DIFF
--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -208,12 +208,11 @@ class WarpTextField extends FormControlMixin(LitElement) {
 
   handler(e: Event) {
     const { name, value } = e.currentTarget as HTMLInputElement;
-    const sanitizedValue = this.type === 'email' ? value.trim() : value;
-    this.value = sanitizedValue;
+    this.value = value;
     const event = new CustomEvent(e.type, {
       detail: {
         name,
-        value: sanitizedValue,
+        value,
         target: e.target,
       },
     });


### PR DESCRIPTION
## Summary

Reverts the `.trim()` added in #569 for `type="email"` inputs.

## Why revert

The original fix was based on the hypothesis that mobile keyboard autocomplete introduces trailing whitespace, causing valid emails to fail regex validation. After investigation ([UUI-1047](https://nmp-jira.atlassian.net/browse/UUI-1047)), we found that:

1. **The `.trim()` is redundant** — per the [HTML spec](https://html.spec.whatwg.org/multipage/input.html#email-state-(type=email)), native `<input type="email">` already strips leading/trailing whitespace via its [value sanitization algorithm](https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm). Since `handler()` reads from `e.currentTarget.value` (the native input), the value is already sanitized.

2. **The real root cause is browser autofill + shadow DOM desync** — when browsers autofill a saved email on page load, they set the value on the native `<input>` inside `w-textfield`'s shadow DOM **without firing `input`/`change` events**. This means `w-textfield.value` stays empty, and consumers (e.g. `react-hook-form` `Controller`) never receive the autofilled value. When the user clicks submit, validation fails on the empty value — not on whitespace.

## Why this started appearing after WARP migration

Previously, consumers used `react-hook-form`'s `register()` which binds directly to the native `<input>` (light DOM, no shadow boundary). After migrating to `w-textfield` + `Controller`, the Controller listens on the `<w-textfield>` host element, not the inner `<input>`, so autofill values are never propagated.

## Proposed upstream fix (future PR)

`w-textfield` should detect browser autofill natively using the CSS `:autofill` animation trick (used by Material UI, Vuetify, and other web component libraries):

```css
@keyframes w-autofill-detect {
  from { }
}
input:-webkit-autofill,
input:autofill {
  animation-name: w-autofill-detect;
}
```

```typescript
// In firstUpdated()
const input = this.renderRoot.querySelector('input');
input?.addEventListener('animationstart', (e: AnimationEvent) => {
  if (e.animationName === 'w-autofill-detect') {
    requestAnimationFrame(() => {
      if (input.value && input.value !== this.value) {
        this.value = input.value;
        this.dispatchEvent(new CustomEvent('input', {
          detail: { name: this.name, value: this.value, target: input },
        }));
      }
    });
  }
});
```

This fires as soon as the browser applies the `:autofill` pseudo-class, allowing `w-textfield` to sync the value without waiting for user interaction.