### PR TITLE
fix: prevent hydration mismatches in React caused by client side DOM changes

### DIFF
--- a/packages/alert/alert.test.ts
+++ b/packages/alert/alert.test.ts
@@ -19,3 +19,31 @@ test('does not render when "show" is not set / or not true', async () => {
   const page = render(component);
   await expect.element(page.container.querySelector('w-alert')).not.toHaveAttribute('show');
 });
+
+test('defaults to info variant when no variant attribute is set', async () => {
+  const component = html`<w-alert show data-testid="alert">Default alert</w-alert>`;
+  const page = render(component);
+
+  const el = page.getByTestId('alert').element() as HTMLElement;
+
+  // The variant attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('variant')).toBe(false);
+
+  // But the info icon should be rendered (default behavior)
+  await expect
+    .poll(() => {
+      const icon = el.shadowRoot?.querySelector('w-icon');
+      return icon?.getAttribute('name');
+    })
+    .toBe('Info');
+});
+
+test('defaults to hidden (show=false) when show attribute is not set', async () => {
+  const component = html`<w-alert data-testid="alert">Hidden alert</w-alert>`;
+  const page = render(component);
+
+  const el = page.getByTestId('alert').element() as HTMLElement;
+
+  // The show attribute should not be present (to avoid hydration mismatch)
+  expect(el.hasAttribute('show')).toBe(false);
+});

--- a/packages/alert/alert.ts
+++ b/packages/alert/alert.ts
@@ -46,10 +46,10 @@ class WarpAlert extends LitElement {
   private _internals: ElementInternals;
 
   @property({ reflect: true })
-  variant: AlertVariants = 'info';
+  variant: AlertVariants;
 
   @property({ type: Boolean, reflect: true })
-  show = true;
+  show: boolean;
 
   @property()
   role = 'alert';
@@ -59,12 +59,14 @@ class WarpAlert extends LitElement {
     this._internals = this.attachInternals();
     // Use ElementInternals for ARIA to avoid hydration mismatches
     this._internals.role = 'alert';
-    this.show = false;
+    // Don't set this.show here - let the attribute or explicit property set control it
+    // Alerts default to hidden and are shown via the show attribute
   }
 
   connectedCallback() {
     super.connectedCallback();
-    if (!this.variant || !alertVariants[this.variant]) {
+    // Validate variant if explicitly set
+    if (this.variant && !alertVariants[this.variant]) {
       throw new Error(
         `Invalid 'variant' attribute. Set its value to one of the following:\nnegative, positive, warning, info.`,
       );
@@ -73,12 +75,14 @@ class WarpAlert extends LitElement {
 
   /** @internal */
   get _wrapperClasses() {
-    return classNames([ccAlert.wrapper, ccAlert[this.variant]]);
+    const variant = this.variant || 'info';
+    return classNames([ccAlert.wrapper, ccAlert[variant]]);
   }
 
   /** @internal */
   get _iconClasses() {
-    const activeIconClassNames = ccAlert[`${this.variant}Icon`];
+    const variant = this.variant || 'info';
+    const activeIconClassNames = ccAlert[`${variant}Icon`];
 
     return classNames([ccAlert.icon, activeIconClassNames]);
   }
@@ -108,16 +112,17 @@ class WarpAlert extends LitElement {
   /** @internal */
   get _icon() {
     const locale = detectLocale();
-    if (this.variant === alertVariants.info) {
+    const variant = this.variant || 'info';
+    if (variant === alertVariants.info) {
       return html`<w-icon name="Info" size="small" locale="${locale}" class="flex"></w-icon>`;
     }
-    if (this.variant === alertVariants.warning) {
+    if (variant === alertVariants.warning) {
       return html`<w-icon name="Warning" size="small" locale="${locale}" class="flex"></w-icon>`;
     }
-    if (this.variant === alertVariants.negative) {
+    if (variant === alertVariants.negative) {
       return html`<w-icon name="Error" size="small" locale="${locale}" class="flex"></w-icon>`;
     }
-    if (this.variant === alertVariants.positive) {
+    if (variant === alertVariants.positive) {
       return html`<w-icon name="Success" size="small" locale="${locale}" class="flex"></w-icon>`;
     }
     return '';

--- a/packages/badge/badge.test.ts
+++ b/packages/badge/badge.test.ts
@@ -10,3 +10,21 @@ test('renders the slotted label', async () => {
   const page = render(component);
   await expect.element(page.getByText('This is also not a button')).toBeVisible();
 });
+
+test('defaults to neutral variant when no variant attribute is set', async () => {
+  const component = html`<w-badge data-testid="badge">Default badge</w-badge>`;
+
+  const page = render(component);
+  const el = page.getByTestId('badge').element() as HTMLElement;
+
+  // The variant attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('variant')).toBe(false);
+
+  // But the neutral styles should still be applied
+  await expect
+    .poll(() => {
+      const inner = el.shadowRoot?.querySelector('div');
+      return inner?.className.includes('bg-[--w-color-badge-neutral-background]');
+    })
+    .toBe(true);
+});

--- a/packages/badge/badge.ts
+++ b/packages/badge/badge.ts
@@ -15,7 +15,7 @@ import { styles } from './styles';
  */
 class WarpBadge extends LitElement {
   @property({ type: String, reflect: true })
-  variant: 'neutral' | 'info' | 'positive' | 'warning' | 'negative' | 'disabled' | 'price' | 'sponsored' = 'neutral';
+  variant: 'neutral' | 'info' | 'positive' | 'warning' | 'negative' | 'disabled' | 'price' | 'sponsored';
 
   @property({ type: String, reflect: true })
   position: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left';
@@ -24,16 +24,17 @@ class WarpBadge extends LitElement {
 
   /** @internal */
   get _class() {
+    const variant = this.variant || 'neutral';
     return classNames([
       'py-4 px-8 border-0 rounded-4 text-xs inline-flex',
-      this.variant === 'neutral' && 'bg-[--w-color-badge-neutral-background] s-text',
-      this.variant === 'info' && 'bg-[--w-color-badge-info-background] s-text',
-      this.variant === 'positive' && 'bg-[--w-color-badge-positive-background] s-text',
-      this.variant === 'warning' && 'bg-[--w-color-badge-warning-background] s-text',
-      this.variant === 'negative' && 'bg-[--w-color-badge-negative-background] s-text',
-      this.variant === 'disabled' && 's-bg-disabled s-text',
-      this.variant === 'price' && 'bg-[--w-black/70] s-text-inverted-static',
-      this.variant === 'sponsored' && 'bg-[--w-color-badge-sponsored-background] s-text',
+      variant === 'neutral' && 'bg-[--w-color-badge-neutral-background] s-text',
+      variant === 'info' && 'bg-[--w-color-badge-info-background] s-text',
+      variant === 'positive' && 'bg-[--w-color-badge-positive-background] s-text',
+      variant === 'warning' && 'bg-[--w-color-badge-warning-background] s-text',
+      variant === 'negative' && 'bg-[--w-color-badge-negative-background] s-text',
+      variant === 'disabled' && 's-bg-disabled s-text',
+      variant === 'price' && 'bg-[--w-black/70] s-text-inverted-static',
+      variant === 'sponsored' && 'bg-[--w-color-badge-sponsored-background] s-text',
       !!this.position && 'absolute backdrop-blur',
       this.position === 'top-left' && 'rounded-tl-0 rounded-tr-0 rounded-bl-0 top-0 left-0',
       this.position === 'top-right' && 'rounded-tl-0 rounded-tr-0 rounded-br-0 top-0 right-0',

--- a/packages/button/button.ts
+++ b/packages/button/button.ts
@@ -154,7 +154,7 @@ class WarpButton extends FormControlMixin(LitElement) {
   };
 
   @property({ reflect: true })
-  type: ButtonType = 'button';
+  type: ButtonType;
 
   @property({ type: Boolean, reflect: true })
   autofocus = false;

--- a/packages/combobox/combobox.test.ts
+++ b/packages/combobox/combobox.test.ts
@@ -6,7 +6,7 @@ import { render } from 'vitest-browser-lit';
 import '../textfield/textfield.js';
 import './combobox.js';
 
-test('renders with autocomplete="off" when attribute not provided', async () => {
+test('renders with autocomplete="off" on inner textfield when attribute not provided', async () => {
   const component = html`<w-combobox data-testid="combobox"></w-combobox>`;
 
   const page = render(component);
@@ -15,7 +15,10 @@ test('renders with autocomplete="off" when attribute not provided', async () => 
   await expect.element(locator).toBeVisible();
 
   const el = (await locator.element()) as HTMLElement;
-  expect(el.getAttribute('autocomplete')).toBe('off');
+  // The autocomplete attribute is not reflected on the outer element to avoid hydration mismatches
+  // Instead, check that the inner textfield receives the correct default value
+  const textfield = el.shadowRoot?.querySelector('w-textfield') as HTMLElement & { autocomplete: string };
+  expect(textfield?.autocomplete).toBe('off');
 });
 
 test('renders with autocomplete attribute when provided', async () => {

--- a/packages/combobox/combobox.ts
+++ b/packages/combobox/combobox.ts
@@ -104,7 +104,7 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
 
   /** Autocomplete attribute for the input field */
   @property({ type: String, reflect: true })
-  autocomplete?: string = 'off';
+  autocomplete?: string;
 
   /** @internal Options list open boolean */
   @state()
@@ -504,7 +504,7 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
           .required=${this.required}
           .optional=${this.optional}
           .name=${this.name}
-          .autocomplete="${this.autocomplete}"
+          .autocomplete="${this.autocomplete || 'off'}"
           role="combobox"
           aria-autocomplete="list"
           aria-expanded=${this._isOpen && this._currentOptions.length !== 0}

--- a/packages/dead-toggle/dead-toggle.test.ts
+++ b/packages/dead-toggle/dead-toggle.test.ts
@@ -11,3 +11,39 @@ test('renders the dead toggle', async () => {
   const page = render(component);
   await expect.element(page.getByTestId('dead-toggle')).toBeVisible();
 });
+
+test('defaults to radio type when no type attribute is set', async () => {
+  const component = html`<w-dead-toggle data-testid="dead-toggle"></w-dead-toggle>`;
+
+  const page = render(component);
+  const el = page.getByTestId('dead-toggle').element() as HTMLElement;
+
+  // The type attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('type')).toBe(false);
+
+  // But the radio styles should still be applied (border-radius: 50%)
+  await expect
+    .poll(() => {
+      const control = el.shadowRoot?.querySelector('.control');
+      return control ? getComputedStyle(control).borderRadius : null;
+    })
+    .toBe('50%');
+});
+
+test('renders as checkbox when type="checkbox" is set', async () => {
+  const component = html`<w-dead-toggle type="checkbox" data-testid="dead-toggle"></w-dead-toggle>`;
+
+  const page = render(component);
+  const el = page.getByTestId('dead-toggle').element() as HTMLElement;
+
+  // The type attribute should be reflected
+  expect(el.getAttribute('type')).toBe('checkbox');
+
+  // And the checkbox styles should be applied (border-radius: 4px)
+  await expect
+    .poll(() => {
+      const control = el.shadowRoot?.querySelector('.control');
+      return control ? getComputedStyle(control).borderRadius : null;
+    })
+    .toBe('4px');
+});

--- a/packages/dead-toggle/dead-toggle.ts
+++ b/packages/dead-toggle/dead-toggle.ts
@@ -12,7 +12,7 @@ import { toggleStyles } from '../toggle-styles';
  */
 export class WarpDeadToggle extends LitElement {
   @property({ type: String, reflect: true })
-  type: 'radio' | 'checkbox' = 'radio';
+  type: 'radio' | 'checkbox';
 
   @property({ type: Boolean, reflect: true })
   checked = false;

--- a/packages/icon/icon.test.ts
+++ b/packages/icon/icon.test.ts
@@ -1,0 +1,69 @@
+import { html } from 'lit';
+
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-lit';
+
+import './icon.js';
+
+test('renders the icon', async () => {
+  const component = html`<w-icon name="Plus" data-testid="icon"></w-icon>`;
+
+  const page = render(component);
+  await expect.element(page.getByTestId('icon')).toBeVisible();
+});
+
+test('defaults to medium size when no size attribute is set', async () => {
+  const component = html`<w-icon name="Plus" data-testid="icon"></w-icon>`;
+
+  const page = render(component);
+  const el = page.getByTestId('icon').element() as HTMLElement;
+
+  // The size attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('size')).toBe(false);
+
+  // But the medium size class should still be applied
+  await expect
+    .poll(() => {
+      const inner = el.shadowRoot?.querySelector('.w-icon');
+      return inner?.classList.contains('w-icon--m');
+    })
+    .toBe(true);
+});
+
+test('defaults to en locale when no locale attribute is set', async () => {
+  const component = html`<w-icon name="Plus" data-testid="icon"></w-icon>`;
+
+  const page = render(component);
+  const el = page.getByTestId('icon').element() as HTMLElement;
+
+  // The locale attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('locale')).toBe(false);
+});
+
+test('uses specified size when size attribute is set', async () => {
+  const component = html`<w-icon name="Plus" size="small" data-testid="icon"></w-icon>`;
+
+  const page = render(component);
+  const el = page.getByTestId('icon').element() as HTMLElement;
+
+  // The size attribute should be reflected
+  expect(el.getAttribute('size')).toBe('small');
+
+  // And the small size class should be applied
+  await expect
+    .poll(() => {
+      const inner = el.shadowRoot?.querySelector('.w-icon');
+      return inner?.classList.contains('w-icon--s');
+    })
+    .toBe(true);
+});
+
+test('uses specified locale when locale attribute is set', async () => {
+  const component = html`<w-icon name="Plus" locale="nb" data-testid="icon"></w-icon>`;
+
+  const page = render(component);
+  const el = page.getByTestId('icon').element() as HTMLElement;
+
+  // The locale attribute should be reflected
+  expect(el.getAttribute('locale')).toBe('nb');
+});

--- a/packages/icon/icon.ts
+++ b/packages/icon/icon.ts
@@ -37,11 +37,11 @@ export class WIcon extends LitElement {
 
   /** Size: small, medium, large or pixel value (e.g. "32px") */
   @property({ type: String, reflect: true })
-  size: 'small' | 'medium' | 'large' | string = 'medium';
+  size: 'small' | 'medium' | 'large' | string;
 
   /** Locale used in CDN URL */
   @property({ type: String, reflect: true })
-  locale = 'en';
+  locale: string;
 
   /** Parsed SVG element (not reflected as attribute) */
   @state()
@@ -53,7 +53,8 @@ export class WIcon extends LitElement {
    * @returns SVGElement or null on failure
    */
   private async fetchIcon(iconName: string): Promise<SVGElement | null> {
-    const uri = `https://assets.finn.no/pkg/eikons/v1/${this.locale}/${iconName}.svg`;
+    const locale = this.locale || 'en';
+    const uri = `https://assets.finn.no/pkg/eikons/v1/${locale}/${iconName}.svg`;
     try {
       const svgText = await cacheFetch<string>(uri);
       const doc = new DOMParser().parseFromString(svgText, 'text/html');
@@ -88,13 +89,14 @@ export class WIcon extends LitElement {
   }
 
   render(): TemplateResult {
+    const size = this.size || 'medium';
     const classes = {
       'w-icon': true,
-      'w-icon--s': this.size === 'small',
-      'w-icon--m': this.size === 'medium',
-      'w-icon--l': this.size === 'large',
+      'w-icon--s': size === 'small',
+      'w-icon--m': size === 'medium',
+      'w-icon--l': size === 'large',
     };
-    const customStyle = typeof this.size === 'string' && this.size.endsWith('px') ? `--w-icon-size: ${this.size};` : '';
+    const customStyle = typeof size === 'string' && size.endsWith('px') ? `--w-icon-size: ${size};` : '';
     return html`<div class="${classMap(classes)}" style="${customStyle}" part="w-${this.name.toLowerCase()}">${this.svg}</div>`;
   }
 }

--- a/packages/link/link.test.ts
+++ b/packages/link/link.test.ts
@@ -8,3 +8,21 @@ test('renders a link with role button ', async () => {
   const screen = await page.render(component);
   await expect.element(screen.getByText('This is a link looking like a button')).toHaveAttribute('href', 'link yo');
 });
+
+test('defaults to secondary variant when no variant attribute is set', async () => {
+  const component = html`<w-link href="/test" data-testid="link">Default link</w-link>`;
+  const screen = await page.render(component);
+
+  const el = screen.getByTestId('link').element() as HTMLElement;
+
+  // The variant attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('variant')).toBe(false);
+
+  // But the secondary styles should still be applied (w-button--secondary class)
+  await expect
+    .poll(() => {
+      const inner = el.shadowRoot?.querySelector('a');
+      return inner?.classList.contains('w-button--secondary');
+    })
+    .toBe(true);
+});

--- a/packages/link/link.ts
+++ b/packages/link/link.ts
@@ -49,7 +49,7 @@ class WarpLink extends LitElement {
   autofocus = false;
 
   @property({ reflect: true })
-  variant: ButtonVariant = 'secondary';
+  variant: ButtonVariant;
 
   @property({ type: Boolean, reflect: true })
   small = false;
@@ -74,7 +74,8 @@ class WarpLink extends LitElement {
   connectedCallback() {
     super.connectedCallback();
 
-    if (!variants.includes(this.variant)) {
+    // Validate variant if explicitly set
+    if (this.variant && !variants.includes(this.variant)) {
       throw new Error(`Invalid "variant" attribute. Set its value to one of the following:\n${variants.join(', ')}.`);
     }
   }
@@ -86,20 +87,21 @@ class WarpLink extends LitElement {
   }
 
   render() {
+    const variant = this.variant || 'secondary';
     const classes = {
       // @ts-expect-error link should be removed so we hide it from types until we can do so
-      'w-button': this.variant !== 'link',
-      'w-button--primary': this.variant === 'primary',
-      'w-button--secondary': this.variant === 'secondary',
-      'w-button--negative': this.variant === 'negative',
-      'w-button--utility': this.variant === 'utility',
-      'w-button--quiet': this.variant === 'quiet',
-      'w-button--negative-quiet': this.variant === 'negativeQuiet',
-      'w-button--utility-quiet': this.variant === 'utilityQuiet',
-      'w-button--overlay': this.variant === 'overlay',
-      'w-button--overlay-inverted': this.variant === 'overlayInverted',
-      'w-button--overlay-quiet': this.variant === 'overlayQuiet',
-      'w-button--overlay-inverted-quiet': this.variant === 'overlayInvertedQuiet',
+      'w-button': variant !== 'link',
+      'w-button--primary': variant === 'primary',
+      'w-button--secondary': variant === 'secondary' || !this.variant,
+      'w-button--negative': variant === 'negative',
+      'w-button--utility': variant === 'utility',
+      'w-button--quiet': variant === 'quiet',
+      'w-button--negative-quiet': variant === 'negativeQuiet',
+      'w-button--utility-quiet': variant === 'utilityQuiet',
+      'w-button--overlay': variant === 'overlay',
+      'w-button--overlay-inverted': variant === 'overlayInverted',
+      'w-button--overlay-quiet': variant === 'overlayQuiet',
+      'w-button--overlay-inverted-quiet': variant === 'overlayInvertedQuiet',
       'w-button--small': this.small,
       'w-button--full-width': this.fullWidth,
       'w-button--disabled': this.disabled,

--- a/packages/page-indicator/page-indicator.test.ts
+++ b/packages/page-indicator/page-indicator.test.ts
@@ -168,3 +168,30 @@ test('updates when selected-page changes', async () => {
   // Cleanup
   document.body.removeChild(container);
 });
+
+test('defaults to page-count=1 and selected-page=1 when no attributes are set', async () => {
+  const component = html`<w-page-indicator></w-page-indicator>`;
+  const page = render(component);
+
+  // Should render a single dot (default page-count=1)
+  await expect
+    .poll(() => {
+      const element = page.container.querySelector('w-page-indicator');
+      return element?.shadowRoot?.querySelectorAll('.w-page-indicator--dot').length;
+    })
+    .toBe(1);
+
+  // The single dot should be selected (default selected-page=1)
+  await expect
+    .poll(() => {
+      const element = page.container.querySelector('w-page-indicator');
+      const dots = element?.shadowRoot?.querySelectorAll('.w-page-indicator--dot');
+      return dots?.[0]?.classList.contains('w-page-indicator--selecteddot');
+    })
+    .toBe(true);
+
+  // Verify no attributes are reflected (to avoid hydration mismatch)
+  const element = page.container.querySelector('w-page-indicator') as HTMLElement;
+  expect(element.hasAttribute('page-count')).toBe(false);
+  expect(element.hasAttribute('selected-page')).toBe(false);
+});

--- a/packages/page-indicator/page-indicator.ts
+++ b/packages/page-indicator/page-indicator.ts
@@ -33,20 +33,20 @@ class WarpPageIndicator extends LitElement {
 
   /** Currently selected page (1-based index) */
   @property({ type: Number, attribute: 'selected-page', reflect: true })
-  selectedPage = 1;
+  selectedPage: number;
 
   /** Total number of pages */
   @property({ type: Number, attribute: 'page-count', reflect: true })
-  pageCount = 1;
+  pageCount: number;
 
   /** Validated page count (minimum 1) */
   private get _validPageCount(): number {
-    return Math.max(1, Math.floor(this.pageCount));
+    return Math.max(1, Math.floor(this.pageCount ?? 1));
   }
 
   /** Validated selected page (clamped to valid range) */
   private get _validSelectedPage(): number {
-    const page = Math.floor(this.selectedPage);
+    const page = Math.floor(this.selectedPage ?? 1);
     return Math.max(1, Math.min(page, this._validPageCount));
   }
 

--- a/packages/pagination/pagination.test.ts
+++ b/packages/pagination/pagination.test.ts
@@ -102,3 +102,29 @@ test('is able to get the correct data-page-number attribute from the element on 
 
   expect(clickedPage).toEqual('14');
 });
+
+test('defaults to current-page=1 when no current-page attribute is set', async () => {
+  const component = html`<w-pagination pages="10" base-url="/page/" data-testid="pagination"></w-pagination>`;
+  const page = render(component);
+
+  const el = page.getByTestId('pagination').element() as HTMLElement;
+
+  // The current-page attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('current-page')).toBe(false);
+
+  // But page 1 should be the active page
+  await expect.element(page.getByLabelText('Page 1')).toHaveAttribute('aria-current', 'page');
+});
+
+test('defaults to visible-pages=7 when no visible-pages attribute is set', async () => {
+  const component = html`<w-pagination current-page="5" pages="20" base-url="/page/" data-testid="pagination"></w-pagination>`;
+  const page = render(component);
+
+  const el = page.getByTestId('pagination').element() as HTMLElement;
+
+  // The visible-pages attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('visible-pages')).toBe(false);
+
+  // But 7 pages should be visible (the default)
+  await expect.poll(() => page.getByRole('link').and(page.getByLabelText('Page ')).all()).toHaveLength(7);
+});

--- a/packages/pagination/pagination.ts
+++ b/packages/pagination/pagination.ts
@@ -40,10 +40,10 @@ class WarpPagination extends LitElement {
   pages: number;
 
   @property({ type: Number, reflect: true, attribute: 'current-page' })
-  currentPageNumber = 1;
+  currentPageNumber: number;
 
   @property({ type: Number, reflect: true, attribute: 'visible-pages' })
-  visiblePages = 7;
+  visiblePages: number;
 
   static styles = [
     reset,
@@ -61,39 +61,49 @@ class WarpPagination extends LitElement {
   }
 
   /** @internal */
+  get _currentPage() {
+    return this.currentPageNumber ?? 1;
+  }
+
+  /** @internal */
+  get _visiblePages() {
+    return this.visiblePages ?? 7;
+  }
+
+  /** @internal */
   get shouldShowShowFirstPageButton() {
-    return this.currentPageNumber - 2 > 0;
+    return this._currentPage - 2 > 0;
   }
 
   /** @internal */
   get shouldShowPreviousPageButton() {
-    return this.currentPageNumber - 1 > 0;
+    return this._currentPage - 1 > 0;
   }
 
   /** @internal */
   get shouldShowNextPageButton() {
-    return this.currentPageNumber < this.pages;
+    return this._currentPage < this.pages;
   }
 
   /** @internal */
   get currentPageIndex() {
-    return this.currentPageNumber - 1;
+    return this._currentPage - 1;
   }
 
   /** @internal */
   get visiblePageNumbers() {
-    if (this.pages <= this.visiblePages) {
+    if (this.pages <= this._visiblePages) {
       // Show all pages if total pages is less than or equal to visible pages
       return Array.from({ length: this.pages }, (_, i) => i + 1);
     }
 
-    const half = Math.floor(this.visiblePages / 2);
-    let start = Math.max(1, this.currentPageNumber - half);
-    const end = Math.min(this.pages, start + this.visiblePages - 1);
+    const half = Math.floor(this._visiblePages / 2);
+    let start = Math.max(1, this._currentPage - half);
+    const end = Math.min(this.pages, start + this._visiblePages - 1);
 
     // Adjust start if we're near the end
-    if (end - start + 1 < this.visiblePages) {
-      start = Math.max(1, end - this.visiblePages + 1);
+    if (end - start + 1 < this._visiblePages) {
+      start = Math.max(1, end - this._visiblePages + 1);
     }
 
     return Array.from({ length: end - start + 1 }, (_, i) => start + i);
@@ -147,8 +157,8 @@ class WarpPagination extends LitElement {
         ${
           this.shouldShowPreviousPageButton
             ? html`<a
-              data-page-number="${this.currentPageNumber - 1}"
-              href="${this.baseUrl}${this.currentPageNumber - 1}"
+              data-page-number="${this._currentPage - 1}"
+              href="${this.baseUrl}${this._currentPage - 1}"
               class="${
                 baseItemStyles +
                 ' s-icon hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]'
@@ -167,7 +177,7 @@ class WarpPagination extends LitElement {
         }
         <div class="hidden md:block">
           ${visiblePages.map((pageNumber) => {
-            const isCurrentPage = pageNumber === this.currentPageNumber;
+            const isCurrentPage = pageNumber === this._currentPage;
             const url = `${this.baseUrl}${pageNumber}`;
 
             let styles = baseItemStyles;
@@ -199,14 +209,14 @@ class WarpPagination extends LitElement {
         <span class="block md:hidden p-8 font-bold">${i18n._({
           id: 'pagination.label.current-page',
           message: 'Page {currentPage}',
-          values: { currentPage: this.currentPageNumber },
+          values: { currentPage: this._currentPage },
           comment: 'Default message for current page label in the pagination component',
         })}</span>
         ${
           this.shouldShowNextPageButton
             ? html`<a
-              data-page-number="${this.currentPageNumber + 1}"
-              href="${this.baseUrl}${this.currentPageNumber + 1}"
+              data-page-number="${this._currentPage + 1}"
+              href="${this.baseUrl}${this._currentPage + 1}"
               class="${
                 baseItemStyles +
                 ' s-icon hover:bg-[--w-color-button-pill-background-hover] active:bg-[--w-color-button-pill-background-active]'

--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -27,10 +27,10 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 
   static styles = [reset, unoStyles, wSliderThumbStyles];
 
-  @property({ attribute: 'aria-label', reflect: true })
+  @property({ attribute: 'aria-label' })
   ariaLabel: string;
 
-  @property({ attribute: 'aria-description', reflect: true })
+  @property({ attribute: 'aria-description' })
   ariaDescription: string;
 
   @property({ reflect: true })
@@ -509,6 +509,9 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
   }
 
   updated(changedProperties: PropertyValues<this>) {
+    // ariaLabel and ariaDescription are used internally on the input element,
+    // not as host attributes. No setAttribute needed - avoids hydration mismatch.
+
     if (changedProperties.has('openEnded')) {
       if (this.openEnded && !this.placeholder) {
         if (this.slot === 'to' || this.slot === '') {

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -541,3 +541,58 @@ test('required slider passes required state to thumb', async () => {
   // Verify the slider has required attribute in HTML
   expect(slider.hasAttribute('required')).toBe(true);
 });
+
+// Hydration mismatch prevention tests
+test('aria-label is not set as host attribute (to avoid hydration mismatch)', async () => {
+  const component = html`
+    <w-slider label="Slider label" min="0" max="100">
+      <w-slider-thumb name="value"></w-slider-thumb>
+    </w-slider>
+  `;
+
+  render(component);
+
+  const slider = document.querySelector('w-slider') as WarpSlider;
+  await slider.updateComplete;
+
+  const thumb = document.querySelector('w-slider-thumb') as WarpSliderThumb;
+  await thumb.updateComplete;
+
+  // aria-label should NOT be a host attribute (to avoid hydration mismatch)
+  expect(thumb.hasAttribute('aria-label')).toBe(false);
+
+  // But the property should be set by the parent
+  expect(thumb.ariaLabel).toBe('Slider label');
+
+  // And the internal input should have the aria-label
+  const rangeInput = thumb.shadowRoot.querySelector('input[type="range"]') as HTMLInputElement;
+  expect(rangeInput.getAttribute('aria-label')).toBe('Slider label');
+});
+
+test('aria-description is not set as host attribute (to avoid hydration mismatch)', async () => {
+  const component = html`
+    <w-slider label="Range" min="0" max="100">
+      <w-slider-thumb slot="from" name="from"></w-slider-thumb>
+      <w-slider-thumb slot="to" name="to"></w-slider-thumb>
+    </w-slider>
+  `;
+
+  render(component);
+
+  const slider = document.querySelector('w-slider') as WarpSlider;
+  await slider.updateComplete;
+
+  const fromThumb = document.querySelector('w-slider-thumb[slot="from"]') as WarpSliderThumb;
+  const toThumb = document.querySelector('w-slider-thumb[slot="to"]') as WarpSliderThumb;
+
+  await fromThumb.updateComplete;
+  await toThumb.updateComplete;
+
+  // aria-description should NOT be a host attribute (to avoid hydration mismatch)
+  expect(fromThumb.hasAttribute('aria-description')).toBe(false);
+  expect(toThumb.hasAttribute('aria-description')).toBe(false);
+
+  // But the properties should be set
+  expect(fromThumb.ariaDescription).toBeTruthy();
+  expect(toThumb.ariaDescription).toBeTruthy();
+});

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -1,6 +1,4 @@
-import { html, LitElement, PropertyValues } from 'lit';
-
-import { property } from 'lit/decorators.js';
+import { css, html, LitElement } from 'lit';
 
 import { reset } from '../styles.js';
 
@@ -13,12 +11,17 @@ import { styles } from '../tabs/styles.js';
  * [See Storybook for usage examples](https://warp-ds.github.io/elements/?path=/docs/tabs--docs)
  */
 export class WarpTabPanel extends LitElement {
-  static styles = [reset, styles];
+  static styles = [
+    reset,
+    styles,
+    css`
+      :host(:not([active])) {
+        display: none;
+      }
+    `,
+  ];
 
   private _internals: ElementInternals;
-
-  @property({ type: Boolean, reflect: true })
-  hidden: boolean;
 
   constructor() {
     super();

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -18,7 +18,7 @@ export class WarpTabPanel extends LitElement {
   private _internals: ElementInternals;
 
   @property({ type: Boolean, reflect: true })
-  hidden = true;
+  hidden: boolean;
 
   constructor() {
     super();

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -44,7 +44,7 @@ export class WarpTab extends LitElement {
   @property({ attribute: 'for', reflect: true })
   for = '';
 
-  @property({ attribute: 'aria-selected', reflect: true })
+  @property({ attribute: 'aria-selected' })
   ariaSelected: 'true' | 'false';
 
   @property({ attribute: 'tabindex', type: Number, reflect: true })
@@ -88,7 +88,12 @@ export class WarpTab extends LitElement {
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
 
-    // Use ElementInternals for ARIA to avoid hydration mismatches
+    // Manually sync aria-selected to DOM attribute for accessibility and CSS selectors,
+    // but only when the property changes (not during initial definition to avoid hydration mismatch)
+    if (changedProperties.has('ariaSelected') && this.ariaSelected !== undefined) {
+      this.setAttribute('aria-selected', this.ariaSelected);
+      this._internals.ariaSelected = this.ariaSelected;
+    }
     // Only let deprecated `active` drive aria-selected when explicitly set by consumers.
     if (changedProperties.has('active') && this.hasAttribute('active')) {
       this._internals.ariaSelected = this.active ? 'true' : 'false';

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -88,10 +88,9 @@ export class WarpTab extends LitElement {
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
 
-    // Manually sync aria-selected to DOM attribute for accessibility and CSS selectors,
-    // but only when the property changes (not during initial definition to avoid hydration mismatch)
-    if (changedProperties.has('ariaSelected') && this.ariaSelected !== undefined) {
-      this.setAttribute('aria-selected', this.ariaSelected);
+    // Use ElementInternals for aria-selected to avoid hydration mismatches
+    // (no DOM attribute needed - AT reads from ElementInternals)
+    if (changedProperties.has('ariaSelected')) {
       this._internals.ariaSelected = this.ariaSelected;
     }
     // Only let deprecated `active` drive aria-selected when explicitly set by consumers.

--- a/packages/tabs/tabs.a11y.test.ts
+++ b/packages/tabs/tabs.a11y.test.ts
@@ -140,7 +140,11 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
       );
       await page.container.querySelector('w-tabs').updateComplete;
 
-      await expect.element(page.container.querySelector('[aria-selected="true"]')).toHaveTextContent("Towers");
+      // Query by property since aria-selected is set via ElementInternals (no DOM attribute)
+      const selectedTab = [...page.container.querySelectorAll('w-tab')].find(
+        (tab: WarpTab) => tab.ariaSelected === 'true'
+      );
+      await expect.element(selectedTab).toHaveTextContent("Towers");
     });
   });
 
@@ -168,7 +172,11 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
       );
       await page.container.querySelector('w-tabs').updateComplete;
 
-      (page.container.querySelector('[aria-selected="true"]') as WarpTab).focus();
+      // Query by property since aria-selected is set via ElementInternals (no DOM attribute)
+      const selectedTab = [...page.container.querySelectorAll('w-tab')].find(
+        (tab: WarpTab) => tab.ariaSelected === 'true'
+      ) as WarpTab;
+      selectedTab.focus();
       await userEvent.keyboard('{ArrowLeft}');
 
       await expect.element(page.getByText('And my axe!')).toBeVisible();
@@ -199,7 +207,10 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
       );
 
       await page.container.querySelector('w-tabs').updateComplete;
-      const inactiveTabs = [...page.container.querySelectorAll('[aria-selected="false"]')] as WarpTab[];
+      // Query by property since aria-selected is set via ElementInternals (no DOM attribute)
+      const inactiveTabs = [...page.container.querySelectorAll('w-tab')].filter(
+        (tab: WarpTab) => tab.ariaSelected === 'false'
+      ) as WarpTab[];
       expect(inactiveTabs).toHaveLength(2);
       for (const tab of inactiveTabs) {
         await expect.element(tab).toHaveAttribute("tabindex", "-1");

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -114,3 +114,23 @@ test('tab-panel hidden attribute is controlled by tabs component', async () => {
   await expect.element(page.getByText('Content 2')).not.toBeVisible();
 });
 
+test('aria-selected is not reflected by default (to avoid hydration mismatch)', async () => {
+  const component = html`<w-tabs>
+    <w-tab for="panel1">Tab 1</w-tab>
+    <w-tab-panel id="panel1"><p>Content 1</p></w-tab-panel>
+
+    <w-tab for="panel2">Tab 2</w-tab>
+    <w-tab-panel id="panel2"><p>Content 2</p></w-tab-panel>
+  </w-tabs>`;
+
+  const page = render(component);
+  const tabsEl = page.container.querySelector('w-tabs');
+  await tabsEl.updateComplete;
+
+  const tabs = page.container.querySelectorAll('w-tab');
+
+  // After tabs component initializes, aria-selected should be set by the parent
+  expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+  expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+});
+

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -89,3 +89,28 @@ test('clicking a tab changes the active attribute, visible tab panel', async () 
   await expect.element(page.getByText('I am on nobody\'s side')).not.toBeVisible();
 });
 
+test('tab-panel hidden attribute is controlled by tabs component', async () => {
+  const component = html`<w-tabs>
+    <w-tab for="panel1">Tab 1</w-tab>
+    <w-tab-panel id="panel1">
+      <p>Content 1</p>
+    </w-tab-panel>
+
+    <w-tab for="panel2">Tab 2</w-tab>
+    <w-tab-panel id="panel2" hidden>
+      <p>Content 2</p>
+    </w-tab-panel>
+  </w-tabs>`;
+
+  const page = render(component);
+
+  // Wait for tabs component to initialize and set hidden attributes
+  await page.container.querySelector('w-tabs').updateComplete;
+
+  // The first panel should be visible (content visible)
+  await expect.element(page.getByText('Content 1')).toBeVisible();
+
+  // The second panel should be hidden (content not visible)
+  await expect.element(page.getByText('Content 2')).not.toBeVisible();
+});
+

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -89,7 +89,7 @@ test('clicking a tab changes the active attribute, visible tab panel', async () 
   await expect.element(page.getByText('I am on nobody\'s side')).not.toBeVisible();
 });
 
-test('tab-panel hidden attribute is controlled by tabs component', async () => {
+test('tab-panel visibility is controlled by active attribute (not hidden) to avoid hydration mismatch', async () => {
   const component = html`<w-tabs>
     <w-tab for="panel1">Tab 1</w-tab>
     <w-tab-panel id="panel1">
@@ -97,20 +97,24 @@ test('tab-panel hidden attribute is controlled by tabs component', async () => {
     </w-tab-panel>
 
     <w-tab for="panel2">Tab 2</w-tab>
-    <w-tab-panel id="panel2" hidden>
+    <w-tab-panel id="panel2">
       <p>Content 2</p>
     </w-tab-panel>
   </w-tabs>`;
 
   const page = render(component);
 
-  // Wait for tabs component to initialize and set hidden attributes
+  // Wait for tabs component to initialize
   await page.container.querySelector('w-tabs').updateComplete;
 
-  // The first panel should be visible (content visible)
-  await expect.element(page.getByText('Content 1')).toBeVisible();
+  const panels = page.container.querySelectorAll('w-tab-panel');
 
-  // The second panel should be hidden (content not visible)
+  // Active panel gets 'active' attribute, not 'hidden' (avoids hydration mismatch)
+  expect(panels[0].hasAttribute('active')).toBe(true);
+  expect(panels[1].hasAttribute('active')).toBe(false);
+
+  // Verify visibility works correctly
+  await expect.element(page.getByText('Content 1')).toBeVisible();
   await expect.element(page.getByText('Content 2')).not.toBeVisible();
 });
 

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -114,7 +114,7 @@ test('tab-panel hidden attribute is controlled by tabs component', async () => {
   await expect.element(page.getByText('Content 2')).not.toBeVisible();
 });
 
-test('aria-selected is not reflected by default (to avoid hydration mismatch)', async () => {
+test('aria-selected uses ElementInternals (no DOM attribute) to avoid hydration mismatch', async () => {
   const component = html`<w-tabs>
     <w-tab for="panel1">Tab 1</w-tab>
     <w-tab-panel id="panel1"><p>Content 1</p></w-tab-panel>
@@ -129,8 +129,12 @@ test('aria-selected is not reflected by default (to avoid hydration mismatch)', 
 
   const tabs = page.container.querySelectorAll('w-tab');
 
-  // After tabs component initializes, aria-selected should be set by the parent
-  expect(tabs[0].getAttribute('aria-selected')).toBe('true');
-  expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+  // aria-selected is set via ElementInternals, not as a DOM attribute (to avoid hydration mismatch)
+  expect(tabs[0].hasAttribute('aria-selected')).toBe(false);
+  expect(tabs[1].hasAttribute('aria-selected')).toBe(false);
+
+  // But the property should be set correctly by the parent
+  expect((tabs[0] as any).ariaSelected).toBe('true');
+  expect((tabs[1] as any).ariaSelected).toBe('false');
 });
 

--- a/packages/tabs/tabs.ts
+++ b/packages/tabs/tabs.ts
@@ -209,18 +209,15 @@ export class WarpTabs extends LitElement {
       }
     });
 
-    // Update tab panels visibility
+    // Update tab panels visibility using 'active' attribute to avoid hydration mismatch
+    // (native 'hidden' always reflects, causing SSR issues)
     const panels: WarpTabPanel[] = Array.from(this.querySelectorAll('w-tab-panel'));
     panels.forEach((panel) => {
       if (!panel.hasAttribute("aria-labelledby")) {
         const controller = tabs.find((tab) => tab.for === panel.id);
         if (controller) panel.setAttribute("aria-labelledby", controller.id);
       }
-      if (panel.id === this._activeTabFor) {
-        panel.hidden = false;
-      } else {
-        panel.hidden = true;
-      }
+      panel.toggleAttribute('active', panel.id === this._activeTabFor);
     });
   }
 

--- a/packages/textfield/textfield.test.ts
+++ b/packages/textfield/textfield.test.ts
@@ -103,3 +103,36 @@ test('renders with no autocomplete attribute when none provided', async () => {
 
   expect(el.shadowRoot.querySelector('input').hasAttribute('autocomplete')).toBe(false);
 });
+
+test('defaults to text type when no type attribute is set', async () => {
+  const component = html`<w-textfield data-testid="textfield" label="Test"></w-textfield>`;
+
+  const page = render(component);
+  const el = page.getByTestId('textfield').element() as HTMLElement;
+
+  // The type attribute should not be reflected on the host (to avoid hydration mismatch)
+  expect(el.hasAttribute('type')).toBe(false);
+
+  // But the inner input should have type="text" as the default
+  await expect
+    .poll(() => {
+      const input = el.shadowRoot?.querySelector('input');
+      return input?.getAttribute('type');
+    })
+    .toBe('text');
+});
+
+test('uses specified type when type attribute is set', async () => {
+  const component = html`<w-textfield data-testid="textfield" label="Email" type="email"></w-textfield>`;
+
+  const page = render(component);
+  const el = page.getByTestId('textfield').element() as HTMLElement;
+
+  // The inner input should have the specified type
+  await expect
+    .poll(() => {
+      const input = el.shadowRoot?.querySelector('input');
+      return input?.getAttribute('type');
+    })
+    .toBe('email');
+});

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -96,7 +96,7 @@ class WarpTextField extends FormControlMixin(LitElement) {
   required = false;
 
   @property({ type: String, reflect: true })
-  type = 'text';
+  type: string;
 
   @property({ type: String, reflect: true })
   value: string;
@@ -246,7 +246,7 @@ class WarpTextField extends FormControlMixin(LitElement) {
           ${this.formatter ? html`<div class="w-textfield__mask"></div>` : nothing}
           <input
             class="${this._inputstyles}"
-            type="${this.type}"
+            type="${this.type || 'text'}"
             min="${ifDefined(this.min)}"
             max="${ifDefined(this.max)}"
             size="${ifDefined(this.size)}"

--- a/packages/toast/toast.test.ts
+++ b/packages/toast/toast.test.ts
@@ -1,0 +1,76 @@
+import { html } from 'lit';
+
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-lit';
+
+import './toast.js';
+
+test('renders the toast with text', async () => {
+  const component = html`<w-toast text="Test message" data-testid="toast"></w-toast>`;
+
+  const page = render(component);
+  await expect.element(page.getByTestId('toast')).toBeVisible();
+  await expect.element(page.getByText('Test message')).toBeVisible();
+});
+
+test('defaults to success type when no type attribute is set', async () => {
+  const component = html`<w-toast text="Success message" data-testid="toast"></w-toast>`;
+
+  const page = render(component);
+  const el = page.getByTestId('toast').element() as HTMLElement;
+
+  // The type attribute should not be reflected (to avoid hydration mismatch)
+  expect(el.hasAttribute('type')).toBe(false);
+
+  // But the success icon should be rendered (default behavior)
+  await expect
+    .poll(() => {
+      const icon = el.shadowRoot?.querySelector('w-icon');
+      return icon?.getAttribute('name');
+    })
+    .toBe('Success');
+});
+
+test('generates unique id when no id attribute is set', async () => {
+  const component = html`<w-toast text="Test message" data-testid="toast"></w-toast>`;
+
+  const page = render(component);
+  const el = page.getByTestId('toast').element() as HTMLElement & { id: string };
+
+  // An id should be generated
+  expect(el.id).toBeTruthy();
+  expect(el.id.length).toBeGreaterThan(0);
+});
+
+test('uses specified type when type attribute is set', async () => {
+  const component = html`<w-toast text="Warning message" type="warning" data-testid="toast"></w-toast>`;
+
+  const page = render(component);
+  const el = page.getByTestId('toast').element() as HTMLElement;
+
+  // The type attribute should be reflected
+  expect(el.getAttribute('type')).toBe('warning');
+
+  // And the warning icon should be rendered
+  await expect
+    .poll(() => {
+      const icon = el.shadowRoot?.querySelector('w-icon');
+      return icon?.getAttribute('name');
+    })
+    .toBe('Warning');
+});
+
+test('renders error type correctly', async () => {
+  const component = html`<w-toast text="Error message" type="error" data-testid="toast"></w-toast>`;
+
+  const page = render(component);
+  const el = page.getByTestId('toast').element() as HTMLElement;
+
+  // The error icon should be rendered
+  await expect
+    .poll(() => {
+      const icon = el.shadowRoot?.querySelector('w-icon');
+      return icon?.getAttribute('name');
+    })
+    .toBe('Error');
+});

--- a/packages/toast/toast.ts
+++ b/packages/toast/toast.ts
@@ -62,10 +62,10 @@ export class WarpToast extends LitElement {
   ];
 
   @property({ type: String, attribute: true, reflect: true })
-  id: string = Date.now().toString(36) + Math.random().toString(36).slice(2, 5);
+  id: string;
 
   @property({ type: String, attribute: true, reflect: true })
-  type: ToastType = 'success';
+  type: ToastType;
 
   @property({ type: String, attribute: true, reflect: true })
   text = '';
@@ -79,6 +79,10 @@ export class WarpToast extends LitElement {
   constructor() {
     super();
     activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+    // Generate unique ID in constructor to avoid hydration mismatch from reflected property default
+    if (!this.id) {
+      this.id = Date.now().toString(36) + Math.random().toString(36).slice(2, 5);
+    }
   }
 
   connectedCallback() {
@@ -94,20 +98,22 @@ export class WarpToast extends LitElement {
   }
 
   get #primaryClasses() {
+    const type = this.type || 'success';
     return classNames([
       ccToast.base,
-      this.type === 'success' && ccToast.positive,
-      this.type === 'warning' && ccToast.warning,
-      this.type === 'error' && ccToast.negative,
+      type === 'success' && ccToast.positive,
+      type === 'warning' && ccToast.warning,
+      type === 'error' && ccToast.negative,
     ]);
   }
 
   get #iconClasses() {
+    const type = this.type || 'success';
     return classNames([
       ccToast.iconBase,
-      this.type === 'success' && ccToast.iconPositive,
-      this.type === 'warning' && ccToast.iconWarning,
-      this.type === 'error' && ccToast.iconNegative,
+      type === 'success' && ccToast.iconPositive,
+      type === 'warning' && ccToast.iconWarning,
+      type === 'error' && ccToast.iconNegative,
     ]);
   }
 
@@ -118,12 +124,12 @@ export class WarpToast extends LitElement {
 
   /** @internal */
   get _warning() {
-    return this.type === 'warning';
+    return (this.type || 'success') === 'warning';
   }
 
   /** @internal */
   get _error() {
-    return this.type === 'error';
+    return (this.type || 'success') === 'error';
   }
 
   /** @internal */

--- a/packages/toggle-styles.ts
+++ b/packages/toggle-styles.ts
@@ -47,6 +47,12 @@ export const toggleStyles = css`
   :host([type='checkbox']) .control {
     border-radius: 4px;
   }
+  /* Default to radio styles when no type attribute is set */
+  :host(:not([type])) .control,
+  :host([type='radio']) .control,
+  :host([role='radio']) .control {
+    border-radius: 50%;
+  }
   .checkbox:has(:checked, :indeterminate),
   :host([type='checkbox'][checked]) .control,
   :host([type='checkbox'][indeterminate]) .control {
@@ -58,10 +64,7 @@ export const toggleStyles = css`
     background-image: var(--w-icon-toggle-checked);
     background-position: center;
   }
-  :host([type='radio']) .control,
-  :host([role='radio']) .control {
-    border-radius: 50%;
-  }
+  :host(:not([type])[checked]) .control,
   :host([type='radio'][checked]) .control,
   /* :state is newly available, so we set an attribute in radio for compat */
   :host([role='radio'][checked-ui]) .control,
@@ -91,6 +94,7 @@ export const toggleStyles = css`
     outline-offset: var(--w-outline-offset, 1px);
   }
 
+  :host(:not([type])[disabled]) .control,
   :host([type='radio'][disabled]) .control,
   /* :state is newly available, so we set an attribute in radio for compat */
   :host([role='radio'][disabled-ui]) .control,


### PR DESCRIPTION
See #566 

This PR continues the work done in #567 

In this PR, reflected default values are removed and calculated as needed instead. This means that if an optional attribute is NOT provided, the default is applied without reflecting the attribute back into the DOM (which is what causes mismatch issues). None of this should be breaking since if a user was setting a value for a given attribute, nothing changes and if they weren't, appearance/behaviour should be the same but the attribute won't be present in the DOM. (though technically it could be possible that someone targetted said attribute with CSS or JS code which could cause an issue)

Second, in this PR, in a couple cases, Ive also changed the parent/child relationship where one exists AND the parent manipulates the child such that its not manipulating attributes (and therefore changing the DOM) and instead manipulates properties.

For example:
Before this change the hidden attribute would be set by w-tab on w-tab-panel. After the change, it is set as a property instead and so does not change the DOM.
```html
<w-tab> 
  <w-tab-panel hidden></w-tab-panel>
<w-tab>
```

Again, changes like this should continue to work as before but theres a small chance that someone could have used styling to target attributes that are only available as properties.

I think we should risk this change as a non breaking change even though technically there are edge cases that are breaking.

Ive done some digging with code search and found the following:
- w-tabs: not yet in use
- w-tab-panel: not yet in use
- w-alert: affects no one
- w-badge: affects no one
- w-button: affects no one
- w-combobox: not yet in use
- w-dead-toggle: not yet released
- w-icon: affects no one
- w-link: affects no one
- w-page-indicator: not yet in use
- w-pagination: not yet in use
- w-slider: affects no one
- w-slider-thumb: affects no one
- w-textfield: affects no one
- w-toast: affects no one

So in my mind we are good to cheat a little and publish these small breaking changes as non breaking