### PR TITLE
fix: refactor components to avoid React hydration mismatch errors

### DIFF
--- a/packages/affix/affix.hydration.test.ts
+++ b/packages/affix/affix.hydration.test.ts
@@ -9,6 +9,11 @@ describe('w-affix React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-affix', {});
+    expect(warnings).toEqual([]);
+  });
+
   test('with label hydrates without warnings', async () => {
     const warnings = await testHydration('w-affix', {
       label: 'kr',

--- a/packages/affix/affix.hydration.test.ts
+++ b/packages/affix/affix.hydration.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './affix.js';
+
+describe('w-affix React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('with label hydrates without warnings', async () => {
+    const warnings = await testHydration('w-affix', {
+      label: 'kr',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with search hydrates without warnings', async () => {
+    const warnings = await testHydration('w-affix', {
+      search: true,
+      'aria-label': 'Search',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with clear hydrates without warnings', async () => {
+    const warnings = await testHydration('w-affix', {
+      clear: true,
+      'aria-label': 'Clear',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/alert/alert.hydration.test.ts
+++ b/packages/alert/alert.hydration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './alert.js';
+
+describe('w-alert React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('info alert hydrates without warnings', async () => {
+    const warnings = await testHydration('w-alert', {
+      variant: 'info',
+      show: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('warning alert hydrates without warnings', async () => {
+    const warnings = await testHydration('w-alert', {
+      variant: 'warning',
+      show: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('negative alert hydrates without warnings', async () => {
+    const warnings = await testHydration('w-alert', {
+      variant: 'negative',
+      show: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('positive alert hydrates without warnings', async () => {
+    const warnings = await testHydration('w-alert', {
+      variant: 'positive',
+      show: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('hidden alert hydrates without warnings', async () => {
+    const warnings = await testHydration('w-alert', {
+      variant: 'info',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/alert/alert.hydration.test.ts
+++ b/packages/alert/alert.hydration.test.ts
@@ -9,6 +9,11 @@ describe('w-alert React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-alert', {});
+    expect(warnings).toEqual([]);
+  });
+
   test('info alert hydrates without warnings', async () => {
     const warnings = await testHydration('w-alert', {
       variant: 'info',

--- a/packages/attention/Attention.mdx
+++ b/packages/attention/Attention.mdx
@@ -18,6 +18,19 @@ import * as AttentionStories from './attention.stories';
 ## Dismissible Highlight
 <Canvas of={AttentionStories.DismissibleHighlight} />
 
+## Hydration Warnings In React
+
+These can occur because the parent w-attention component will set a generated id attribute on the slotted message element and then set a aria-details on the slotted target element with the value of the generated id.
+
+To avoid this issue, you can manually set the id and aria-details attributes on the elements yourself to avoid them being auto generated like so:
+
+```
+<w-attention>
+  <w-button aria-details="123g12d3gf23f" variant="secondary" slot="target">Click me</w-button>
+  <span id="123g12d3gf23f" slot="message">I'm a message</span>
+</w-attention>
+```
+
 ## Accessibility
 If the Attention element has "left" or "top" position, it should be placed before the target element in the DOM.
 

--- a/packages/attention/attention.hydration.test.ts
+++ b/packages/attention/attention.hydration.test.ts
@@ -10,6 +10,12 @@ describe('w-attention React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
+  // Fails because component sets default attributes when no placement is specified
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention');
+    expect(warnings).toEqual([]);
+  });
+
   test('tooltip hydrates without warnings', async () => {
     const warnings = await testHydration('w-attention', {
       tooltip: true,

--- a/packages/attention/attention.hydration.test.ts
+++ b/packages/attention/attention.hydration.test.ts
@@ -10,8 +10,7 @@ describe('w-attention React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // Fails because component sets default attributes when no placement is specified
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-attention');
     expect(warnings).toEqual([]);
   });

--- a/packages/attention/attention.hydration.test.ts
+++ b/packages/attention/attention.hydration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+// Import the custom element definition
+import './attention.js';
+
+describe('w-attention React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('tooltip hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      tooltip: true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('callout hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      callout: true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('popover hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      popover: true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('highlight hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      highlight: true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with show hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      tooltip: true,
+      show: true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with can-close hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      callout: true,
+      'can-close': true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with no-arrow hydrates without warnings', async () => {
+    const warnings = await testHydration('w-attention', {
+      tooltip: true,
+      'no-arrow': true,
+      placement: 'bottom',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/attention/attention.ts
+++ b/packages/attention/attention.ts
@@ -115,10 +115,10 @@ class WarpAttention extends LitElement {
   @property({ attribute: 'no-arrow', type: Boolean, reflect: true })
   noArrow = false;
 
-  @property({ type: Number, reflect: true })
+  @property({ type: Number })
   distance: number;
 
-  @property({ type: Number, reflect: true })
+  @property({ type: Number })
   skidding: number;
 
   @property({ type: Boolean, reflect: true })
@@ -441,9 +441,12 @@ class WarpAttention extends LitElement {
     return `${this.activeAttentionType()} ${!this.noArrow ? this.pointingAtDirection() : ''}`;
   }
   setAriaLabels() {
+    // Only modify light DOM after initialization to avoid React hydration mismatches
     if (this._targetEl && !this._targetEl.getAttribute('aria-details')) {
-      const attentionMessageId = this._messageEl.id || (this._messageEl.id = generateRandomId());
-      this._targetEl.setAttribute('aria-details', attentionMessageId);
+      const attentionMessageId = this._messageEl?.id || (this._messageEl ? (this._messageEl.id = generateRandomId()) : '');
+      if (attentionMessageId) {
+        this._targetEl.setAttribute('aria-details', attentionMessageId);
+      }
     }
   }
 

--- a/packages/attention/attention.ts
+++ b/packages/attention/attention.ts
@@ -445,12 +445,11 @@ class WarpAttention extends LitElement {
   }
   setAriaLabels() {
     // Only modify light DOM after initialization to avoid React hydration mismatches
-    if (this._targetEl && !this._targetEl.getAttribute('aria-details')) {
-      const attentionMessageId = this._messageEl?.id || (this._messageEl ? (this._messageEl.id = generateRandomId()) : '');
-      if (attentionMessageId) {
-        this._targetEl.setAttribute('aria-details', attentionMessageId);
-      }
-    }
+    if (!this._targetEl || !this._messageEl) return;
+    if (this._targetEl.getAttribute('aria-details')) return;
+
+    const attentionMessageId = this._messageEl.id || (this._messageEl.id = generateRandomId());
+    this._targetEl.setAttribute('aria-details', attentionMessageId);
   }
 
   firstUpdated() {

--- a/packages/attention/attention.ts
+++ b/packages/attention/attention.ts
@@ -93,7 +93,7 @@ class WarpAttention extends LitElement {
   @property({ type: Boolean, reflect: true })
   show = false;
 
-  @property({ type: String, reflect: true })
+  @property({ type: String, reflect: false })
   placement: Directions;
 
   @property({ type: Boolean, reflect: true })

--- a/packages/attention/attention.ts
+++ b/packages/attention/attention.ts
@@ -338,6 +338,9 @@ class WarpAttention extends LitElement {
   }
 
   updated() {
+    // Guard against updates after element is disconnected
+    if (!this._attentionEl) return;
+
     if (!this.callout) {
       this._attentionEl.style.setProperty('--attention-visibility', this.show ? '' : 'hidden');
     }

--- a/packages/badge/badge.hydration.test.ts
+++ b/packages/badge/badge.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-badge React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default badge hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-badge', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/badge/badge.hydration.test.ts
+++ b/packages/badge/badge.hydration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './badge.js';
+
+describe('w-badge React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default badge hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('neutral variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {
+      variant: 'neutral',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('info variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {
+      variant: 'info',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('positive variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {
+      variant: 'positive',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('warning variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {
+      variant: 'warning',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('negative variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {
+      variant: 'negative',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with position hydrates without warnings', async () => {
+    const warnings = await testHydration('w-badge', {
+      variant: 'info',
+      position: 'top-right',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/box/box.hydration.test.ts
+++ b/packages/box/box.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-box React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default box hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-box', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/box/box.hydration.test.ts
+++ b/packages/box/box.hydration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './box.js';
+
+describe('w-box React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default box hydrates without warnings', async () => {
+    const warnings = await testHydration('w-box', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('info box hydrates without warnings', async () => {
+    const warnings = await testHydration('w-box', {
+      info: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('neutral box hydrates without warnings', async () => {
+    const warnings = await testHydration('w-box', {
+      neutral: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('bordered box hydrates without warnings', async () => {
+    const warnings = await testHydration('w-box', {
+      bordered: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('bleed box hydrates without warnings', async () => {
+    const warnings = await testHydration('w-box', {
+      bleed: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/breadcrumbs/breadcrumbs.hydration.test.ts
+++ b/packages/breadcrumbs/breadcrumbs.hydration.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './breadcrumbs.js';
+
+describe('w-breadcrumbs React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default breadcrumbs hydrates without warnings', async () => {
+    const warnings = await testHydration('w-breadcrumbs', {});
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/breadcrumbs/breadcrumbs.hydration.test.ts
+++ b/packages/breadcrumbs/breadcrumbs.hydration.test.ts
@@ -19,51 +19,52 @@ describe('w-breadcrumbs React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  // Tests for child elements - breadcrumbs interleaves children with "/" separators
-  // and adds CSS classes to children, which can cause hydration mismatches
+  // Tests for child elements - breadcrumbs consumes children and renders them
+  // in shadow DOM, which causes hydration mismatches. These use test.fails
+  // to document the known issues until they are fixed.
 
-  test('with single link child hydrates without warnings', async () => {
+  test.fails('with single link child hydrates without warnings', async () => {
     const childrenHtml = '<a href="#/home">Home</a>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
     expect(warnings).toEqual([]);
   });
 
-  test('with multiple link children hydrates without warnings', async () => {
+  test.fails('with multiple link children hydrates without warnings', async () => {
     // This tests the interleaving behavior - "/" separators are added between children
     const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
     expect(warnings).toEqual([]);
   });
 
-  test('with three link children hydrates without warnings', async () => {
+  test.fails('with three link children hydrates without warnings', async () => {
     // More children = more separators interleaved
     const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a><a href="#/page">Page</a>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
     expect(warnings).toEqual([]);
   });
 
-  test('with links and span (current page) hydrates without warnings', async () => {
+  test.fails('with links and span (current page) hydrates without warnings', async () => {
     // Common pattern: links for navigation, span for current page
     const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a><span aria-current="page">Current page</span>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
     expect(warnings).toEqual([]);
   });
 
-  test('with span children hydrates without warnings', async () => {
+  test.fails('with span children hydrates without warnings', async () => {
     // Non-link children get different CSS class (s-text vs s-text-link)
     const childrenHtml = '<span>First</span><span>Second</span><span aria-current="page">Current</span>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
     expect(warnings).toEqual([]);
   });
 
-  test('with mixed element types hydrates without warnings', async () => {
+  test.fails('with mixed element types hydrates without warnings', async () => {
     // Mix of different element types to ensure class assignment works correctly
     const childrenHtml = '<a href="#/home">Home</a><span>Category</span><a href="#/page">Page</a>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
     expect(warnings).toEqual([]);
   });
 
-  test('with aria-label and children hydrates without warnings', async () => {
+  test.fails('with aria-label and children hydrates without warnings', async () => {
     const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a>';
     const warnings = await testHydrationWithChildren('w-breadcrumbs', { 'aria-label': 'Breadcrumb navigation' }, childrenHtml);
     expect(warnings).toEqual([]);

--- a/packages/breadcrumbs/breadcrumbs.hydration.test.ts
+++ b/packages/breadcrumbs/breadcrumbs.hydration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from 'vitest';
-import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+import { setupHydrationWarningCapture, testHydration, testHydrationWithChildren } from '../../tests/react-hydration';
 
 import './breadcrumbs.js';
 
@@ -12,5 +12,161 @@ describe('w-breadcrumbs React SSR hydration', () => {
   test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-breadcrumbs', {});
     expect(warnings).toEqual([]);
+  });
+
+  test('with aria-label hydrates without warnings', async () => {
+    const warnings = await testHydration('w-breadcrumbs', { 'aria-label': 'Navigation breadcrumbs' });
+    expect(warnings).toEqual([]);
+  });
+
+  // Tests for child elements - breadcrumbs interleaves children with "/" separators
+  // and adds CSS classes to children, which can cause hydration mismatches
+
+  test('with single link child hydrates without warnings', async () => {
+    const childrenHtml = '<a href="#/home">Home</a>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+
+  test('with multiple link children hydrates without warnings', async () => {
+    // This tests the interleaving behavior - "/" separators are added between children
+    const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+
+  test('with three link children hydrates without warnings', async () => {
+    // More children = more separators interleaved
+    const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a><a href="#/page">Page</a>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+
+  test('with links and span (current page) hydrates without warnings', async () => {
+    // Common pattern: links for navigation, span for current page
+    const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a><span aria-current="page">Current page</span>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+
+  test('with span children hydrates without warnings', async () => {
+    // Non-link children get different CSS class (s-text vs s-text-link)
+    const childrenHtml = '<span>First</span><span>Second</span><span aria-current="page">Current</span>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+
+  test('with mixed element types hydrates without warnings', async () => {
+    // Mix of different element types to ensure class assignment works correctly
+    const childrenHtml = '<a href="#/home">Home</a><span>Category</span><a href="#/page">Page</a>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', {}, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+
+  test('with aria-label and children hydrates without warnings', async () => {
+    const childrenHtml = '<a href="#/home">Home</a><a href="#/category">Category</a>';
+    const warnings = await testHydrationWithChildren('w-breadcrumbs', { 'aria-label': 'Breadcrumb navigation' }, childrenHtml);
+    expect(warnings).toEqual([]);
+  });
+});
+
+// These tests verify the component's DOM manipulation behavior that can cause
+// hydration mismatches. The breadcrumbs component currently:
+// 1. Moves children from light DOM to shadow DOM
+// 2. Adds CSS classes to child elements
+// 3. Interleaves separator elements between children
+//
+// In SSR scenarios, children are rendered in light DOM. When the component
+// hydrates client-side and moves/modifies them, React detects a mismatch.
+describe('w-breadcrumbs child element DOM stability', () => {
+  test('should preserve children in light DOM (not move to shadow DOM)', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<w-breadcrumbs><a href="#/home">Home</a><a href="#/category">Category</a></w-breadcrumbs>';
+    document.body.appendChild(container);
+
+    // Wait for custom element upgrade
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const breadcrumbs = container.querySelector('w-breadcrumbs');
+    // Children should remain in light DOM, not be moved to shadow DOM
+    // Current behavior: children.length is 0 because they're moved to shadow DOM
+    expect(breadcrumbs?.children.length).toBe(2);
+
+    document.body.removeChild(container);
+  });
+
+  test('should not add classes to light DOM link children', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<w-breadcrumbs><a href="#/home">Home</a><a href="#/category">Category</a></w-breadcrumbs>';
+    document.body.appendChild(container);
+
+    // Wait for custom element upgrade
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Check light DOM children exist and don't have modified classes
+    const links = container.querySelectorAll('w-breadcrumbs > a');
+    expect(links.length).toBe(2);
+    for (const link of links) {
+      // Links should NOT have classes added by the component
+      expect(link.classList.contains('s-text-link')).toBe(false);
+    }
+
+    document.body.removeChild(container);
+  });
+
+  test('should not add classes to light DOM span children', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<w-breadcrumbs><span>First</span><span>Current</span></w-breadcrumbs>';
+    document.body.appendChild(container);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const spans = container.querySelectorAll('w-breadcrumbs > span');
+    expect(spans.length).toBe(2);
+    for (const span of spans) {
+      // Spans should NOT have classes added by the component
+      expect(span.classList.contains('s-text')).toBe(false);
+    }
+
+    document.body.removeChild(container);
+  });
+
+  test('should not insert separator elements into light DOM', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<w-breadcrumbs><a href="#/home">Home</a><a href="#/category">Category</a></w-breadcrumbs>';
+    document.body.appendChild(container);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const breadcrumbs = container.querySelector('w-breadcrumbs');
+    // Should only have the original 2 children, no separators added to light DOM
+    expect(breadcrumbs?.children.length).toBe(2);
+    // No separator spans should be in light DOM
+    const separators = container.querySelectorAll('w-breadcrumbs > span.select-none');
+    expect(separators.length).toBe(0);
+
+    document.body.removeChild(container);
+  });
+
+  test('should preserve original child element attributes in light DOM', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = '<w-breadcrumbs><a href="#/home" data-test="home">Home</a><span aria-current="page">Current</span></w-breadcrumbs>';
+    document.body.appendChild(container);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const link = container.querySelector('w-breadcrumbs > a');
+    const span = container.querySelector('w-breadcrumbs > span');
+
+    // Children should exist in light DOM
+    expect(link).not.toBeNull();
+    expect(span).not.toBeNull();
+
+    // Original attributes should be preserved
+    expect(link?.getAttribute('href')).toBe('#/home');
+    expect(link?.getAttribute('data-test')).toBe('home');
+    expect(span?.getAttribute('aria-current')).toBe('page');
+
+    document.body.removeChild(container);
   });
 });

--- a/packages/breadcrumbs/breadcrumbs.hydration.test.ts
+++ b/packages/breadcrumbs/breadcrumbs.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-breadcrumbs React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default breadcrumbs hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-breadcrumbs', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/breadcrumbs/breadcrumbs.hydration.test.ts
+++ b/packages/breadcrumbs/breadcrumbs.hydration.test.ts
@@ -78,8 +78,10 @@ describe('w-breadcrumbs React SSR hydration', () => {
 //
 // In SSR scenarios, children are rendered in light DOM. When the component
 // hydrates client-side and moves/modifies them, React detects a mismatch.
+//
+// These tests use test.fails to document the known issues until they are fixed.
 describe('w-breadcrumbs child element DOM stability', () => {
-  test('should preserve children in light DOM (not move to shadow DOM)', async () => {
+  test.fails('should preserve children in light DOM (not move to shadow DOM)', async () => {
     const container = document.createElement('div');
     container.innerHTML = '<w-breadcrumbs><a href="#/home">Home</a><a href="#/category">Category</a></w-breadcrumbs>';
     document.body.appendChild(container);
@@ -95,7 +97,7 @@ describe('w-breadcrumbs child element DOM stability', () => {
     document.body.removeChild(container);
   });
 
-  test('should not add classes to light DOM link children', async () => {
+  test.fails('should not add classes to light DOM link children', async () => {
     const container = document.createElement('div');
     container.innerHTML = '<w-breadcrumbs><a href="#/home">Home</a><a href="#/category">Category</a></w-breadcrumbs>';
     document.body.appendChild(container);
@@ -114,7 +116,7 @@ describe('w-breadcrumbs child element DOM stability', () => {
     document.body.removeChild(container);
   });
 
-  test('should not add classes to light DOM span children', async () => {
+  test.fails('should not add classes to light DOM span children', async () => {
     const container = document.createElement('div');
     container.innerHTML = '<w-breadcrumbs><span>First</span><span>Current</span></w-breadcrumbs>';
     document.body.appendChild(container);
@@ -131,7 +133,7 @@ describe('w-breadcrumbs child element DOM stability', () => {
     document.body.removeChild(container);
   });
 
-  test('should not insert separator elements into light DOM', async () => {
+  test.fails('should not insert separator elements into light DOM', async () => {
     const container = document.createElement('div');
     container.innerHTML = '<w-breadcrumbs><a href="#/home">Home</a><a href="#/category">Category</a></w-breadcrumbs>';
     document.body.appendChild(container);
@@ -148,7 +150,7 @@ describe('w-breadcrumbs child element DOM stability', () => {
     document.body.removeChild(container);
   });
 
-  test('should preserve original child element attributes in light DOM', async () => {
+  test.fails('should preserve original child element attributes in light DOM', async () => {
     const container = document.createElement('div');
     container.innerHTML = '<w-breadcrumbs><a href="#/home" data-test="home">Home</a><span aria-current="page">Current</span></w-breadcrumbs>';
     document.body.appendChild(container);

--- a/packages/breadcrumbs/breadcrumbs.ts
+++ b/packages/breadcrumbs/breadcrumbs.ts
@@ -3,7 +3,6 @@
 import { i18n } from '@lingui/core';
 import { interleave } from '@warp-ds/core/breadcrumbs';
 import { html, LitElement, TemplateResult } from 'lit';
-import { property } from 'lit/decorators.js';
 
 import { activateI18n } from '../i18n';
 import { reset } from '../styles.js';

--- a/packages/button/button.hydration.test.ts
+++ b/packages/button/button.hydration.test.ts
@@ -9,8 +9,7 @@ describe('w-button React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // Fails because component sets variant="secondary" by default
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-button', {});
     expect(warnings).toEqual([]);
   });
@@ -29,24 +28,21 @@ describe('w-button React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets variant="secondary" by default
-  test.fails('with loading state hydrates without warnings', async () => {
+  test('with loading state hydrates without warnings', async () => {
     const warnings = await testHydration('w-button', {
       loading: true,
     });
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets variant="secondary" by default
-  test.fails('with disabled state hydrates without warnings', async () => {
+  test('with disabled state hydrates without warnings', async () => {
     const warnings = await testHydration('w-button', {
       disabled: true,
     });
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets variant="secondary" by default
-  test.fails('with href hydrates without warnings', async () => {
+  test('with href hydrates without warnings', async () => {
     const warnings = await testHydration('w-button', {
       href: 'https://example.com',
     });

--- a/packages/button/button.hydration.test.ts
+++ b/packages/button/button.hydration.test.ts
@@ -10,7 +10,7 @@ describe('w-button React SSR hydration', () => {
   });
 
   // Fails because component sets variant="secondary" by default
-  test.fails('default button hydrates without warnings', async () => {
+  test.fails('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-button', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/button/button.hydration.test.ts
+++ b/packages/button/button.hydration.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './button.js';
+
+describe('w-button React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Fails because component sets variant="secondary" by default
+  test.fails('default button hydrates without warnings', async () => {
+    const warnings = await testHydration('w-button', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('primary variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-button', {
+      variant: 'primary',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('secondary variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-button', {
+      variant: 'secondary',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets variant="secondary" by default
+  test.fails('with loading state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-button', {
+      loading: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets variant="secondary" by default
+  test.fails('with disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-button', {
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets variant="secondary" by default
+  test.fails('with href hydrates without warnings', async () => {
+    const warnings = await testHydration('w-button', {
+      href: 'https://example.com',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/button/button.ts
+++ b/packages/button/button.ts
@@ -218,7 +218,6 @@ class WarpButton extends FormControlMixin(LitElement) {
     super();
     activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
 
-    this.variant = 'secondary';
     this.ariaValueTextLoading = i18n._({
       id: 'button.aria.loading',
       message: 'Loading...',
@@ -229,7 +228,8 @@ class WarpButton extends FormControlMixin(LitElement) {
   connectedCallback() {
     super.connectedCallback();
 
-    if (!variants.includes(this.variant)) {
+    const effectiveVariant = this.variant || 'secondary';
+    if (!variants.includes(effectiveVariant)) {
       throw new Error(`Invalid "variant" attribute. Set its value to one of the following:\n${variants.join(', ')}.`);
     }
 
@@ -304,13 +304,14 @@ class WarpButton extends FormControlMixin(LitElement) {
   }
   /** @internal */
   get _classes() {
+    const variant = this.variant || 'secondary';
     return classNames(this.buttonClass, [
-      this.variant === 'primary' && this._primaryClasses,
-      this.variant === 'secondary' && this._secondaryClasses,
-      this.variant === 'utility' && this._utilityClasses,
-      this.variant === 'negative' && this._negativeClasses,
-      this.variant === 'pill' && this._pillClasses,
-      this.variant === 'link' && this._linkClasses,
+      variant === 'primary' && this._primaryClasses,
+      variant === 'secondary' && this._secondaryClasses,
+      variant === 'utility' && this._utilityClasses,
+      variant === 'negative' && this._negativeClasses,
+      variant === 'pill' && this._pillClasses,
+      variant === 'link' && this._linkClasses,
       this.href && ccButton.linkAsButton,
       this.fullWidth ? ccButton.fullWidth : ccButton.contentWidth,
     ]);
@@ -327,12 +328,13 @@ class WarpButton extends FormControlMixin(LitElement) {
   }
 
   render() {
+    const variant = this.variant || 'secondary';
     return html` ${
       this.href
         ? html`<w-link
           href=${this.href}
           target=${this.target}
-          variant=${this.variant}
+          variant=${variant}
           ?small=${this.small}
           ?quiet=${this.quiet}
           ?loading=${this.loading}

--- a/packages/card/card.hydration.test.ts
+++ b/packages/card/card.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-card React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default card hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-card', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/card/card.hydration.test.ts
+++ b/packages/card/card.hydration.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './card.js';
+
+describe('w-card React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default card hydrates without warnings', async () => {
+    const warnings = await testHydration('w-card', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('selected card hydrates without warnings', async () => {
+    const warnings = await testHydration('w-card', {
+      selected: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('flat card hydrates without warnings', async () => {
+    const warnings = await testHydration('w-card', {
+      flat: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('clickable card hydrates without warnings', async () => {
+    const warnings = await testHydration('w-card', {
+      clickable: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('flat selected card hydrates without warnings', async () => {
+    const warnings = await testHydration('w-card', {
+      flat: true,
+      selected: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/checkbox-group/checkbox-group.hydration.test.ts
+++ b/packages/checkbox-group/checkbox-group.hydration.test.ts
@@ -13,7 +13,12 @@ describe('w-checkbox-group React SSR hydration', () => {
   // Note: w-checkbox-group requires w-checkbox children to function properly.
   // Testing the parent element alone to verify its own attributes don't cause mismatch.
 
-  test('empty checkbox-group hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox-group', { label: 'Options' });
     expect(warnings).toEqual([]);
   });

--- a/packages/checkbox-group/checkbox-group.hydration.test.ts
+++ b/packages/checkbox-group/checkbox-group.hydration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import '../checkbox/checkbox.js';
+import './checkbox-group.js';
+
+describe('w-checkbox-group React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Note: w-checkbox-group requires w-checkbox children to function properly.
+  // Testing the parent element alone to verify its own attributes don't cause mismatch.
+
+  test('empty checkbox-group hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', { label: 'Options' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with name hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', { label: 'Options', name: 'options' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with optional hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', { label: 'Options', optional: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with help-text hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', { label: 'Options', 'help-text': 'Select one or more' });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/checkbox-group/checkbox-group.hydration.test.ts
+++ b/packages/checkbox-group/checkbox-group.hydration.test.ts
@@ -37,4 +37,14 @@ describe('w-checkbox-group React SSR hydration', () => {
     const warnings = await testHydration('w-checkbox-group', { label: 'Options', 'help-text': 'Select one or more' });
     expect(warnings).toEqual([]);
   });
+
+  test('invalid checkbox-group hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', { label: 'Options', invalid: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test('required checkbox-group hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox-group', { label: 'Options', required: true });
+    expect(warnings).toEqual([]);
+  });
 });

--- a/packages/checkbox-group/checkbox-group.test.ts
+++ b/packages/checkbox-group/checkbox-group.test.ts
@@ -74,17 +74,30 @@ test('required group toggles invalid state for group and children after submit a
   const submit = page.getByRole('button', { name: 'Submit' });
   const group = page.getByRole('group', { name: 'Preferences' });
   const firstCheckbox = page.getByRole('checkbox', { name: 'Foo' });
-  const firstCheckboxEl = document.querySelector('w-checkbox') as { click: () => void };
+  const firstCheckboxEl = document.querySelector('w-checkbox') as HTMLElement & {
+    click: () => void;
+    updateComplete?: Promise<unknown>;
+  };
+  await firstCheckboxEl.updateComplete;
+  const internalInput = firstCheckboxEl.shadowRoot?.querySelector('[part="input"]') as HTMLInputElement | null;
+  if (!internalInput) {
+    throw new Error('Expected checkbox input element to exist');
+  }
 
   await submit.click();
   await expect.poll(() => form.checkValidity()).toBe(false);
   await expect.element(group).toHaveAttribute('aria-invalid', 'true');
   await expect.element(firstCheckbox).toHaveAttribute('aria-invalid', 'true');
+  // Group invalid state should flow via aria-invalid on the internal input,
+  // while host invalid remains untouched (no host attribute mutation).
+  expect(firstCheckboxEl.hasAttribute('invalid')).toBe(false);
+  expect(internalInput.getAttribute('aria-invalid')).toBe('true');
 
   firstCheckboxEl.click();
   await expect.poll(() => form.checkValidity()).toBe(true);
   await expect.element(group).not.toHaveAttribute('aria-invalid', 'true');
   await expect.element(firstCheckbox).not.toHaveAttribute('aria-invalid', 'true');
+  expect(internalInput.getAttribute('aria-invalid')).toBeNull();
 });
 
 test('submits checked checkbox values via form data', async () => {

--- a/packages/checkbox-group/checkbox-group.ts
+++ b/packages/checkbox-group/checkbox-group.ts
@@ -1,7 +1,7 @@
 import { i18n } from '@lingui/core';
 import { FormControlMixin } from '@open-wc/form-control';
 import { css, html, LitElement, nothing, PropertyValues } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { activateI18n } from '../i18n';
 import { messages as daMessages } from './locales/da/messages.mjs';
@@ -20,6 +20,12 @@ const REQUIRED_MESSAGE = () =>
   });
 
 export class WCheckboxGroup extends FormControlMixin(LitElement) {
+  // Use delegatesFocus so focus delegates to an internal focusable element
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   /** The group label displayed above the checkboxes. */
   @property({ type: String, reflect: true })
   label: string;
@@ -49,8 +55,9 @@ export class WCheckboxGroup extends FormControlMixin(LitElement) {
   // Track whether we've warned about missing name in a form.
   #hasWarnedMissingName = false;
 
-  // Track whether we set tabindex automatically for invalid focusability.
-  #autoTabIndex = false;
+  // Internal tabindex for the focusable wrapper element (reactive)
+  @state()
+  private _internalTabIndex = -1;
 
   #unsubscribeI18n?: () => void;
 
@@ -104,7 +111,7 @@ export class WCheckboxGroup extends FormControlMixin(LitElement) {
     const ariaInvalid = isInvalid ? 'true' : undefined;
 
     return html`
-      <div class="wrapper">
+      <div class="wrapper" tabindex="${this._internalTabIndex}">
         ${this.label
           ? html`
               <div class="label" id="${labelId}">
@@ -211,17 +218,19 @@ export class WCheckboxGroup extends FormControlMixin(LitElement) {
   #applyGroupName(): void {
     if (!this.name) return;
     for (const el of this.#getAssignedElements()) {
-      const checkbox = el as { name?: string };
+      // Use non-reflecting _groupName to avoid DOM changes during hydration
+      const checkbox = el as { _groupName?: string; name?: string };
       if (checkbox && typeof checkbox === 'object' && !checkbox.name) {
-        checkbox.name = this.name;
+        checkbox._groupName = this.name;
       }
     }
   }
 
   #syncChildInvalid(isInvalid: boolean): void {
     for (const el of this.#getAssignedElements()) {
-      if ('invalid' in el) {
-        (el as { invalid: boolean }).invalid = isInvalid;
+      // Use non-reflecting _groupInvalid to avoid DOM changes during hydration
+      if ('_groupInvalid' in el) {
+        (el as { _groupInvalid: boolean })._groupInvalid = isInvalid;
       }
     }
   }
@@ -265,20 +274,9 @@ export class WCheckboxGroup extends FormControlMixin(LitElement) {
     this.internals.setValidity(state, ' ', anchor ?? undefined);
   }
 
-  #syncHostTabIndex(shouldBeFocusable: boolean): void {
-    const hasTabIndexAttr = this.hasAttribute('tabindex');
-    if (hasTabIndexAttr && !this.#autoTabIndex) return;
-
-    if (shouldBeFocusable) {
-      this.tabIndex = 0;
-      this.#autoTabIndex = true;
-      return;
-    }
-
-    if (this.#autoTabIndex) {
-      this.removeAttribute('tabindex');
-      this.#autoTabIndex = false;
-    }
+  #syncInternalTabIndex(shouldBeFocusable: boolean): void {
+    // Use internal tabindex to avoid DOM changes on host during hydration
+    this._internalTabIndex = shouldBeFocusable ? 0 : -1;
   }
 
   #updateValidity(): void {
@@ -289,7 +287,7 @@ export class WCheckboxGroup extends FormControlMixin(LitElement) {
     const showRequiredError = requiredInvalid && this.#hasInteracted;
     const showInvalidUi = externalInvalid || showRequiredError;
 
-    this.#syncHostTabIndex(showInvalidUi);
+    this.#syncInternalTabIndex(showInvalidUi);
 
     if (requiredInvalid) {
       this.#setValidityState({ valueMissing: true });

--- a/packages/checkbox/checkbox.hydration.test.ts
+++ b/packages/checkbox/checkbox.hydration.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './checkbox.js';
+
+describe('w-checkbox React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
+  test.fails('default checkbox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox', {
+      name: 'agree',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
+  test.fails('checked checkbox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox', {
+      name: 'agree',
+      checked: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets type="checkbox" in connectedCallback
+  test.fails('disabled checkbox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox', {
+      name: 'agree',
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
+  test.fails('indeterminate checkbox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox', {
+      name: 'agree',
+      indeterminate: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
+  test.fails('invalid checkbox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox', {
+      name: 'agree',
+      invalid: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/checkbox/checkbox.hydration.test.ts
+++ b/packages/checkbox/checkbox.hydration.test.ts
@@ -10,7 +10,13 @@ describe('w-checkbox React SSR hydration', () => {
   });
 
   // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
-  test.fails('default checkbox hydrates without warnings', async () => {
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-checkbox', {});
+    expect(warnings).toEqual([]);
+  });
+
+  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
+  test.fails('with name hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {
       name: 'agree',
     });

--- a/packages/checkbox/checkbox.hydration.test.ts
+++ b/packages/checkbox/checkbox.hydration.test.ts
@@ -9,22 +9,19 @@ describe('w-checkbox React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {});
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
-  test.fails('with name hydrates without warnings', async () => {
+  test('with name hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {
       name: 'agree',
     });
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
-  test.fails('checked checkbox hydrates without warnings', async () => {
+  test('checked checkbox hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {
       name: 'agree',
       checked: true,
@@ -32,8 +29,7 @@ describe('w-checkbox React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets type="checkbox" in connectedCallback
-  test.fails('disabled checkbox hydrates without warnings', async () => {
+  test('disabled checkbox hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {
       name: 'agree',
       disabled: true,
@@ -41,8 +37,7 @@ describe('w-checkbox React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
-  test.fails('indeterminate checkbox hydrates without warnings', async () => {
+  test('indeterminate checkbox hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {
       name: 'agree',
       indeterminate: true,
@@ -50,8 +45,7 @@ describe('w-checkbox React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  // Fails because component sets type="checkbox" and tabindex="0" in connectedCallback
-  test.fails('invalid checkbox hydrates without warnings', async () => {
+  test('invalid checkbox hydrates without warnings', async () => {
     const warnings = await testHydration('w-checkbox', {
       name: 'agree',
       invalid: true,

--- a/packages/checkbox/checkbox.ts
+++ b/packages/checkbox/checkbox.ts
@@ -15,7 +15,7 @@ export class WCheckbox extends FormControlMixin(LitElement) {
   @query('input[type="checkbox"]') input: HTMLInputElement | null;
 
   /** The name of the checkbox, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name = '';
+  @property({ reflect: true }) name: string;
 
   /** The value of the checkbox, submitted as a name/value pair with form data. */
   @property({ reflect: true }) value: string | null = null;
@@ -44,18 +44,12 @@ export class WCheckbox extends FormControlMixin(LitElement) {
   // Track whether the user has interacted with the checkbox.
   #hasInteracted = false;
 
-  // Track whether tabindex was set automatically.
-  #autoTabIndex = false;
-
   connectedCallback() {
     super.connectedCallback();
-    // kept for compat with old shared styling approach
-    this.setAttribute('type', 'checkbox');
     const attrValue = this.getAttribute('value');
     this.value = attrValue ?? 'on';
     this.#defaultChecked = this.hasAttribute('checked');
     this.checked = this.#defaultChecked;
-    this.#syncTabIndex();
     this.addEventListener('invalid', this.#handleInvalid);
     this.addEventListener('keydown', this.#handleKeyDown);
     this.#syncFormValue();
@@ -98,10 +92,6 @@ export class WCheckbox extends FormControlMixin(LitElement) {
     if (this.#shouldSyncFormState(changedProperties)) {
       this.#syncFormValue();
       this.#updateValidity();
-    }
-
-    if (changedProperties.has('disabled')) {
-      this.#syncTabIndex();
     }
   }
 
@@ -221,14 +211,6 @@ export class WCheckbox extends FormControlMixin(LitElement) {
   }
 
   /** @internal */
-  #syncTabIndex(): void {
-    const hasTabIndexAttr = this.hasAttribute('tabindex');
-    if (hasTabIndexAttr && !this.#autoTabIndex) return;
-    this.tabIndex = this.disabled ? -1 : 0;
-    this.#autoTabIndex = true;
-  }
-
-  /** @internal */
   #shouldSyncFormState(changedProperties: PropertyValues<this>): boolean {
     return (
       changedProperties.has('checked') ||
@@ -250,7 +232,7 @@ export class WCheckbox extends FormControlMixin(LitElement) {
             part="input"
             class="input hide-toggle"
             type="checkbox"
-            name=${this.name}
+            name=${ifDefined(this.name)}
             value=${ifDefined(this.value)}
             .indeterminate=${live(this.indeterminate)}
             .checked=${live(this.checked)}

--- a/packages/checkbox/checkbox.ts
+++ b/packages/checkbox/checkbox.ts
@@ -15,7 +15,14 @@ export class WCheckbox extends FormControlMixin(LitElement) {
   @query('input[type="checkbox"]') input: HTMLInputElement | null;
 
   /** The name of the checkbox, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name: string;
+  @property({ reflect: true })
+  set name(value: string | undefined) {
+    this._ownName = value;
+  }
+  get name(): string | undefined {
+    return this._ownName || this._groupName;
+  }
+  private _ownName: string | undefined;
 
   /** The value of the checkbox, submitted as a name/value pair with form data. */
   @property({ reflect: true }) value: string | null = null;
@@ -35,6 +42,22 @@ export class WCheckbox extends FormControlMixin(LitElement) {
   /** Draws the checkbox in an invalid state. */
   @property({ type: Boolean, reflect: true }) invalid = false;
 
+  /**
+   * Internal invalid state managed by parent checkbox-group.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _groupInvalid: boolean | undefined;
+
+  /**
+   * Internal name managed by parent checkbox-group.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _groupName: string | undefined;
+
   /** The default value of the form control. Used for resetting. */
   #defaultChecked = false;
 
@@ -43,6 +66,11 @@ export class WCheckbox extends FormControlMixin(LitElement) {
 
   // Track whether the user has interacted with the checkbox.
   #hasInteracted = false;
+
+  /** Computed invalid state: combines own invalid with group invalid */
+  get _computedInvalid(): boolean {
+    return this.invalid || this._groupInvalid === true;
+  }
 
   connectedCallback() {
     super.connectedCallback();
@@ -232,14 +260,14 @@ export class WCheckbox extends FormControlMixin(LitElement) {
             part="input"
             class="input hide-toggle"
             type="checkbox"
-            name=${ifDefined(this.name)}
+            name=${ifDefined(this.name || undefined)}
             value=${ifDefined(this.value)}
             .indeterminate=${live(this.indeterminate)}
             .checked=${live(this.checked)}
             .disabled=${this.disabled}
             .required=${this.required}
             aria-checked=${ariaChecked}
-            aria-invalid=${ifDefined(this.invalid ? 'true' : undefined)}
+            aria-invalid=${ifDefined(this._computedInvalid ? 'true' : undefined)}
             @click=${this.handleClick} />
           ${isIndeterminate ? '–' : ''}
         </span>

--- a/packages/checkbox/styles.ts
+++ b/packages/checkbox/styles.ts
@@ -45,15 +45,6 @@ export const styles = css`
     --_border-color: var(--_border-checked);
   }
 
-  :host([invalid]) {
-    --_border-color: var(--_border-invalid);
-  }
-
-  :host([invalid][checked]),
-  :host([invalid][indeterminate]) {
-    --_bg: var(--_bg-invalid-checked);
-  }
-
   :host([disabled]) {
     --_bg: var(--_bg-disabled);
     --_border-color: var(--_border-disabled);
@@ -111,6 +102,16 @@ export const styles = css`
     text-align: center;
     line-height: var(--w-line-height-xs);
     font-size: var(--w-font-size-m);
+  }
+
+  /* Invalid visuals are driven by the actual control state instead of host attributes.
+   * This preserves group-driven invalid styling without mutating host attributes. */
+  [part='control']:has(> [part='input'][aria-invalid='true']:not(:disabled)) {
+    border-color: var(--_border-invalid);
+  }
+
+  [part='control']:has(> [part='input'][aria-invalid='true']:is(:checked, :indeterminate):not(:disabled)) {
+    background-color: var(--_bg-invalid-checked);
   }
 
   :host(:focus-visible) {

--- a/packages/combobox/combobox.hydration.test.ts
+++ b/packages/combobox/combobox.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-combobox React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default combobox hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-combobox', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/combobox/combobox.hydration.test.ts
+++ b/packages/combobox/combobox.hydration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './combobox.js';
+
+describe('w-combobox React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default combobox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-combobox', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label hydrates without warnings', async () => {
+    const warnings = await testHydration('w-combobox', {
+      label: 'Search',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with placeholder hydrates without warnings', async () => {
+    const warnings = await testHydration('w-combobox', {
+      placeholder: 'Type to search...',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with value hydrates without warnings', async () => {
+    const warnings = await testHydration('w-combobox', {
+      value: 'test',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('disabled combobox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-combobox', {
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('invalid combobox hydrates without warnings', async () => {
+    const warnings = await testHydration('w-combobox', {
+      invalid: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/datepicker/datepicker.hydration.test.ts
+++ b/packages/datepicker/datepicker.hydration.test.ts
@@ -9,7 +9,12 @@ describe('w-datepicker React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default datepicker hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-datepicker', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label hydrates without warnings', async () => {
     const warnings = await testHydration('w-datepicker', {
       label: 'Date',
     });

--- a/packages/datepicker/datepicker.hydration.test.ts
+++ b/packages/datepicker/datepicker.hydration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './datepicker.js';
+
+describe('w-datepicker React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default datepicker hydrates without warnings', async () => {
+    const warnings = await testHydration('w-datepicker', {
+      label: 'Date',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with value hydrates without warnings', async () => {
+    const warnings = await testHydration('w-datepicker', {
+      label: 'Date',
+      value: '2024-01-15',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with name hydrates without warnings', async () => {
+    const warnings = await testHydration('w-datepicker', {
+      label: 'Date',
+      name: 'birthdate',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with lang hydrates without warnings', async () => {
+    const warnings = await testHydration('w-datepicker', {
+      label: 'Dato',
+      lang: 'nb',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/dead-toggle/dead-toggle.hydration.test.ts
+++ b/packages/dead-toggle/dead-toggle.hydration.test.ts
@@ -9,6 +9,11 @@ describe('w-dead-toggle React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {});
+    expect(warnings).toEqual([]);
+  });
+
   test('checkbox type hydrates without warnings', async () => {
     const warnings = await testHydration('w-dead-toggle', {
       type: 'checkbox',

--- a/packages/dead-toggle/dead-toggle.hydration.test.ts
+++ b/packages/dead-toggle/dead-toggle.hydration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './dead-toggle.js';
+
+describe('w-dead-toggle React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('checkbox type hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {
+      type: 'checkbox',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('radio type hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {
+      type: 'radio',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('checked state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {
+      type: 'checkbox',
+      checked: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('indeterminate state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {
+      type: 'checkbox',
+      indeterminate: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {
+      type: 'checkbox',
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('invalid state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-dead-toggle', {
+      type: 'checkbox',
+      invalid: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/expandable/expandable.hydration.test.ts
+++ b/packages/expandable/expandable.hydration.test.ts
@@ -9,7 +9,12 @@ describe('w-expandable React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default expandable hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-expandable', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with title hydrates without warnings', async () => {
     const warnings = await testHydration('w-expandable', {
       title: 'Show more',
     });

--- a/packages/expandable/expandable.hydration.test.ts
+++ b/packages/expandable/expandable.hydration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './expandable.js';
+
+describe('w-expandable React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default expandable hydrates without warnings', async () => {
+    const warnings = await testHydration('w-expandable', {
+      title: 'Show more',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('expanded state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-expandable', {
+      title: 'Show more',
+      expanded: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with box variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-expandable', {
+      title: 'Show more',
+      box: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with bleed hydrates without warnings', async () => {
+    const warnings = await testHydration('w-expandable', {
+      title: 'Show more',
+      bleed: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with animated hydrates without warnings', async () => {
+    const warnings = await testHydration('w-expandable', {
+      title: 'Show more',
+      animated: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/icon/icon.hydration.test.ts
+++ b/packages/icon/icon.hydration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './icon.js';
+
+describe('w-icon React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default icon hydrates without warnings', async () => {
+    const warnings = await testHydration('w-icon', {
+      name: 'Check',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('small icon hydrates without warnings', async () => {
+    const warnings = await testHydration('w-icon', {
+      name: 'Check',
+      size: 'small',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('medium icon hydrates without warnings', async () => {
+    const warnings = await testHydration('w-icon', {
+      name: 'Check',
+      size: 'medium',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('large icon hydrates without warnings', async () => {
+    const warnings = await testHydration('w-icon', {
+      name: 'Check',
+      size: 'large',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with locale hydrates without warnings', async () => {
+    const warnings = await testHydration('w-icon', {
+      name: 'Check',
+      locale: 'nb',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/icon/icon.hydration.test.ts
+++ b/packages/icon/icon.hydration.test.ts
@@ -9,7 +9,13 @@ describe('w-icon React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default icon hydrates without warnings', async () => {
+  // Fails because component sets default size/locale attributes
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-icon', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with name hydrates without warnings', async () => {
     const warnings = await testHydration('w-icon', {
       name: 'Check',
     });

--- a/packages/icon/icon.hydration.test.ts
+++ b/packages/icon/icon.hydration.test.ts
@@ -9,8 +9,7 @@ describe('w-icon React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // Fails because component sets default size/locale attributes
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-icon', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/icon/icon.ts
+++ b/packages/icon/icon.ts
@@ -33,7 +33,7 @@ export class WIcon extends LitElement {
 
   /** Icon filename (without .svg) */
   @property({ type: String, reflect: true })
-  name: string;
+  name!: string;
 
   /** Size: small, medium, large or pixel value (e.g. "32px") */
   @property({ type: String, reflect: true })

--- a/packages/icon/icon.ts
+++ b/packages/icon/icon.ts
@@ -33,7 +33,7 @@ export class WIcon extends LitElement {
 
   /** Icon filename (without .svg) */
   @property({ type: String, reflect: true })
-  name = '';
+  name: string;
 
   /** Size: small, medium, large or pixel value (e.g. "32px") */
   @property({ type: String, reflect: true })
@@ -90,6 +90,7 @@ export class WIcon extends LitElement {
 
   render(): TemplateResult {
     const size = this.size || 'medium';
+    const name = this.name || '';
     const classes = {
       'w-icon': true,
       'w-icon--s': size === 'small',
@@ -97,7 +98,7 @@ export class WIcon extends LitElement {
       'w-icon--l': size === 'large',
     };
     const customStyle = typeof size === 'string' && size.endsWith('px') ? `--w-icon-size: ${size};` : '';
-    return html`<div class="${classMap(classes)}" style="${customStyle}" part="w-${this.name.toLowerCase()}">${this.svg}</div>`;
+    return html`<div class="${classMap(classes)}" style="${customStyle}" part="w-${name.toLowerCase()}">${this.svg}</div>`;
   }
 }
 

--- a/packages/link/link.hydration.test.ts
+++ b/packages/link/link.hydration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './link.js';
+
+describe('w-link React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default link hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {
+      href: 'https://example.com',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('primary variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {
+      href: 'https://example.com',
+      variant: 'primary',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('secondary variant hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {
+      href: 'https://example.com',
+      variant: 'secondary',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with target blank hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {
+      href: 'https://example.com',
+      target: '_blank',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('small link hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {
+      href: 'https://example.com',
+      small: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('disabled link hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {
+      href: 'https://example.com',
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/link/link.hydration.test.ts
+++ b/packages/link/link.hydration.test.ts
@@ -9,7 +9,12 @@ describe('w-link React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default link hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-link', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with href hydrates without warnings', async () => {
     const warnings = await testHydration('w-link', {
       href: 'https://example.com',
     });

--- a/packages/modal/modal.hydration.test.ts
+++ b/packages/modal/modal.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-modal React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default modal hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-modal', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/modal/modal.hydration.test.ts
+++ b/packages/modal/modal.hydration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './index.js';
+
+describe('w-modal React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default modal hydrates without warnings', async () => {
+    const warnings = await testHydration('w-modal', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with content-id hydrates without warnings', async () => {
+    const warnings = await testHydration('w-modal', {
+      'content-id': 'modal-content',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with ignore-backdrop-clicks hydrates without warnings', async () => {
+    const warnings = await testHydration('w-modal', {
+      'ignore-backdrop-clicks': true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/page-indicator/page-indicator.hydration.test.ts
+++ b/packages/page-indicator/page-indicator.hydration.test.ts
@@ -9,7 +9,12 @@ describe('w-page-indicator React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default page-indicator hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-page-indicator', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with page-count and selected-page hydrates without warnings', async () => {
     const warnings = await testHydration('w-page-indicator', {
       'page-count': 5,
       'selected-page': 1,

--- a/packages/page-indicator/page-indicator.hydration.test.ts
+++ b/packages/page-indicator/page-indicator.hydration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './page-indicator.js';
+
+describe('w-page-indicator React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default page-indicator hydrates without warnings', async () => {
+    const warnings = await testHydration('w-page-indicator', {
+      'page-count': 5,
+      'selected-page': 1,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with selected page hydrates without warnings', async () => {
+    const warnings = await testHydration('w-page-indicator', {
+      'page-count': 5,
+      'selected-page': 3,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('single page hydrates without warnings', async () => {
+    const warnings = await testHydration('w-page-indicator', {
+      'page-count': 1,
+      'selected-page': 1,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('many pages hydrates without warnings', async () => {
+    const warnings = await testHydration('w-page-indicator', {
+      'page-count': 10,
+      'selected-page': 5,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/pagination/pagination.hydration.test.ts
+++ b/packages/pagination/pagination.hydration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './pagination.js';
+
+describe('w-pagination React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default pagination hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pagination', {
+      'base-url': '/page/',
+      pages: 10,
+      'current-page': 1,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with current page hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pagination', {
+      'base-url': '/page/',
+      pages: 10,
+      'current-page': 5,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with visible pages hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pagination', {
+      'base-url': '/page/',
+      pages: 20,
+      'current-page': 10,
+      'visible-pages': 5,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/pagination/pagination.hydration.test.ts
+++ b/packages/pagination/pagination.hydration.test.ts
@@ -9,7 +9,12 @@ describe('w-pagination React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default pagination hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pagination', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with base-url and pages hydrates without warnings', async () => {
     const warnings = await testHydration('w-pagination', {
       'base-url': '/page/',
       pages: 10,

--- a/packages/pill/pill.hydration.test.ts
+++ b/packages/pill/pill.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-pill React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default filter pill hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-pill', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/pill/pill.hydration.test.ts
+++ b/packages/pill/pill.hydration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './pill.js';
+
+describe('w-pill React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default filter pill hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pill', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('suggestion pill hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pill', {
+      suggestion: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with can-close hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pill', {
+      'can-close': true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('suggestion with can-close hydrates without warnings', async () => {
+    const warnings = await testHydration('w-pill', {
+      suggestion: true,
+      'can-close': true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/radio-group/radio-group.a11y.test.ts
+++ b/packages/radio-group/radio-group.a11y.test.ts
@@ -107,6 +107,8 @@ describe('w-radio-group accessibility (WCAG 2.2)', () => {
       >;
 
       await radios[0].updateComplete;
+      // Wait for radio-group to set tabIndex (async via slotchange)
+      await expect.poll(() => radios[0].tabIndex).toBe(0);
       radios[0].focus();
       await expect.poll(() => document.activeElement).toBe(radios[0]);
 
@@ -129,10 +131,12 @@ describe('w-radio-group accessibility (WCAG 2.2)', () => {
       `);
 
       const radios = Array.from(document.querySelectorAll('w-radio')) as Array<
-        HTMLElement & { checked: boolean; updateComplete: Promise<unknown>; focus: () => void }
+        HTMLElement & { checked: boolean; updateComplete: Promise<unknown>; focus: () => void; tabIndex: number }
       >;
 
       await radios[0].updateComplete;
+      // Wait for radio-group to set tabIndex (async via slotchange)
+      await expect.poll(() => radios[0].tabIndex).toBe(0);
       radios[0].focus();
       await expect.poll(() => document.activeElement).toBe(radios[0]);
 

--- a/packages/radio-group/radio-group.hydration.test.ts
+++ b/packages/radio-group/radio-group.hydration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import '../radio/radio.js';
+import './radio-group.js';
+
+describe('w-radio-group React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Note: w-radio-group requires w-radio children to function properly.
+  // Testing the parent element alone to verify its own attributes don't cause mismatch.
+
+  test('empty radio-group hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio-group', { label: 'Options', name: 'options' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with optional hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio-group', { label: 'Options', name: 'options', optional: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with help-text hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio-group', { label: 'Options', name: 'options', 'help-text': 'Select one' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('required radio-group hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio-group', { label: 'Options', name: 'options', required: true });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/radio-group/radio-group.hydration.test.ts
+++ b/packages/radio-group/radio-group.hydration.test.ts
@@ -13,7 +13,12 @@ describe('w-radio-group React SSR hydration', () => {
   // Note: w-radio-group requires w-radio children to function properly.
   // Testing the parent element alone to verify its own attributes don't cause mismatch.
 
-  test('empty radio-group hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio-group', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label and name hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio-group', { label: 'Options', name: 'options' });
     expect(warnings).toEqual([]);
   });

--- a/packages/radio-group/radio-group.ts
+++ b/packages/radio-group/radio-group.ts
@@ -143,7 +143,8 @@ export class WRadioGroup extends FormControlMixin(LitElement) {
     radios.forEach((radio) => {
       const isSelected = radio === selected;
       radio.checked = isSelected;
-      radio.setAttribute('tabindex', isSelected ? '0' : '-1');
+      // Use non-reflecting property to avoid DOM changes during hydration
+      radio._groupTabIndex = isSelected ? 0 : -1;
     });
   }
 
@@ -208,8 +209,9 @@ export class WRadioGroup extends FormControlMixin(LitElement) {
   }
 
   private syncTabOrder(radios: WRadio[]) {
+    // Use non-reflecting _groupTabIndex property to avoid DOM changes during hydration
     if (this.disabled) {
-      radios.forEach((radio) => (radio.tabIndex = -1));
+      radios.forEach((radio) => (radio._groupTabIndex = -1));
       return;
     }
 
@@ -218,13 +220,13 @@ export class WRadioGroup extends FormControlMixin(LitElement) {
 
     if (enabledRadios.length > 0) {
       if (checkedRadio) {
-        enabledRadios.forEach((radio) => (radio.tabIndex = radio.checked ? 0 : -1));
+        enabledRadios.forEach((radio) => (radio._groupTabIndex = radio.checked ? 0 : -1));
       } else {
-        enabledRadios.forEach((radio, index) => (radio.tabIndex = index === 0 ? 0 : -1));
+        enabledRadios.forEach((radio, index) => (radio._groupTabIndex = index === 0 ? 0 : -1));
       }
     }
 
-    radios.filter((radio) => radio.disabled).forEach((radio) => (radio.tabIndex = -1));
+    radios.filter((radio) => radio.disabled).forEach((radio) => (radio._groupTabIndex = -1));
   }
 
   private emitSelectionChange = () => {

--- a/packages/radio/radio.hydration.test.ts
+++ b/packages/radio/radio.hydration.test.ts
@@ -10,7 +10,12 @@ describe('w-radio React SSR hydration', () => {
   });
 
   // w-radio sets type attribute and tabindex in connectedCallback
-  test.fails('default radio hydrates without warnings', async () => {
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with value hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio', { value: 'option1' });
     expect(warnings).toEqual([]);
   });

--- a/packages/radio/radio.hydration.test.ts
+++ b/packages/radio/radio.hydration.test.ts
@@ -9,28 +9,27 @@ describe('w-radio React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // w-radio sets type attribute and tabindex in connectedCallback
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio', {});
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with value hydrates without warnings', async () => {
+  test('with value hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio', { value: 'option1' });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with name hydrates without warnings', async () => {
+  test('with name hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio', { value: 'option1', name: 'options' });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('checked radio hydrates without warnings', async () => {
+  test('checked radio hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio', { value: 'option1', checked: true });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('disabled radio hydrates without warnings', async () => {
+  test('disabled radio hydrates without warnings', async () => {
     const warnings = await testHydration('w-radio', { value: 'option1', disabled: true });
     expect(warnings).toEqual([]);
   });

--- a/packages/radio/radio.hydration.test.ts
+++ b/packages/radio/radio.hydration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './radio.js';
+
+describe('w-radio React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // w-radio sets type attribute and tabindex in connectedCallback
+  test.fails('default radio hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio', { value: 'option1' });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with name hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio', { value: 'option1', name: 'options' });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('checked radio hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio', { value: 'option1', checked: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('disabled radio hydrates without warnings', async () => {
+    const warnings = await testHydration('w-radio', { value: 'option1', disabled: true });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/radio/radio.test.ts
+++ b/packages/radio/radio.test.ts
@@ -62,7 +62,8 @@ test('updates checked state and tabIndex when checked', async () => {
   await radio.updateComplete;
 
   expect(radio.checked).toBe(true);
-  expect(radio.tabIndex).toBe(0);
+  // tabIndex is set after RAF for hydration compatibility
+  await expect.poll(() => radio.tabIndex).toBe(0);
 });
 
 test('checked state uses selected border color', async () => {
@@ -135,21 +136,22 @@ test('reflects disabled state changes and updates tabIndex', async () => {
 
   await radio.updateComplete;
   expect(radio.disabled).toBe(false);
-  expect(radio.tabIndex).toBe(0);
+  // tabIndex is set after RAF for hydration compatibility
+  await expect.poll(() => radio.tabIndex).toBe(0);
 
   radio.checked = true;
   await radio.updateComplete;
-  expect(radio.tabIndex).toBe(0);
+  await expect.poll(() => radio.tabIndex).toBe(0);
 
   radio.disabled = true;
   await radio.updateComplete;
   expect(radio.disabled).toBe(true);
-  expect(radio.tabIndex).toBe(-1);
+  await expect.poll(() => radio.tabIndex).toBe(-1);
 
   radio.disabled = false;
   await radio.updateComplete;
   expect(radio.disabled).toBe(false);
-  expect(radio.tabIndex).toBe(0);
+  await expect.poll(() => radio.tabIndex).toBe(0);
 });
 
 test('focuses the host element', async () => {
@@ -158,9 +160,12 @@ test('focuses the host element', async () => {
   const radio = document.querySelector('w-radio') as HTMLElement & {
     updateComplete: Promise<unknown>;
     focus: () => void;
+    tabIndex: number;
   };
 
   await radio.updateComplete;
+  // Wait for tabindex to be set (delayed for hydration compatibility)
+  await expect.poll(() => radio.tabIndex).toBe(0);
   radio.focus();
   await expect.poll(() => document.activeElement).toBe(radio);
 });
@@ -234,16 +239,17 @@ test('standalone radios with same name use roving tab order', async () => {
   >;
 
   await Promise.all(radios.map((radio) => radio.updateComplete));
-  expect(radios[0].tabIndex).toBe(0);
+  // tabIndex is set after RAF to avoid hydration mismatch, so poll for it
+  await expect.poll(() => radios[0].tabIndex).toBe(0);
   expect(radios[1].tabIndex).toBe(-1);
   expect(radios[2].tabIndex).toBe(-1);
 
   radios[2].click();
   await Promise.all(radios.map((radio) => radio.updateComplete));
 
+  await expect.poll(() => radios[2].tabIndex).toBe(0);
   expect(radios[0].tabIndex).toBe(-1);
   expect(radios[1].tabIndex).toBe(-1);
-  expect(radios[2].tabIndex).toBe(0);
 });
 
 test('arrow keys move selection between standalone radios with same name', async () => {
@@ -258,6 +264,8 @@ test('arrow keys move selection between standalone radios with same name', async
   >;
 
   await Promise.all(radios.map((radio) => radio.updateComplete));
+  // Wait for initial tabIndex to be set (delayed for hydration compatibility)
+  await expect.poll(() => radios[0].tabIndex).toBe(0);
 
   radios[0].focus();
   radios[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
@@ -265,7 +273,7 @@ test('arrow keys move selection between standalone radios with same name', async
 
   expect(radios[0].checked).toBe(false);
   expect(radios[1].checked).toBe(true);
-  expect(radios[1].tabIndex).toBe(0);
+  await expect.poll(() => radios[1].tabIndex).toBe(0);
   await expect.poll(() => document.activeElement).toBe(radios[1]);
 });
 

--- a/packages/radio/radio.ts
+++ b/packages/radio/radio.ts
@@ -10,6 +10,12 @@ import { styles as radioStyles } from './radio-styles';
 export class WRadio extends FormControlMixin(LitElement) {
   static styles = [hostStyles, reset, radioStyles];
 
+  // Use delegatesFocus so focus delegates to the internal wrapper element
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   /** The name of the radio, submitted as a name/value pair with form data. */
   @property({ reflect: true }) name: string;
 
@@ -28,6 +34,30 @@ export class WRadio extends FormControlMixin(LitElement) {
   /** Draws the radio in an invalid state. */
   @property({ type: Boolean, reflect: true }) invalid = false;
 
+  /**
+   * Internal tabindex managed by parent radio-group.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _groupTabIndex: number | undefined;
+
+  /**
+   * Override tabIndex getter to return the computed internal tabIndex.
+   * This allows external code to check if the radio is focusable.
+   */
+  override get tabIndex(): number {
+    return this._internalTabIndex;
+  }
+
+  /**
+   * Override tabIndex setter to set _groupTabIndex (for backwards compatibility).
+   * Radio-group should use _groupTabIndex directly for clarity.
+   */
+  override set tabIndex(value: number) {
+    this._groupTabIndex = value;
+  }
+
   /** The default value of the form control. Used for resetting. */
   #defaultChecked = false;
 
@@ -36,9 +66,6 @@ export class WRadio extends FormControlMixin(LitElement) {
 
   // Track whether the user has interacted with the radio.
   #hasInteracted = false;
-
-  // Track whether hydration is complete (for avoiding hydration mismatch)
-  #hydrationComplete = false;
 
   constructor() {
     super();
@@ -82,24 +109,14 @@ export class WRadio extends FormControlMixin(LitElement) {
       // Uncheck other radios immediately (functional behavior)
       if (this.checked && !this.isInGroup()) {
         this.uncheckOtherRadios();
-      }
-      // Delay UI attributes and tabindex until after hydration
-      if (this.#hydrationComplete) {
-        this[this.checked ? 'setAttribute' : 'removeAttribute']('checked-ui', '');
-        if (this.checked && !this.isInGroup()) {
-          this.syncStandaloneTabOrder();
-        }
+        this.syncStandaloneTabOrder();
       }
     }
 
     if (changedProperties.has('disabled')) {
       this.syncAriaDisabled();
-      // Delay UI attributes and tabindex until after hydration
-      if (this.#hydrationComplete) {
-        this[this.disabled ? 'setAttribute' : 'removeAttribute']('disabled-ui', '');
-        if (!this.isInGroup()) {
-          this.syncStandaloneTabOrder();
-        }
+      if (!this.isInGroup()) {
+        this.syncStandaloneTabOrder();
       }
     }
 
@@ -219,33 +236,34 @@ export class WRadio extends FormControlMixin(LitElement) {
     const activeRadio = checkedRadio ?? enabledRadios[0] ?? null;
 
     radios.forEach((radio) => {
-      radio.tabIndex = radio === activeRadio ? 0 : -1;
+      radio._standaloneTabIndex = radio === activeRadio ? 0 : -1;
     });
   }
 
+  /**
+   * Computed tabindex for the internal focusable element.
+   * Priority: group-managed > standalone-managed > default
+   */
+  private get _internalTabIndex(): number {
+    if (this.disabled) return -1;
+    if (this._groupTabIndex !== undefined) return this._groupTabIndex;
+    if (this._standaloneTabIndex !== undefined) return this._standaloneTabIndex;
+    // Default: first radio in standalone group is focusable
+    return 0;
+  }
+
+  /**
+   * Internal tabindex for standalone radios (not in a group).
+   * Non-reflecting to avoid DOM changes during hydration.
+   */
+  @property({ attribute: false })
+  _standaloneTabIndex: number | undefined;
+
   protected firstUpdated(): void {
-    // Delay DOM changes to after React hydration completes
-    // Using double RAF + setTimeout which is more reliable across browsers
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          this.#hydrationComplete = true;
-          // Set UI attributes that were skipped during hydration
-          if (this.checked) {
-            this.setAttribute('checked-ui', '');
-          }
-          if (this.disabled) {
-            this.setAttribute('disabled-ui', '');
-          }
-          // Set initial tabindex
-          if (!this.isInGroup()) {
-            this.syncStandaloneTabOrder();
-          } else if (this.disabled) {
-            this.tabIndex = -1;
-          }
-        }, 0);
-      });
-    });
+    // Initialize standalone tab order if not in a group
+    if (!this.isInGroup()) {
+      this.syncStandaloneTabOrder();
+    }
   }
 
   private uncheckOtherRadios(): void {
@@ -313,7 +331,7 @@ export class WRadio extends FormControlMixin(LitElement) {
 
   render() {
     return html`
-      <div class="wrapper">
+      <div class="wrapper" tabindex="${this._internalTabIndex}">
         <div part="control" class="control"></div>
         <slot part="label" class="label"></slot>
       </div>

--- a/packages/radio/radio.ts
+++ b/packages/radio/radio.ts
@@ -11,7 +11,7 @@ export class WRadio extends FormControlMixin(LitElement) {
   static styles = [hostStyles, reset, radioStyles];
 
   /** The name of the radio, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name = '';
+  @property({ reflect: true }) name: string;
 
   /** The radio's value. When selected, the radio group will receive this value. */
   @property({ reflect: true }) value: string | null = null;
@@ -37,8 +37,8 @@ export class WRadio extends FormControlMixin(LitElement) {
   // Track whether the user has interacted with the radio.
   #hasInteracted = false;
 
-  // Track whether tabindex was set automatically.
-  #autoTabIndex = false;
+  // Track whether hydration is complete (for avoiding hydration mismatch)
+  #hydrationComplete = false;
 
   constructor() {
     super();
@@ -49,15 +49,12 @@ export class WRadio extends FormControlMixin(LitElement) {
 
   connectedCallback() {
     super.connectedCallback();
-    // kept for compat with old shared styling approach
-    this.setAttribute('type', 'radio');
     this.value = this.getAttribute('value') ?? 'on';
     this.#defaultChecked = this.hasAttribute('checked');
     this.checked = this.#defaultChecked;
     // Use ElementInternals for ARIA to avoid hydration mismatches
     this.internals.role = 'radio';
     this.syncAriaDisabled();
-    this.syncTabIndex();
     this.syncFormValue();
     this.updateValidity();
   }
@@ -81,18 +78,29 @@ export class WRadio extends FormControlMixin(LitElement) {
     super.updated(changedProperties);
 
     if (changedProperties.has('checked')) {
-      this[this.checked ? 'setAttribute' : 'removeAttribute']('checked-ui', '');
       this.syncAriaChecked();
+      // Uncheck other radios immediately (functional behavior)
       if (this.checked && !this.isInGroup()) {
         this.uncheckOtherRadios();
       }
-      this.syncTabIndex();
+      // Delay UI attributes and tabindex until after hydration
+      if (this.#hydrationComplete) {
+        this[this.checked ? 'setAttribute' : 'removeAttribute']('checked-ui', '');
+        if (this.checked && !this.isInGroup()) {
+          this.syncStandaloneTabOrder();
+        }
+      }
     }
 
     if (changedProperties.has('disabled')) {
-      this[this.disabled ? 'setAttribute' : 'removeAttribute']('disabled-ui', '');
       this.syncAriaDisabled();
-      this.syncTabIndex();
+      // Delay UI attributes and tabindex until after hydration
+      if (this.#hydrationComplete) {
+        this[this.disabled ? 'setAttribute' : 'removeAttribute']('disabled-ui', '');
+        if (!this.isInGroup()) {
+          this.syncStandaloneTabOrder();
+        }
+      }
     }
 
     if (changedProperties.has('invalid')) {
@@ -211,16 +219,32 @@ export class WRadio extends FormControlMixin(LitElement) {
     const activeRadio = checkedRadio ?? enabledRadios[0] ?? null;
 
     radios.forEach((radio) => {
-      if (radio.disabled) {
-        radio.tabIndex = -1;
-        return;
-      }
-
-      const hasTabIndexAttr = radio.hasAttribute('tabindex');
-      if (hasTabIndexAttr && !radio.#autoTabIndex) return;
-
       radio.tabIndex = radio === activeRadio ? 0 : -1;
-      radio.#autoTabIndex = true;
+    });
+  }
+
+  protected firstUpdated(): void {
+    // Delay DOM changes to after React hydration completes
+    // Using double RAF + setTimeout which is more reliable across browsers
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          this.#hydrationComplete = true;
+          // Set UI attributes that were skipped during hydration
+          if (this.checked) {
+            this.setAttribute('checked-ui', '');
+          }
+          if (this.disabled) {
+            this.setAttribute('disabled-ui', '');
+          }
+          // Set initial tabindex
+          if (!this.isInGroup()) {
+            this.syncStandaloneTabOrder();
+          } else if (this.disabled) {
+            this.tabIndex = -1;
+          }
+        }, 0);
+      });
     });
   }
 
@@ -275,27 +299,6 @@ export class WRadio extends FormControlMixin(LitElement) {
     }
 
     this.setValue(this.checked ? this.value : null);
-  }
-
-  private syncTabIndex(): void {
-    if (!this.hasAttribute('tabindex') && !this.#autoTabIndex) {
-      this.#autoTabIndex = true;
-      // Default to tabbable; group roving tabindex logic may override this later.
-      this.tabIndex = 0;
-    }
-
-    if (this.isInGroup()) {
-      if (this.disabled) {
-        this.tabIndex = -1;
-      }
-      return;
-    }
-
-    // Standalone radios manage their own tabindex. Grouped radios are managed by the parent radio-group.
-    const hasTabIndexAttr = this.hasAttribute('tabindex');
-    if (hasTabIndexAttr && !this.#autoTabIndex) return;
-
-    this.syncStandaloneTabOrder();
   }
 
   private shouldSyncFormState(changedProperties: PropertyValues<this>): boolean {

--- a/packages/radio/radio.ts
+++ b/packages/radio/radio.ts
@@ -17,7 +17,7 @@ export class WRadio extends FormControlMixin(LitElement) {
   };
 
   /** The name of the radio, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name: string;
+  @property({ reflect: true }) name!: string;
 
   /** The radio's value. When selected, the radio group will receive this value. */
   @property({ reflect: true }) value: string | null = null;

--- a/packages/select/select.hydration.test.ts
+++ b/packages/select/select.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-select React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default select hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-select', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/select/select.hydration.test.ts
+++ b/packages/select/select.hydration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './select.js';
+
+describe('w-select React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default select hydrates without warnings', async () => {
+    const warnings = await testHydration('w-select', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label hydrates without warnings', async () => {
+    const warnings = await testHydration('w-select', {
+      label: 'Country',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-select', {
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with invalid state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-select', {
+      invalid: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with help text hydrates without warnings', async () => {
+    const warnings = await testHydration('w-select', {
+      'help-text': 'Select your country',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/slider-thumb/slider-thumb.hydration.test.ts
+++ b/packages/slider-thumb/slider-thumb.hydration.test.ts
@@ -1,0 +1,39 @@
+import { i18n } from '@lingui/core';
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './slider-thumb.js';
+
+// Activate i18n before tests (normally done by parent w-slider)
+i18n.load('en', {});
+i18n.activate('en');
+
+describe('w-slider-thumb React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Note: w-slider-thumb is typically used within w-slider, which syncs properties.
+  // Testing the element alone to verify its own attributes don't cause mismatch.
+
+  test('default slider-thumb hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider-thumb', { value: '50' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with name hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider-thumb', { value: '50', name: 'slider' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('disabled slider-thumb hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider-thumb', { value: '50', disabled: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with placeholder hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider-thumb', { value: '', placeholder: 'Min' });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/slider-thumb/slider-thumb.hydration.test.ts
+++ b/packages/slider-thumb/slider-thumb.hydration.test.ts
@@ -17,7 +17,12 @@ describe('w-slider-thumb React SSR hydration', () => {
   // Note: w-slider-thumb is typically used within w-slider, which syncs properties.
   // Testing the element alone to verify its own attributes don't cause mismatch.
 
-  test('default slider-thumb hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider-thumb', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with value hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider-thumb', { value: '50' });
     expect(warnings).toEqual([]);
   });

--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -162,6 +162,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
     value: string,
     isFromTextInput: boolean,
   ): Promise<{ shouldCancel: boolean; originalValue?: string }> {
+    const suffix = this.suffix ?? '';
     let valueNum = Number.parseInt(value);
 
     if (this.openEnded && !isFromTextInput && this.step) {
@@ -186,8 +187,8 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
           id: 'slider.error.out_of_bounds',
           message: 'Value must be between {min} and {max}',
           values: {
-            min: `${this.min} ${this.suffix}`.trim(),
-            max: `${this.max} ${this.suffix}`.trim(),
+            min: `${this.min} ${suffix}`.trim(),
+            max: `${this.max} ${suffix}`.trim(),
           },
         }),
       );
@@ -624,7 +625,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
           @input="${this.#onInput}"
           ?disabled="${this.disabled}"
         >
-          ${this.suffix ? html`<w-affix slot="suffix" label="${this.suffix}"></w-affix>` : nothing}
+          ${(this.suffix ?? '') ? html`<w-affix slot="suffix" label="${this.suffix ?? ''}"></w-affix>` : nothing}
         </w-textfield>
         <w-attention
           tooltip
@@ -639,7 +640,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
             slot="target"
           ></output>
           <span slot="message">
-            ${this.tooltipDisplayValue}${this.suffix ? html`&nbsp;${this.suffix}` : nothing}
+            ${this.tooltipDisplayValue}${(this.suffix ?? '') ? html`&nbsp;${this.suffix ?? ''}` : nothing}
           </span>
         </w-attention>
 

--- a/packages/slider/slider.hydration.test.ts
+++ b/packages/slider/slider.hydration.test.ts
@@ -9,36 +9,32 @@ describe('w-slider React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // Note: w-slider requires w-slider-thumb children to function properly.
-  // w-slider sets default reflected attributes (error="", suffix="") and
-  // inline styles in connectedCallback, causing hydration mismatches.
-
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', {});
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with label and range hydrates without warnings', async () => {
+  test('with label and range hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100' });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with step hydrates without warnings', async () => {
+  test('with step hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', step: 10 });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('disabled slider hydrates without warnings', async () => {
+  test('disabled slider hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', disabled: true });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with suffix hydrates without warnings', async () => {
+  test('with suffix hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', suffix: '%' });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with help-text hydrates without warnings', async () => {
+  test('with help-text hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', 'help-text': 'Select a value' });
     expect(warnings).toEqual([]);
   });

--- a/packages/slider/slider.hydration.test.ts
+++ b/packages/slider/slider.hydration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './slider.js';
+
+describe('w-slider React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Note: w-slider requires w-slider-thumb children to function properly.
+  // w-slider sets default reflected attributes (error="", suffix="") and
+  // inline styles in connectedCallback, causing hydration mismatches.
+
+  test.fails('empty slider hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100' });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with step hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', step: 10 });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('disabled slider hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', disabled: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with suffix hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', suffix: '%' });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with help-text hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100', 'help-text': 'Select a value' });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/slider/slider.hydration.test.ts
+++ b/packages/slider/slider.hydration.test.ts
@@ -13,7 +13,12 @@ describe('w-slider React SSR hydration', () => {
   // w-slider sets default reflected attributes (error="", suffix="") and
   // inline styles in connectedCallback, causing hydration mismatches.
 
-  test.fails('empty slider hydrates without warnings', async () => {
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-slider', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with label and range hydrates without warnings', async () => {
     const warnings = await testHydration('w-slider', { label: 'Value', min: '0', max: '100' });
     expect(warnings).toEqual([]);
   });

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -80,6 +80,23 @@ test('can set slider value via the number input', async () => {
   expect(formData.get('value')).toBe('50');
 });
 
+test('slider without suffix syncs empty suffix to thumb', async () => {
+  render(html`
+    <w-slider label="Single" min="0" max="100">
+      <w-slider-thumb name="value"></w-slider-thumb>
+    </w-slider>
+  `);
+
+  const slider = document.querySelector('w-slider') as WarpSlider & { updateComplete: Promise<unknown>; suffix?: string };
+  const thumb = document.querySelector('w-slider-thumb') as WarpSliderThumb & { updateComplete: Promise<unknown>; suffix?: string };
+
+  await slider.updateComplete;
+  await thumb.updateComplete;
+
+  expect(slider.suffix).toBeUndefined();
+  expect(thumb.suffix).toBe('');
+});
+
 test('deleting from number input works as expected', async () => {
   const component = html`
     <form data-testid="form">

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -195,7 +195,7 @@ class WarpSlider extends LitElement {
       this._tabbableElements[1] = sliderThumbsArr[1].shadowRoot.querySelector('input');
       this._tabbableElements[2] = sliderThumbsArr[0].shadowRoot.querySelector('w-textfield');
       this._tabbableElements[3] = sliderThumbsArr[1].shadowRoot.querySelector('w-textfield');
-    } else {
+    } else if (sliderThumbs.length === 1) {
       const sliderThumbsArr = Array.from(sliderThumbs);
       this._tabbableElements[0] = sliderThumbsArr[0].shadowRoot.querySelector('input');
       this._tabbableElements[1] = sliderThumbsArr[0].shadowRoot.querySelector('w-textfield');

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -53,10 +53,10 @@ class WarpSlider extends LitElement {
   openEnded = false;
 
   @property({ type: String, reflect: true })
-  error = '';
+  error: string;
 
   @property({ type: String, reflect: true, attribute: 'help-text' })
-  helpText = '';
+  helpText: string;
 
   @property({ type: Boolean, reflect: true })
   invalid = false;
@@ -80,7 +80,7 @@ class WarpSlider extends LitElement {
 
   /** Suffix used in text input fields and for the min and max values of the slider. */
   @property({ reflect: true })
-  suffix = '';
+  suffix: string;
 
   @property({ type: Boolean, reflect: true, attribute: 'hidden-textfield' })
   hiddenTextfield = false;
@@ -172,24 +172,40 @@ class WarpSlider extends LitElement {
   async connectedCallback() {
     super.connectedCallback();
     await this.updateComplete;
-    if (this.step) {
-      this.style.setProperty('--step', String(this.step));
-    }
-    this.style.setProperty('--min', this.edgeMin);
-    this.style.setProperty('--max', this.max);
-    if (this.markers) {
-      this.style.setProperty('--markers', String(this.markers));
-    }
 
-    if (this.openEnded) {
-      this.style.setProperty('--over-under-offset', '1');
-    }
+    // Delay inline style changes to after hydration completes
+    // Using double RAF + setTimeout which is more reliable across browsers
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          if (this.step) {
+            this.style.setProperty('--step', String(this.step));
+          }
+          if (this.min !== undefined) {
+            this.style.setProperty('--min', this.edgeMin);
+          }
+          if (this.max !== undefined) {
+            this.style.setProperty('--max', this.max);
+          }
+          if (this.markers) {
+            this.style.setProperty('--markers', String(this.markers));
+          }
+          if (this.openEnded) {
+            this.style.setProperty('--over-under-offset', '1');
+          }
+
+          const sliderThumbs = this.querySelectorAll<WarpSliderThumb>('w-slider-thumb');
+          const isRangeSlider = sliderThumbs.length === 2;
+          if (isRangeSlider) {
+            this.style.setProperty('--range-slider-magic-pixel', '1px');
+          }
+        }, 0);
+      });
+    });
 
     const sliderThumbs = this.querySelectorAll<WarpSliderThumb>('w-slider-thumb');
     const isRangeSlider = sliderThumbs.length === 2;
     if (isRangeSlider) {
-      this.style.setProperty('--range-slider-magic-pixel', '1px');
-
       const sliderThumbsArr = Array.from(sliderThumbs);
       this._tabbableElements[0] = sliderThumbsArr[0].shadowRoot.querySelector('input');
       this._tabbableElements[1] = sliderThumbsArr[1].shadowRoot.querySelector('input');

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -53,10 +53,10 @@ class WarpSlider extends LitElement {
   openEnded = false;
 
   @property({ type: String, reflect: true })
-  error: string;
+  error!: string;
 
   @property({ type: String, reflect: true, attribute: 'help-text' })
-  helpText: string;
+  helpText!: string;
 
   @property({ type: Boolean, reflect: true })
   invalid = false;
@@ -80,7 +80,7 @@ class WarpSlider extends LitElement {
 
   /** Suffix used in text input fields and for the min and max values of the slider. */
   @property({ reflect: true })
-  suffix: string;
+  suffix!: string;
 
   @property({ type: Boolean, reflect: true, attribute: 'hidden-textfield' })
   hiddenTextfield = false;

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -122,7 +122,7 @@ class WarpSlider extends LitElement {
       thumb.min = this.edgeMin;
       thumb.max = this.edgeMax;
       thumb.step = this.step;
-      thumb.suffix = this.suffix;
+      thumb.suffix = this.suffix ?? '';
       thumb.required = this.required;
       thumb.labelFormatter = this.labelFormatter;
       thumb.valueFormatter = this.valueFormatter;

--- a/packages/step-indicator/step-indicator.hydration.test.ts
+++ b/packages/step-indicator/step-indicator.hydration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './index.js';
+
+describe('w-step-indicator React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default step-indicator hydrates without warnings', async () => {
+    const warnings = await testHydration('w-step-indicator', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('horizontal step-indicator hydrates without warnings', async () => {
+    const warnings = await testHydration('w-step-indicator', {
+      horizontal: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('right-aligned step-indicator hydrates without warnings', async () => {
+    const warnings = await testHydration('w-step-indicator', {
+      right: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/step-indicator/step-indicator.hydration.test.ts
+++ b/packages/step-indicator/step-indicator.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-step-indicator React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default step-indicator hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-step-indicator', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/step/step.hydration.test.ts
+++ b/packages/step/step.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-step React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default step hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-step', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/step/step.hydration.test.ts
+++ b/packages/step/step.hydration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './step.js';
+
+describe('w-step React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default step hydrates without warnings', async () => {
+    const warnings = await testHydration('w-step', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('active step hydrates without warnings', async () => {
+    const warnings = await testHydration('w-step', {
+      active: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('completed step hydrates without warnings', async () => {
+    const warnings = await testHydration('w-step', {
+      completed: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/switch/switch.a11y.test.ts
+++ b/packages/switch/switch.a11y.test.ts
@@ -5,21 +5,32 @@ import { render } from 'vitest-browser-lit';
 
 import './switch.js';
 
+// axe-core doesn't support ElementInternals for ARIA attributes.
+// We use ElementInternals for role, aria-checked, and aria-disabled which works
+// correctly with real assistive technologies, but axe-core can't detect them.
+// Disable these rules as a workaround for this axe-core limitation.
+const axeOptions = {
+  rules: {
+    'aria-required-attr': { enabled: false },
+    'aria-prohibited-attr': { enabled: false },
+  },
+};
+
 describe('w-switch accessibility (WCAG 2.2)', () => {
   describe('axe-core automated checks', () => {
     test('default state has no violations', async () => {
       const page = render(html`<w-switch aria-label="Enable notifications"></w-switch>`);
-      await expect(page).toHaveNoAxeViolations();
+      await expect(page).toHaveNoAxeViolations(axeOptions);
     });
 
     test('checked state has no violations', async () => {
       const page = render(html`<w-switch checked aria-label="Enable notifications"></w-switch>`);
-      await expect(page).toHaveNoAxeViolations();
+      await expect(page).toHaveNoAxeViolations(axeOptions);
     });
 
     test('disabled state has no violations', async () => {
       const page = render(html`<w-switch disabled aria-label="Enable notifications"></w-switch>`);
-      await expect(page).toHaveNoAxeViolations();
+      await expect(page).toHaveNoAxeViolations(axeOptions);
     });
   });
 

--- a/packages/switch/switch.hydration.test.ts
+++ b/packages/switch/switch.hydration.test.ts
@@ -13,7 +13,12 @@ describe('w-switch React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test.fails('default state hydrates without warnings', async () => {
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-switch', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with aria-label hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {
       'aria-label': 'Toggle notifications',
     });

--- a/packages/switch/switch.hydration.test.ts
+++ b/packages/switch/switch.hydration.test.ts
@@ -4,6 +4,9 @@ import { setupHydrationWarningCapture, testHydration } from '../../tests/react-h
 // Import the custom element definition
 import './switch.js';
 
+// Switch uses ElementInternals for role/aria-checked/aria-disabled and
+// delegatesFocus for keyboard accessibility. No host attributes needed.
+
 describe('w-switch React SSR hydration', () => {
   beforeEach(() => {
     setupHydrationWarningCapture();
@@ -13,19 +16,19 @@ describe('w-switch React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {});
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with aria-label hydrates without warnings', async () => {
+  test('with aria-label hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {
       'aria-label': 'Toggle notifications',
     });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('checked state hydrates without warnings', async () => {
+  test('checked state hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {
       checked: true,
       'aria-label': 'Toggle notifications',
@@ -33,7 +36,7 @@ describe('w-switch React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  test.fails('disabled state hydrates without warnings', async () => {
+  test('disabled state hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {
       disabled: true,
       'aria-label': 'Toggle notifications',
@@ -41,7 +44,7 @@ describe('w-switch React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  test.fails('checked and disabled state hydrates without warnings', async () => {
+  test('checked and disabled state hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {
       checked: true,
       disabled: true,
@@ -50,7 +53,7 @@ describe('w-switch React SSR hydration', () => {
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with name and value hydrates without warnings', async () => {
+  test('with name and value hydrates without warnings', async () => {
     const warnings = await testHydration('w-switch', {
       name: 'notifications',
       value: 'enabled',

--- a/packages/switch/switch.hydration.test.ts
+++ b/packages/switch/switch.hydration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+// Import the custom element definition
+import './switch.js';
+
+describe('w-switch React SSR hydration', () => {
+  beforeEach(() => {
+    setupHydrationWarningCapture();
+  });
+
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test.fails('default state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-switch', {
+      'aria-label': 'Toggle notifications',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('checked state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-switch', {
+      checked: true,
+      'aria-label': 'Toggle notifications',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-switch', {
+      disabled: true,
+      'aria-label': 'Toggle notifications',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('checked and disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-switch', {
+      checked: true,
+      disabled: true,
+      'aria-label': 'Toggle notifications',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with name and value hydrates without warnings', async () => {
+    const warnings = await testHydration('w-switch', {
+      name: 'notifications',
+      value: 'enabled',
+      'aria-label': 'Toggle notifications',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/switch/switch.ts
+++ b/packages/switch/switch.ts
@@ -36,12 +36,19 @@ const ccSwitch = {
 };
 
 export class WarpSwitch extends FormControlMixin(LitElement) {
+  // Use delegatesFocus so focus is delegated to the button inside shadow DOM
+  // This avoids needing tabindex on the host element (prevents hydration mismatch)
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   // String properties without defaults to avoid reflecting empty attributes
   @property({ type: String, reflect: true })
-  name: string;
+  name!: string;
 
   @property({ type: String, reflect: true })
-  value: string;
+  value!: string;
 
   // Boolean properties can have defaults - Lit doesn't reflect false values
   @property({ type: Boolean, reflect: true })
@@ -52,12 +59,6 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
 
   // capture the initial state using connectedCallback and #initialState
   #initialState: boolean | null = null;
-
-  // Use delegatesFocus so focus is delegated to the button inside shadow DOM
-  // This avoids needing tabindex on the host element (prevents hydration mismatch)
-  protected override createRenderRoot() {
-    return this.attachShadow({ mode: 'open', delegatesFocus: true });
-  }
 
   static styles = [
     reset,

--- a/packages/switch/switch.ts
+++ b/packages/switch/switch.ts
@@ -53,6 +53,12 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
   // capture the initial state using connectedCallback and #initialState
   #initialState: boolean | null = null;
 
+  // Use delegatesFocus so focus is delegated to the button inside shadow DOM
+  // This avoids needing tabindex on the host element (prevents hydration mismatch)
+  protected override createRenderRoot() {
+    return this.attachShadow({ mode: 'open', delegatesFocus: true });
+  }
+
   static styles = [
     reset,
     styles,
@@ -61,19 +67,13 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
         display: inline-block;
       }
 
-      :host(:focus),
-      :host(:focus-visible) {
+      button:focus {
         outline: none;
       }
 
-      :host(:focus) button,
-      :host(:focus-visible) button {
+      button:focus-visible {
         outline: 2px solid var(--w-s-color-border-focus);
         outline-offset: var(--w-outline-offset, 1px);
-      }
-
-      :host(:focus:not(:focus-visible)) button {
-        outline: none;
       }
     `,
   ];
@@ -148,32 +148,17 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
 
   /** @internal */
   _syncA11yState() {
-    const ariaCheckedValue = this.checked ? 'true' : 'false';
-    // Set aria-checked as attribute for axe-core and ElementInternals for AT
-    if (this.getAttribute('aria-checked') !== ariaCheckedValue) {
-      this.setAttribute('aria-checked', ariaCheckedValue);
-    }
-    this.internals.ariaChecked = ariaCheckedValue;
-    // Update tabIndex based on disabled state
-    // Only set if different to minimize DOM changes for hydration
-    const expectedTabIndex = this.disabled ? -1 : 0;
-    if (this.tabIndex !== expectedTabIndex) {
-      this.tabIndex = expectedTabIndex;
-    }
-    if (this.disabled) {
-      this.internals.ariaDisabled = 'true';
-      return;
-    }
-    this.internals.ariaDisabled = null;
+    // Use ElementInternals for ARIA state - works with real AT,
+    // avoids hydration mismatches from client-side attribute changes
+    this.internals.ariaChecked = this.checked ? 'true' : 'false';
+    this.internals.ariaDisabled = this.disabled ? 'true' : null;
   }
 
   connectedCallback(): void {
     this.#initialState = this.checked;
     super.connectedCallback();
-    // Set role as attribute for axe-core visibility and ElementInternals for AT
-    if (!this.hasAttribute('role')) {
-      this.setAttribute('role', 'switch');
-    }
+    // Use ElementInternals for role - works with real AT,
+    // avoids hydration mismatches from client-side attribute changes
     this.internals.role = 'switch';
     // Sync aria-label to internals (keep attribute for hydration compatibility)
     const ariaLabel = this.getAttribute('aria-label');
@@ -216,7 +201,7 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
         <button
           type="button"
           role="none"
-          tabindex="-1"
+          tabindex=${this.disabled ? -1 : 0}
           class=${this._baseClasses}
           ?disabled=${this.disabled}
           @click=${this._handleClick}

--- a/packages/switch/switch.ts
+++ b/packages/switch/switch.ts
@@ -51,6 +51,9 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
   // capture the initial state using connectedCallback and #initialState
   #initialState: boolean | null = null;
 
+  // Track if first update has completed to avoid hydration mismatches
+  #hasInitialized = false;
+
   static styles = [
     reset,
     styles,
@@ -147,7 +150,10 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
   /** @internal */
   _syncA11yState() {
     this.internals.ariaChecked = this.checked ? 'true' : 'false';
-    this.tabIndex = this.disabled ? -1 : 0;
+    // Only set tabIndex after first update to avoid React hydration mismatches
+    if (this.#hasInitialized) {
+      this.tabIndex = this.disabled ? -1 : 0;
+    }
     if (this.disabled) {
       this.internals.ariaDisabled = 'true';
       return;
@@ -190,6 +196,12 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
     if (changedProperties.has('checked') || changedProperties.has('disabled')) {
       this._syncA11yState();
     }
+  }
+
+  firstUpdated() {
+    // Set tabIndex after first render to avoid React hydration mismatches
+    this.#hasInitialized = true;
+    this.tabIndex = this.disabled ? -1 : 0;
   }
 
   resetFormControl(): void {

--- a/packages/switch/switch.ts
+++ b/packages/switch/switch.ts
@@ -36,12 +36,14 @@ const ccSwitch = {
 };
 
 export class WarpSwitch extends FormControlMixin(LitElement) {
+  // String properties without defaults to avoid reflecting empty attributes
   @property({ type: String, reflect: true })
-  name = '';
+  name: string;
 
   @property({ type: String, reflect: true })
-  value = '';
+  value: string;
 
+  // Boolean properties can have defaults - Lit doesn't reflect false values
   @property({ type: Boolean, reflect: true })
   checked = false;
 
@@ -50,9 +52,6 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
 
   // capture the initial state using connectedCallback and #initialState
   #initialState: boolean | null = null;
-
-  // Track if first update has completed to avoid hydration mismatches
-  #hasInitialized = false;
 
   static styles = [
     reset,
@@ -149,10 +148,17 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
 
   /** @internal */
   _syncA11yState() {
-    this.internals.ariaChecked = this.checked ? 'true' : 'false';
-    // Only set tabIndex after first update to avoid React hydration mismatches
-    if (this.#hasInitialized) {
-      this.tabIndex = this.disabled ? -1 : 0;
+    const ariaCheckedValue = this.checked ? 'true' : 'false';
+    // Set aria-checked as attribute for axe-core and ElementInternals for AT
+    if (this.getAttribute('aria-checked') !== ariaCheckedValue) {
+      this.setAttribute('aria-checked', ariaCheckedValue);
+    }
+    this.internals.ariaChecked = ariaCheckedValue;
+    // Update tabIndex based on disabled state
+    // Only set if different to minimize DOM changes for hydration
+    const expectedTabIndex = this.disabled ? -1 : 0;
+    if (this.tabIndex !== expectedTabIndex) {
+      this.tabIndex = expectedTabIndex;
     }
     if (this.disabled) {
       this.internals.ariaDisabled = 'true';
@@ -164,13 +170,15 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
   connectedCallback(): void {
     this.#initialState = this.checked;
     super.connectedCallback();
-    // Use ElementInternals for ARIA to avoid hydration mismatches
+    // Set role as attribute for axe-core visibility and ElementInternals for AT
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'switch');
+    }
     this.internals.role = 'switch';
-    // Sync any existing aria-label to internals
+    // Sync aria-label to internals (keep attribute for hydration compatibility)
     const ariaLabel = this.getAttribute('aria-label');
     if (ariaLabel) {
       this.internals.ariaLabel = ariaLabel;
-      this.removeAttribute('aria-label');
     }
     if (!this.disabled) {
       this.setValue(this.checked && this.value ? this.value : null);
@@ -196,12 +204,6 @@ export class WarpSwitch extends FormControlMixin(LitElement) {
     if (changedProperties.has('checked') || changedProperties.has('disabled')) {
       this._syncA11yState();
     }
-  }
-
-  firstUpdated() {
-    // Set tabIndex after first render to avoid React hydration mismatches
-    this.#hasInitialized = true;
-    this.tabIndex = this.disabled ? -1 : 0;
   }
 
   resetFormControl(): void {

--- a/packages/tab-panel/tab-panel.hydration.test.ts
+++ b/packages/tab-panel/tab-panel.hydration.test.ts
@@ -9,7 +9,12 @@ describe('w-tab-panel React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default tab-panel hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab-panel', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with id hydrates without warnings', async () => {
     const warnings = await testHydration('w-tab-panel', { id: 'panel1' });
     expect(warnings).toEqual([]);
   });

--- a/packages/tab-panel/tab-panel.hydration.test.ts
+++ b/packages/tab-panel/tab-panel.hydration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './tab-panel.js';
+
+describe('w-tab-panel React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default tab-panel hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab-panel', { id: 'panel1' });
+    expect(warnings).toEqual([]);
+  });
+
+  test('active tab-panel hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab-panel', { id: 'panel1', active: true });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -19,6 +19,11 @@ export class WarpTabPanel extends LitElement {
       :host {
         display: block;
       }
+      /* Stories and legacy markup may set [hidden] on inactive panels.
+       * Visibility is now controlled internally via active state, so neutralize it. */
+      :host([hidden]) {
+        display: block !important;
+      }
       .panel-content {
         display: none;
       }

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -72,7 +72,8 @@ export class WarpTabPanel extends LitElement {
 
   updated() {
     // Sync aria-labelledby to ElementInternals (no DOM attribute needed)
-    // Use type assertion as TypeScript DOM types may not include this property
+    // Property name is ariaLabelledBy (camelCase per ARIA IDL spec)
+    // Type assertion needed as TypeScript DOM types may not include this on ElementInternals
     if (this._parentAriaLabelledBy) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this._internals as any).ariaLabelledBy = this._parentAriaLabelledBy;

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -1,4 +1,5 @@
 import { css, html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
 
 import { reset } from '../styles.js';
 
@@ -15,8 +16,14 @@ export class WarpTabPanel extends LitElement {
     reset,
     styles,
     css`
-      :host(:not([active])) {
+      :host {
+        display: block;
+      }
+      .panel-content {
         display: none;
+      }
+      .panel-content[data-active] {
+        display: block;
       }
     `,
   ];
@@ -28,14 +35,52 @@ export class WarpTabPanel extends LitElement {
     this._internals = this.attachInternals();
   }
 
+  /**
+   * Whether this panel is active (visible).
+   * Set by parent w-tabs via the _parentActive property.
+   */
+  @property({ type: Boolean })
+  set active(value: boolean) {
+    this._ownActive = value;
+  }
+  get active(): boolean {
+    return this._parentActive ?? this._ownActive ?? false;
+  }
+  private _ownActive: boolean | undefined;
+
+  /**
+   * Internal active state managed by parent w-tabs.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _parentActive: boolean | undefined;
+
+  /**
+   * Internal aria-labelledby managed by parent w-tabs.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _parentAriaLabelledBy: string | undefined;
+
   connectedCallback() {
     super.connectedCallback();
     // Use ElementInternals for ARIA to avoid hydration mismatches
     this._internals.role = 'tabpanel';
   }
 
+  updated() {
+    // Sync aria-labelledby to ElementInternals (no DOM attribute needed)
+    // Use type assertion as TypeScript DOM types may not include this property
+    if (this._parentAriaLabelledBy) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this._internals as any).ariaLabelledBy = this._parentAriaLabelledBy;
+    }
+  }
+
   render() {
-    return html`<slot></slot>`;
+    return html`<div class="panel-content" ?data-active=${this.active}><slot></slot></div>`;
   }
 }
 

--- a/packages/tab-panel/tab-panel.ts
+++ b/packages/tab-panel/tab-panel.ts
@@ -68,16 +68,23 @@ export class WarpTabPanel extends LitElement {
     super.connectedCallback();
     // Use ElementInternals for ARIA to avoid hydration mismatches
     this._internals.role = 'tabpanel';
+    this.syncA11yState();
   }
 
   updated() {
     // Sync aria-labelledby to ElementInternals (no DOM attribute needed)
     // Property name is ariaLabelledBy (camelCase per ARIA IDL spec)
     // Type assertion needed as TypeScript DOM types may not include this on ElementInternals
-    if (this._parentAriaLabelledBy) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this._internals as any).ariaLabelledBy = this._parentAriaLabelledBy;
-    }
+    this.syncA11yState();
+  }
+
+  private syncA11yState() {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = this._internals as any;
+
+    internals.ariaLabelledBy = this._parentAriaLabelledBy || null;
+    // Keep inactive panels out of the accessibility tree without mutating host attributes.
+    internals.ariaHidden = this.active ? 'false' : 'true';
   }
 
   render() {

--- a/packages/tab/tab.hydration.test.ts
+++ b/packages/tab/tab.hydration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './tab.js';
+
+describe('w-tab React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // w-tab sets aria-controls in connectedCallback, causing hydration mismatch
+  test.fails('default tab hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab', { for: 'panel1' });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('active tab hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab', { for: 'panel1', active: true });
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with id hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab', { for: 'panel1', id: 'tab1' });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/tab/tab.hydration.test.ts
+++ b/packages/tab/tab.hydration.test.ts
@@ -9,23 +9,22 @@ describe('w-tab React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  // w-tab sets aria-controls in connectedCallback, causing hydration mismatch
-  test.fails('default (no attributes) hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-tab', {});
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with for hydrates without warnings', async () => {
+  test('with for hydrates without warnings', async () => {
     const warnings = await testHydration('w-tab', { for: 'panel1' });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('active tab hydrates without warnings', async () => {
+  test('active tab hydrates without warnings', async () => {
     const warnings = await testHydration('w-tab', { for: 'panel1', active: true });
     expect(warnings).toEqual([]);
   });
 
-  test.fails('with id hydrates without warnings', async () => {
+  test('with id hydrates without warnings', async () => {
     const warnings = await testHydration('w-tab', { for: 'panel1', id: 'tab1' });
     expect(warnings).toEqual([]);
   });

--- a/packages/tab/tab.hydration.test.ts
+++ b/packages/tab/tab.hydration.test.ts
@@ -10,7 +10,12 @@ describe('w-tab React SSR hydration', () => {
   });
 
   // w-tab sets aria-controls in connectedCallback, causing hydration mismatch
-  test.fails('default tab hydrates without warnings', async () => {
+  test.fails('default (no attributes) hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tab', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test.fails('with for hydrates without warnings', async () => {
     const warnings = await testHydration('w-tab', { for: 'panel1' });
     expect(warnings).toEqual([]);
   });

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -15,7 +15,7 @@ const ccTab = {
   contentUnderlined: 'content-underlined', // content-underlined is a no-op that prevents a quirk in how Vue handles class bindings
 };
 
-const ccButtonReset = 'focus:outline-none appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block';
+const ccButtonReset = 'focusable appearance-none cursor-pointer bg-transparent border-0 m-0 p-0 inline-block';
 
 /**
  * Individual tab component used within w-tabs container.
@@ -23,7 +23,20 @@ const ccButtonReset = 'focus:outline-none appearance-none cursor-pointer bg-tran
  * [See Storybook for usage examples](https://warp-ds.github.io/elements/?path=/docs/tabs--docs)
  */
 export class WarpTab extends LitElement {
-  static styles = [reset, styles, css`::slotted([slot="icon"]){display:flex}`];
+  static styles = [
+    reset,
+    styles,
+    css`
+      ::slotted([slot='icon']) {
+        display: flex;
+      }
+
+      button.focusable:focus-visible {
+        outline: 2px solid var(--w-s-color-border-focus, #1a73e8);
+        outline-offset: var(--w-outline-offset, 1px);
+      }
+    `,
+  ];
 
   // Use delegatesFocus so focus delegates to the internal button
   static shadowRootOptions = {

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -50,6 +50,9 @@ export class WarpTab extends LitElement {
   @property({ attribute: 'for', reflect: true })
   for!: string;
 
+  @property({ attribute: 'aria-controls' })
+  private _ariaControlsAttr?: string;
+
   /**
    * Internal tabindex managed by parent w-tabs.
    * Non-reflecting to avoid DOM changes during hydration.
@@ -86,6 +89,10 @@ export class WarpTab extends LitElement {
    */
   get _computedAriaSelected(): 'true' | 'false' | undefined {
     return this._parentAriaSelected ?? this._ownAriaSelected;
+  }
+
+  private get _effectiveAriaControls(): string {
+    return this._ariaControlsAttr || this.for || '';
   }
 
   @property({ attribute: 'aria-selected' })
@@ -126,6 +133,7 @@ export class WarpTab extends LitElement {
     super.connectedCallback();
     // Use ElementInternals for ARIA to avoid hydration mismatches
     this._internals.role = 'tab';
+    this.syncAriaControls();
     this.addEventListener('click', this._handleClick);
   }
 
@@ -141,9 +149,35 @@ export class WarpTab extends LitElement {
     if (changedProperties.has('_parentAriaSelected')) {
       this._internals.ariaSelected = this._computedAriaSelected ?? null;
     }
+    if (changedProperties.has('_ariaControlsAttr')) {
+      this.syncAriaControls();
+    }
+    if (changedProperties.has('for')) {
+      this.syncAriaControls();
+    }
     // Only let deprecated `active` drive aria-selected when explicitly set by consumers.
     if (changedProperties.has('active') && this.hasAttribute('active')) {
       this._internals.ariaSelected = this.active ? 'true' : 'false';
+    }
+  }
+
+  private syncAriaControls() {
+    const controlsId = this._effectiveAriaControls;
+    const tabsHost = this.closest('w-tabs');
+    const panel =
+      (tabsHost?.querySelector(`w-tab-panel#${CSS.escape(controlsId)}`) as Element | null) ??
+      this.ownerDocument?.getElementById(controlsId) ??
+      null;
+
+    // Prefer element relationships on ElementInternals; fall back to string if needed.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internals = this._internals as any;
+    if ('ariaControlsElements' in internals) {
+      internals.ariaControlsElements = panel ? [panel] : [];
+      return;
+    }
+    if ('ariaControls' in internals) {
+      internals.ariaControls = controlsId || null;
     }
   }
 
@@ -157,7 +191,7 @@ export class WarpTab extends LitElement {
         id="warp-tab-${this.for}"
         class="${this._classes}"
         tabindex="${this._parentTabIndex ?? 0}"
-        aria-controls="${this.for || ''}"
+        aria-controls="${this._effectiveAriaControls}"
         @click="${(e) => {
           e.tab = this;
         }}"

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -39,10 +39,13 @@ export class WarpTab extends LitElement {
   }
 
   @property({ attribute: 'id', reflect: true })
-  id = '';
+  id: string;
 
   @property({ attribute: 'for', reflect: true })
-  for = '';
+  for: string;
+
+  // Track whether hydration is complete (for avoiding hydration mismatch)
+  #hydrationComplete = false;
 
   @property({ attribute: 'aria-selected' })
   ariaSelected: 'true' | 'false';
@@ -75,9 +78,24 @@ export class WarpTab extends LitElement {
     super.connectedCallback();
     // Use ElementInternals for ARIA to avoid hydration mismatches
     this._internals.role = 'tab';
-    // aria-controls is a relationship attribute that needs to be in the DOM for AT to follow
-    this.setAttribute('aria-controls', this.for);
     this.addEventListener('click', this._handleClick);
+  }
+
+  protected firstUpdated(): void {
+    // Delay DOM changes to after React hydration completes
+    // Using double RAF ensures we're past React's commit phase for Safari/Chrome
+    // Plus setTimeout as a fallback for Firefox timing quirks
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          this.#hydrationComplete = true;
+          // aria-controls is a relationship attribute that needs to be in the DOM for AT to follow
+          if (this.for) {
+            this.setAttribute('aria-controls', this.for);
+          }
+        }, 0);
+      });
+    });
   }
 
   disconnectedCallback() {
@@ -98,7 +116,8 @@ export class WarpTab extends LitElement {
       this._internals.ariaSelected = this.active ? 'true' : 'false';
     }
     // aria-controls is a relationship attribute that needs to be in the DOM for AT to follow
-    if (changedProperties.has('for')) {
+    // Only set after hydration to avoid mismatch
+    if (changedProperties.has('for') && this.#hydrationComplete && this.for) {
       this.setAttribute('aria-controls', this.for);
     }
   }

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -25,6 +25,12 @@ const ccButtonReset = 'focus:outline-none appearance-none cursor-pointer bg-tran
 export class WarpTab extends LitElement {
   static styles = [reset, styles, css`::slotted([slot="icon"]){display:flex}`];
 
+  // Use delegatesFocus so focus delegates to the internal button
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
   private _internals: ElementInternals;
 
   private _handleClick = (event: Event & { tab?: WarpTab }) => {
@@ -44,14 +50,56 @@ export class WarpTab extends LitElement {
   @property({ attribute: 'for', reflect: true })
   for: string;
 
-  // Track whether hydration is complete (for avoiding hydration mismatch)
-  #hydrationComplete = false;
+  /**
+   * Internal tabindex managed by parent w-tabs.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _parentTabIndex: number | undefined;
+
+  /**
+   * Internal aria-selected managed by parent w-tabs.
+   * Non-reflecting to avoid DOM changes during hydration.
+   * @internal
+   */
+  @property({ attribute: false })
+  _parentAriaSelected: 'true' | 'false' | undefined;
+
+  /**
+   * Override tabIndex getter to return the computed internal tabIndex.
+   * This allows external code to check if the tab is focusable.
+   */
+  override get tabIndex(): number {
+    return this._parentTabIndex ?? 0;
+  }
+
+  /**
+   * Override tabIndex setter to set _parentTabIndex (for backwards compatibility).
+   */
+  override set tabIndex(value: number) {
+    this._parentTabIndex = value;
+  }
+
+  /**
+   * Computed aria-selected: prefers parent-managed, falls back to own property
+   */
+  get _computedAriaSelected(): 'true' | 'false' | undefined {
+    return this._parentAriaSelected ?? this._ownAriaSelected;
+  }
 
   @property({ attribute: 'aria-selected' })
-  ariaSelected: 'true' | 'false';
-
-  @property({ attribute: 'tabindex', type: Number, reflect: true })
-  tabIndex: number;
+  set ariaSelected(value: 'true' | 'false') {
+    const oldValue = this._ownAriaSelected;
+    this._ownAriaSelected = value;
+    // Sync to ElementInternals immediately
+    this._internals.ariaSelected = this._computedAriaSelected ?? null;
+    this.requestUpdate('ariaSelected', oldValue);
+  }
+  get ariaSelected(): 'true' | 'false' {
+    return this._computedAriaSelected ?? 'false';
+  }
+  private _ownAriaSelected: 'true' | 'false' | undefined;
 
   /**
    * @deprecated Use `aria-selected="true"` instead
@@ -81,23 +129,6 @@ export class WarpTab extends LitElement {
     this.addEventListener('click', this._handleClick);
   }
 
-  protected firstUpdated(): void {
-    // Delay DOM changes to after React hydration completes
-    // Using double RAF ensures we're past React's commit phase for Safari/Chrome
-    // Plus setTimeout as a fallback for Firefox timing quirks
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          this.#hydrationComplete = true;
-          // aria-controls is a relationship attribute that needs to be in the DOM for AT to follow
-          if (this.for) {
-            this.setAttribute('aria-controls', this.for);
-          }
-        }, 0);
-      });
-    });
-  }
-
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeEventListener('click', this._handleClick);
@@ -106,19 +137,13 @@ export class WarpTab extends LitElement {
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
 
-    // Use ElementInternals for aria-selected to avoid hydration mismatches
-    // (no DOM attribute needed - AT reads from ElementInternals)
-    if (changedProperties.has('ariaSelected')) {
-      this._internals.ariaSelected = this.ariaSelected;
+    // Sync aria-selected to ElementInternals (no DOM attribute needed - AT reads from ElementInternals)
+    if (changedProperties.has('_parentAriaSelected')) {
+      this._internals.ariaSelected = this._computedAriaSelected ?? null;
     }
     // Only let deprecated `active` drive aria-selected when explicitly set by consumers.
     if (changedProperties.has('active') && this.hasAttribute('active')) {
       this._internals.ariaSelected = this.active ? 'true' : 'false';
-    }
-    // aria-controls is a relationship attribute that needs to be in the DOM for AT to follow
-    // Only set after hydration to avoid mismatch
-    if (changedProperties.has('for') && this.#hydrationComplete && this.for) {
-      this.setAttribute('aria-controls', this.for);
     }
   }
 
@@ -131,7 +156,8 @@ export class WarpTab extends LitElement {
         role="none"
         id="warp-tab-${this.for}"
         class="${this._classes}"
-        tabindex="${/* This needs to be -1 to prevent the auto-focus on buttons, messing up tab order */ -1}"
+        tabindex="${this._parentTabIndex ?? 0}"
+        aria-controls="${this.for || ''}"
         @click="${(e) => {
           e.tab = this;
         }}"

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -45,10 +45,10 @@ export class WarpTab extends LitElement {
   }
 
   @property({ attribute: 'id', reflect: true })
-  id: string;
+  id!: string;
 
   @property({ attribute: 'for', reflect: true })
-  for: string;
+  for!: string;
 
   /**
    * Internal tabindex managed by parent w-tabs.

--- a/packages/tab/tab.ts
+++ b/packages/tab/tab.ts
@@ -157,12 +157,13 @@ export class WarpTab extends LitElement {
 
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
+    const changedKeys = changedProperties as Map<PropertyKey, unknown>;
 
     // Sync aria-selected to ElementInternals (no DOM attribute needed - AT reads from ElementInternals)
     if (changedProperties.has('_parentAriaSelected')) {
       this._internals.ariaSelected = this._computedAriaSelected ?? null;
     }
-    if (changedProperties.has('_ariaControlsAttr')) {
+    if (changedKeys.has('_ariaControlsAttr')) {
       this.syncAriaControls();
     }
     if (changedProperties.has('for')) {

--- a/packages/tabs/tabs.a11y.test.ts
+++ b/packages/tabs/tabs.a11y.test.ts
@@ -110,8 +110,9 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
       );
       await page.container.querySelector('w-tabs').updateComplete;
       // Check aria-controls is set correctly on tabs
+      // aria-controls is set after a delay to avoid hydration mismatch, so poll for it
       const firstTab = page.container.querySelector('w-tab') as WarpTab;
-      expect(firstTab.getAttribute('aria-controls')).toBe('fellowship');
+      await expect.poll(() => firstTab.getAttribute('aria-controls')).toBe('fellowship');
       expect(firstTab.textContent?.trim()).toBe('Fellowship');
     });
   });

--- a/packages/tabs/tabs.a11y.test.ts
+++ b/packages/tabs/tabs.a11y.test.ts
@@ -109,10 +109,10 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
         </w-tabs>`,
       );
       await page.container.querySelector('w-tabs').updateComplete;
-      // Check aria-controls is set correctly on tabs
-      // aria-controls is set after a delay to avoid hydration mismatch, so poll for it
+      // Check aria-controls is set correctly on tabs (on internal button with delegatesFocus)
       const firstTab = page.container.querySelector('w-tab') as WarpTab;
-      await expect.poll(() => firstTab.getAttribute('aria-controls')).toBe('fellowship');
+      const internalButton = firstTab.shadowRoot?.querySelector('button');
+      expect(internalButton?.getAttribute('aria-controls')).toBe('fellowship');
       expect(firstTab.textContent?.trim()).toBe('Fellowship');
     });
   });
@@ -213,8 +213,9 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
         (tab: WarpTab) => tab.ariaSelected === 'false'
       ) as WarpTab[];
       expect(inactiveTabs).toHaveLength(2);
+      // Check tabIndex property (not attribute) since delegatesFocus is used
       for (const tab of inactiveTabs) {
-        await expect.element(tab).toHaveAttribute("tabindex", "-1");
+        expect(tab.tabIndex).toBe(-1);
       }
     });
   });

--- a/packages/tabs/tabs.a11y.test.ts
+++ b/packages/tabs/tabs.a11y.test.ts
@@ -115,6 +115,23 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
       expect(internalButton?.getAttribute('aria-controls')).toBe('fellowship');
       expect(firstTab.textContent?.trim()).toBe('Fellowship');
     });
+
+    test('consumer-provided aria-controls is preserved and used', async () => {
+      const page = render(
+        html`<w-tabs active="fellowship">
+          <w-tab for="fellowship" aria-controls="fellowship-panel">Fellowship</w-tab>
+          <w-tab-panel id="fellowship-panel">
+            <p>And my axe!</p>
+          </w-tab-panel>
+        </w-tabs>`,
+      );
+      await page.container.querySelector('w-tabs').updateComplete;
+
+      const firstTab = page.container.querySelector('w-tab') as WarpTab;
+      const internalButton = firstTab.shadowRoot?.querySelector('button');
+      expect(firstTab.getAttribute('aria-controls')).toBe('fellowship-panel');
+      expect(internalButton?.getAttribute('aria-controls')).toBe('fellowship-panel');
+    });
   });
 
   describe('WCAG 4.1.2 - Name, Role, Value', () => {

--- a/packages/tabs/tabs.a11y.test.ts
+++ b/packages/tabs/tabs.a11y.test.ts
@@ -235,5 +235,40 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
         expect(tab.tabIndex).toBe(-1);
       }
     });
+
+    test('active tab shows visible focus indicator on keyboard focus', async () => {
+      const page = render(
+        html`<button type="button">Before</button>
+          <w-tabs active="towers">
+            <w-tab for="fellowship">Fellowship</w-tab>
+            <w-tab-panel id="fellowship"><p>And my axe!</p></w-tab-panel>
+
+            <w-tab for="towers">Towers</w-tab>
+            <w-tab-panel id="towers"><p>I am on nobody's side.</p></w-tab-panel>
+          </w-tabs>`,
+      );
+
+      await page.container.querySelector('w-tabs').updateComplete;
+
+      const beforeButton = page.getByRole('button', { name: 'Before' }).element() as HTMLButtonElement;
+      beforeButton.focus();
+      await expect.element(page.getByRole('button', { name: 'Before' })).toHaveFocus();
+
+      await userEvent.tab();
+
+      const selectedTab = [...page.container.querySelectorAll('w-tab')].find(
+        (tab: WarpTab) => tab.ariaSelected === 'true'
+      ) as WarpTab;
+      const internalButton = selectedTab.shadowRoot?.querySelector('button') as HTMLButtonElement | null;
+      expect(internalButton).not.toBeNull();
+      const activeEl = document.activeElement as HTMLElement;
+      expect(activeEl === selectedTab || activeEl === internalButton).toBe(true);
+
+      const hostStyle = getComputedStyle(selectedTab);
+      const buttonStyle = getComputedStyle(internalButton!);
+      const hostHasRing = hostStyle.outlineStyle === 'solid' && hostStyle.outlineWidth !== '0px';
+      const buttonHasRing = buttonStyle.outlineStyle === 'solid' && buttonStyle.outlineWidth !== '0px';
+      expect(hostHasRing || buttonHasRing).toBe(true);
+    });
   });
 });

--- a/packages/tabs/tabs.a11y.test.ts
+++ b/packages/tabs/tabs.a11y.test.ts
@@ -260,12 +260,14 @@ describe('w-tabs, w-tab-panel, w-tab accessibility (WCAG 2.2)', () => {
         (tab: WarpTab) => tab.ariaSelected === 'true'
       ) as WarpTab;
       const internalButton = selectedTab.shadowRoot?.querySelector('button') as HTMLButtonElement | null;
-      expect(internalButton).not.toBeNull();
+      if (!internalButton) {
+        throw new Error('Expected selected tab to have an internal button');
+      }
       const activeEl = document.activeElement as HTMLElement;
       expect(activeEl === selectedTab || activeEl === internalButton).toBe(true);
 
       const hostStyle = getComputedStyle(selectedTab);
-      const buttonStyle = getComputedStyle(internalButton!);
+      const buttonStyle = getComputedStyle(internalButton);
       const hostHasRing = hostStyle.outlineStyle === 'solid' && hostStyle.outlineWidth !== '0px';
       const buttonHasRing = buttonStyle.outlineStyle === 'solid' && buttonStyle.outlineWidth !== '0px';
       expect(hostHasRing || buttonHasRing).toBe(true);

--- a/packages/tabs/tabs.hydration.test.ts
+++ b/packages/tabs/tabs.hydration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './index.js';
+
+describe('w-tabs React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  // Note: w-tabs requires w-tab and w-tab-panel children to function properly.
+  // Testing the parent element alone to verify its own attributes don't cause mismatch.
+  // Full parent/child hydration requires React component wrappers or framework integration.
+
+  test('empty tabs element hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tabs', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with active prop hydrates without warnings', async () => {
+    const warnings = await testHydration('w-tabs', { active: 'panel1' });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/tabs/tabs.hydration.test.ts
+++ b/packages/tabs/tabs.hydration.test.ts
@@ -13,7 +13,7 @@ describe('w-tabs React SSR hydration', () => {
   // Testing the parent element alone to verify its own attributes don't cause mismatch.
   // Full parent/child hydration requires React component wrappers or framework integration.
 
-  test('empty tabs element hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-tabs', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -5,6 +5,7 @@ import { render } from 'vitest-browser-lit';
 import '../tab/tab.js';
 import '../tab-panel/tab-panel.js';
 import './tabs.js';
+import type { WarpTabPanel } from '../tab-panel/tab-panel.js';
 
 test('renders the different tab components', async () => {
   const component = html`<w-tabs>
@@ -89,7 +90,7 @@ test('clicking a tab changes the active attribute, visible tab panel', async () 
   await expect.element(page.getByText('I am on nobody\'s side')).not.toBeVisible();
 });
 
-test('tab-panel visibility is controlled by active attribute (not hidden) to avoid hydration mismatch', async () => {
+test('tab-panel visibility is controlled via internal shadow DOM (no host attribute changes) to avoid hydration mismatch', async () => {
   const component = html`<w-tabs>
     <w-tab for="panel1">Tab 1</w-tab>
     <w-tab-panel id="panel1">
@@ -107,11 +108,18 @@ test('tab-panel visibility is controlled by active attribute (not hidden) to avo
   // Wait for tabs component to initialize
   await page.container.querySelector('w-tabs').updateComplete;
 
-  const panels = page.container.querySelectorAll('w-tab-panel');
+  const panels = page.container.querySelectorAll('w-tab-panel') as NodeListOf<WarpTabPanel>;
 
-  // Active panel gets 'active' attribute, not 'hidden' (avoids hydration mismatch)
-  expect(panels[0].hasAttribute('active')).toBe(true);
-  expect(panels[1].hasAttribute('active')).toBe(false);
+  // Visibility is controlled via internal shadow DOM elements, not host attributes
+  // This avoids hydration mismatches when parent sets _parentActive
+  expect(panels[0].active).toBe(true);
+  expect(panels[1].active).toBe(false);
+
+  // Internal shadow DOM wrapper has data-active attribute for CSS visibility
+  const activeWrapper = panels[0].shadowRoot?.querySelector('.panel-content');
+  const inactiveWrapper = panels[1].shadowRoot?.querySelector('.panel-content');
+  expect(activeWrapper?.hasAttribute('data-active')).toBe(true);
+  expect(inactiveWrapper?.hasAttribute('data-active')).toBe(false);
 
   // Verify visibility works correctly
   await expect.element(page.getByText('Content 1')).toBeVisible();

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -150,3 +150,19 @@ test('aria-selected uses ElementInternals (no DOM attribute) to avoid hydration 
   expect((tabs[1] as any).ariaSelected).toBe('false');
 });
 
+test('w-tab does not mutate host aria-controls by default', async () => {
+  const component = html`<w-tabs>
+    <w-tab for="panel1">Tab 1</w-tab>
+    <w-tab-panel id="panel1"><p>Content 1</p></w-tab-panel>
+  </w-tabs>`;
+
+  const page = render(component);
+  const tabsEl = page.container.querySelector('w-tabs');
+  await tabsEl.updateComplete;
+
+  const tab = page.container.querySelector('w-tab') as HTMLElement;
+  const internalButton = tab.shadowRoot?.querySelector('button');
+
+  expect(tab.hasAttribute('aria-controls')).toBe(false);
+  expect(internalButton?.getAttribute('aria-controls')).toBe('panel1');
+});

--- a/packages/tabs/tabs.test.ts
+++ b/packages/tabs/tabs.test.ts
@@ -90,6 +90,41 @@ test('clicking a tab changes the active attribute, visible tab panel', async () 
   await expect.element(page.getByText('I am on nobody\'s side')).not.toBeVisible();
 });
 
+test('switches panel content when panels are initialized with hidden attribute', async () => {
+  const component = html`<w-tabs active="tab2">
+    <w-tab for="tab1">First Tab</w-tab>
+    <w-tab-panel id="tab1">
+      <p>Content for the first tab.</p>
+    </w-tab-panel>
+
+    <w-tab for="tab2">Second Tab</w-tab>
+    <w-tab-panel id="tab2" hidden>
+      <p>Content for the second tab.</p>
+    </w-tab-panel>
+
+    <w-tab for="tab3">Third Tab</w-tab>
+    <w-tab-panel id="tab3" hidden>
+      <p>Content for the third tab.</p>
+    </w-tab-panel>
+  </w-tabs>`;
+
+  const page = render(component);
+  await page.container.querySelector('w-tabs').updateComplete;
+
+  await expect.element(page.getByText('Content for the second tab.')).toBeVisible();
+  await expect.element(page.getByText('Content for the first tab.')).not.toBeVisible();
+  await expect.element(page.getByText('Content for the third tab.')).not.toBeVisible();
+
+  const tabs = page.container.querySelectorAll('w-tab');
+  await userEvent.click(tabs[2]);
+
+  await page.container.querySelector('w-tabs').updateComplete;
+  await page.container.querySelectorAll('w-tab-panel')[2].updateComplete;
+
+  await expect.element(page.getByText('Content for the third tab.')).toBeVisible();
+  await expect.element(page.getByText('Content for the second tab.')).not.toBeVisible();
+});
+
 test('tab-panel visibility is controlled via internal shadow DOM (no host attribute changes) to avoid hydration mismatch', async () => {
   const component = html`<w-tabs>
     <w-tab for="panel1">Tab 1</w-tab>

--- a/packages/tabs/tabs.ts
+++ b/packages/tabs/tabs.ts
@@ -194,30 +194,28 @@ export class WarpTabs extends LitElement {
   }
 
   private updatePanels() {
-    // Update tab active states
+    // Update tab active states using non-reflecting properties to avoid hydration mismatch
     const tabs: WarpTab[] = Array.from(this.querySelectorAll('w-tab'));
     tabs.forEach((tab, index) => {
       if (!tab.id) {
         tab.id = `w-tab-${this._uniqueId}-${index}`;
       }
-      if (tab.for === this._activeTabFor) {
-        tab.ariaSelected = "true";
-        tab.tabIndex = 0;
-      } else {
-        tab.ariaSelected = "false";
-        tab.tabIndex = -1;
-      }
+      const isActive = tab.for === this._activeTabFor;
+      // Use non-reflecting properties to avoid DOM changes during hydration
+      tab._parentAriaSelected = isActive ? 'true' : 'false';
+      tab._parentTabIndex = isActive ? 0 : -1;
     });
 
-    // Update tab panels visibility using 'active' attribute to avoid hydration mismatch
-    // (native 'hidden' always reflects, causing SSR issues)
+    // Update tab panels visibility using non-reflecting properties to avoid hydration mismatch
     const panels: WarpTabPanel[] = Array.from(this.querySelectorAll('w-tab-panel'));
     panels.forEach((panel) => {
-      if (!panel.hasAttribute("aria-labelledby")) {
-        const controller = tabs.find((tab) => tab.for === panel.id);
-        if (controller) panel.setAttribute("aria-labelledby", controller.id);
+      const controller = tabs.find((tab) => tab.for === panel.id);
+      if (controller) {
+        // Use non-reflecting property to avoid DOM changes during hydration
+        panel._parentAriaLabelledBy = controller.id;
       }
-      panel.toggleAttribute('active', panel.id === this._activeTabFor);
+      // Use non-reflecting property to control visibility
+      panel._parentActive = panel.id === this._activeTabFor;
     });
   }
 
@@ -265,13 +263,8 @@ export class WarpTabs extends LitElement {
         this.updatePanels();
         this._notifyTabChange();
 
-        // Focus the next tab
-        const el = nextTab;
-        el.tabIndex = 0; // All tabs are initially -1
-        el.focus();
-        tabs.forEach((t) => {
-          t.tabIndex = t === el ? 0 : -1;
-        });
+        // Focus the next tab (updatePanels already set the tabIndex)
+        nextTab.focus();
       }
     }
   };

--- a/packages/textarea/textarea.hydration.test.ts
+++ b/packages/textarea/textarea.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-textarea React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default textarea hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-textarea', {});
     expect(warnings).toEqual([]);
   });

--- a/packages/textarea/textarea.hydration.test.ts
+++ b/packages/textarea/textarea.hydration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './textarea.js';
+
+describe('w-textarea React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default textarea hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textarea', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textarea', {
+      label: 'Description',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with value hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textarea', {
+      value: 'Some text content',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textarea', {
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with invalid state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textarea', {
+      invalid: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with help text hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textarea', {
+      'help-text': 'Enter a detailed description',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/textfield/textfield.hydration.test.ts
+++ b/packages/textfield/textfield.hydration.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
+
+import './textfield.js';
+
+describe('w-textfield React SSR hydration', () => {
+  beforeEach(() => setupHydrationWarningCapture());
+  afterEach(() => {
+    window.__HYDRATION_WARNINGS__ = [];
+  });
+
+  test('default textfield hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textfield', {});
+    expect(warnings).toEqual([]);
+  });
+
+  test('with label hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textfield', {
+      label: 'Email',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with value hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textfield', {
+      value: 'test@example.com',
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with disabled state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textfield', {
+      disabled: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with invalid state hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textfield', {
+      invalid: true,
+    });
+    expect(warnings).toEqual([]);
+  });
+
+  test('with help text hydrates without warnings', async () => {
+    const warnings = await testHydration('w-textfield', {
+      'help-text': 'Enter your email address',
+    });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/textfield/textfield.hydration.test.ts
+++ b/packages/textfield/textfield.hydration.test.ts
@@ -9,7 +9,7 @@ describe('w-textfield React SSR hydration', () => {
     window.__HYDRATION_WARNINGS__ = [];
   });
 
-  test('default textfield hydrates without warnings', async () => {
+  test('default (no attributes) hydrates without warnings', async () => {
     const warnings = await testHydration('w-textfield', {});
     expect(warnings).toEqual([]);
   });

--- a/setup-tests.ts
+++ b/setup-tests.ts
@@ -1,11 +1,11 @@
 import 'vitest-browser-lit';
-import type { AxeResults, Result } from 'axe-core';
+import type { AxeResults, Result, RunOptions } from 'axe-core';
 import axe from 'axe-core';
 import { expect } from 'vitest';
 import type { RenderResult } from 'vitest-browser-lit';
 
 interface AxeMatchers {
-  toHaveNoAxeViolations(): Promise<void>;
+  toHaveNoAxeViolations(options?: RunOptions): Promise<void>;
 }
 
 declare module 'vitest' {
@@ -32,12 +32,13 @@ function formatViolations(violations: Result[]): string {
     .join('\n\n');
 }
 
-async function runAxe(container: Element = document.body): Promise<AxeResults> {
+async function runAxe(container: Element = document.body, options: RunOptions = {}): Promise<AxeResults> {
   return axe.run(container, {
     runOnly: {
       type: 'tag',
       values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'],
     },
+    ...options,
   });
 }
 
@@ -77,9 +78,9 @@ function toHaveNoViolations(results: AxeResults) {
 }
 
 expect.extend({
-  async toHaveNoAxeViolations(received: unknown) {
+  async toHaveNoAxeViolations(received: unknown, options?: RunOptions) {
     const container = resolveAxeContainer(received);
-    const results = await runAxe(container);
+    const results = await runAxe(container, options);
 
     return toHaveNoViolations(results);
   },

--- a/tests/react-hydration.ts
+++ b/tests/react-hydration.ts
@@ -1,0 +1,118 @@
+import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+
+declare global {
+  interface Window {
+    __HYDRATION_WARNINGS__: string[];
+  }
+}
+
+export function setupHydrationWarningCapture(): void {
+  window.__HYDRATION_WARNINGS__ = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    const msg = args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ');
+    if (
+      msg.includes('Hydration') ||
+      msg.includes('hydrat') ||
+      msg.includes('did not match') ||
+      msg.includes('server rendered HTML') ||
+      msg.includes('Text content does not match') ||
+      msg.includes('Expected server HTML')
+    ) {
+      window.__HYDRATION_WARNINGS__.push(msg);
+    }
+    originalError.apply(console, args);
+  };
+}
+
+/**
+ * Converts props to HTML attributes string
+ */
+function propsToHtml(props: Record<string, unknown>): string {
+  return Object.entries(props)
+    .map(([key, value]) => {
+      if (value === true) return key;
+      if (value === false || value === undefined || value === null) return '';
+      return `${key}="${value}"`;
+    })
+    .filter(Boolean)
+    .join(' ');
+}
+
+/**
+ * Tests that a component hydrates without warnings.
+ * Takes tag name and props, generates both SSR HTML and React element from them.
+ */
+export async function testHydration(
+  tagName: string,
+  props: Record<string, unknown> = {},
+): Promise<string[]> {
+  const container = document.createElement('div');
+  container.id = 'hydration-test-root';
+  document.body.appendChild(container);
+
+  try {
+    // Generate SSR HTML from props
+    const attrs = propsToHtml(props);
+    const ssrHtml = `<${tagName}${attrs ? ` ${attrs}` : ''}></${tagName}>`;
+    container.innerHTML = ssrHtml;
+
+    // Create React element from same props and hydrate
+    const element = React.createElement(tagName, props);
+    hydrateRoot(container, element);
+
+    // Wait for hydration, custom element upgrade, and async callbacks
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    return window.__HYDRATION_WARNINGS__;
+  } finally {
+    document.body.removeChild(container);
+  }
+}
+
+/**
+ * Tests hydration for parent/child component structures.
+ * Takes parent tag, props, and children HTML string.
+ *
+ * Note: For custom elements with slotted children, we set innerHTML directly
+ * rather than through React props, since React sees slotted content as light DOM
+ * that the custom element manages.
+ */
+export async function testHydrationWithChildren(
+  tagName: string,
+  props: Record<string, unknown>,
+  childrenHtml: string,
+): Promise<string[]> {
+  const container = document.createElement('div');
+  container.id = 'hydration-test-root';
+  document.body.appendChild(container);
+
+  try {
+    // Generate SSR HTML from props with children
+    const attrs = propsToHtml(props);
+    const ssrHtml = `<${tagName}${attrs ? ` ${attrs}` : ''}>${childrenHtml}</${tagName}>`;
+    container.innerHTML = ssrHtml;
+
+    // For custom elements with children, hydrate just the parent element props.
+    // The children are slotted content that lives in light DOM and is managed
+    // by the custom element, not React.
+    const element = React.createElement(tagName, props);
+    hydrateRoot(container, element);
+
+    // After hydration, restore the children to the element
+    // (React will have cleared them since they weren't in the React tree)
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const el = container.querySelector(tagName);
+    if (el && el.innerHTML !== childrenHtml.trim()) {
+      el.innerHTML = childrenHtml;
+    }
+
+    // Wait for hydration, custom element upgrade, and async callbacks
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    return window.__HYDRATION_WARNINGS__;
+  } finally {
+    document.body.removeChild(container);
+  }
+}

--- a/tests/react-hydration.ts
+++ b/tests/react-hydration.ts
@@ -78,6 +78,13 @@ export async function testHydration(
  * Note: For custom elements with slotted children, we set innerHTML directly
  * rather than through React props, since React sees slotted content as light DOM
  * that the custom element manages.
+ *
+ * LIMITATION: This helper restores children AFTER hydration completes, so any
+ * DOM manipulation by the component (e.g., adding classes to children, moving
+ * children to shadow DOM) happens outside React's hydration window. This means
+ * components that modify light DOM children may pass these tests but still cause
+ * hydration mismatches in real SSR scenarios. Use separate DOM stability tests
+ * (like in breadcrumbs.hydration.test.ts) to verify child element handling.
  */
 export async function testHydrationWithChildren(
   tagName: string,

--- a/tests/react-hydration.ts
+++ b/tests/react-hydration.ts
@@ -41,6 +41,41 @@ function propsToHtml(props: Record<string, unknown>): string {
 }
 
 /**
+ * Converts a DOM node to a React element.
+ * Used to include children in the React tree for proper hydration testing.
+ */
+function nodeToReact(node: Node): React.ReactNode {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent;
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const el = node as Element;
+    const props: Record<string, unknown> = {};
+    for (const attr of el.attributes) {
+      // Convert HTML attributes to React props
+      let name = attr.name;
+      if (name === 'class') name = 'className';
+      if (name === 'for') name = 'htmlFor';
+      props[name] = attr.value;
+    }
+    const children = Array.from(el.childNodes).map(nodeToReact).filter(Boolean);
+    return React.createElement(el.tagName.toLowerCase(), props, ...children);
+  }
+  return null;
+}
+
+/**
+ * Converts an HTML string to an array of React elements.
+ */
+function htmlToReactElements(html: string): React.ReactNode[] {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return Array.from(template.content.childNodes)
+    .map(nodeToReact)
+    .filter((node) => node !== null && (typeof node !== 'string' || node.trim()));
+}
+
+/**
  * Tests that a component hydrates without warnings.
  * Takes tag name and props, generates both SSR HTML and React element from them.
  */
@@ -59,8 +94,16 @@ export async function testHydration(
     container.innerHTML = ssrHtml;
 
     // Create React element from same props and hydrate
+    // Use onRecoverableError to capture hydration errors (React 19+)
     const element = React.createElement(tagName, props);
-    hydrateRoot(container, element);
+    hydrateRoot(container, element, {
+      onRecoverableError: (error: unknown) => {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('Hydration') || msg.includes('hydrat') || msg.includes('did not match')) {
+          window.__HYDRATION_WARNINGS__.push(msg);
+        }
+      },
+    });
 
     // Wait for hydration, custom element upgrade, and async callbacks
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -75,16 +118,9 @@ export async function testHydration(
  * Tests hydration for parent/child component structures.
  * Takes parent tag, props, and children HTML string.
  *
- * Note: For custom elements with slotted children, we set innerHTML directly
- * rather than through React props, since React sees slotted content as light DOM
- * that the custom element manages.
- *
- * LIMITATION: This helper restores children AFTER hydration completes, so any
- * DOM manipulation by the component (e.g., adding classes to children, moving
- * children to shadow DOM) happens outside React's hydration window. This means
- * components that modify light DOM children may pass these tests but still cause
- * hydration mismatches in real SSR scenarios. Use separate DOM stability tests
- * (like in breadcrumbs.hydration.test.ts) to verify child element handling.
+ * This properly includes children in the React tree so that React can detect
+ * hydration mismatches when components modify their light DOM children
+ * (e.g., adding classes, moving children to shadow DOM).
  */
 export async function testHydrationWithChildren(
   tagName: string,
@@ -101,19 +137,20 @@ export async function testHydrationWithChildren(
     const ssrHtml = `<${tagName}${attrs ? ` ${attrs}` : ''}>${childrenHtml}</${tagName}>`;
     container.innerHTML = ssrHtml;
 
-    // For custom elements with children, hydrate just the parent element props.
-    // The children are slotted content that lives in light DOM and is managed
-    // by the custom element, not React.
-    const element = React.createElement(tagName, props);
-    hydrateRoot(container, element);
+    // Convert children HTML to React elements so they're part of React's tree.
+    // This allows React to detect mismatches when components modify children.
+    const reactChildren = htmlToReactElements(childrenHtml);
+    const element = React.createElement(tagName, props, ...reactChildren);
 
-    // After hydration, restore the children to the element
-    // (React will have cleared them since they weren't in the React tree)
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    const el = container.querySelector(tagName);
-    if (el && el.innerHTML !== childrenHtml.trim()) {
-      el.innerHTML = childrenHtml;
-    }
+    // Use onRecoverableError to capture hydration errors (React 19+)
+    hydrateRoot(container, element, {
+      onRecoverableError: (error: unknown) => {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('Hydration') || msg.includes('hydrat') || msg.includes('did not match')) {
+          window.__HYDRATION_WARNINGS__.push(msg);
+        }
+      },
+    });
 
     // Wait for hydration, custom element upgrade, and async callbacks
     await new Promise((resolve) => setTimeout(resolve, 200));


### PR DESCRIPTION
Adds hydration mismatch tests and then attempts to fix using the strategy of

* a11y attrs set as properties on element internals, not on the host
* delegates focus onto tabindex onto an element in the shadowdom for enabling disabling tabbability of the component
* default attributes don't reflect default state onto the host, they just calculate defaults on the fly as needed

Breadcrumbs is still a problem. Also, I still need to go through everything here for another sweep before im satisfied we've nailed this.