### PR TITLE
fix: use correct initial value and update active track on reset

### DIFF
--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -116,6 +116,11 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 
   resetFormControl(): void {
     this.value = this.#initialValue;
+    this.dispatchEvent(
+      new CustomEvent('thumbreset', {
+        bubbles: true,
+      }),
+    );
   }
 
   /**
@@ -532,6 +537,12 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
     }
 
     if (changedProperties.has('value')) {
+      if (typeof this.#initialValue === "undefined" && typeof this.value !== "undefined") {
+        // If w-slider sets our initial value based on the min and max attributes then
+        // this.value will be undefined in connectedCallback. We need this check here
+        // in order for form resets to work correctly.
+        this.#initialValue = this.value;
+      }
       this.setValue(this.value);
       this.#syncRangeValue();
     }

--- a/packages/slider/slider.react.stories.tsx
+++ b/packages/slider/slider.react.stories.tsx
@@ -176,9 +176,18 @@ export const OpenEnded: Story = {
               return value;
             }}
           >
-            <SliderThumb slot="from" aria-label="Fra år" name="from" />
-            <SliderThumb slot="to" aria-label="Til år" name="to" />
+            <SliderThumb slot="from" aria-label="Fra år" name="from" value={openEndedFrom} />
+            <SliderThumb slot="to" aria-label="Til år" name="to" value={openEndedTo} />
           </Slider>
+          <button 
+            type="button"
+            onClick={() => {
+              setOpenEndedFrom("");
+              setOpenEndedTo("");
+            }}
+          >
+            What's button type reset lol
+          </button>
         </form>
         <p>Drag the slider to show the value below. See the Code tab for how to format the labels.</p>
         <output>

--- a/packages/slider/slider.stories.ts
+++ b/packages/slider/slider.stories.ts
@@ -53,18 +53,24 @@ export const SingleDisabled: Story = {
 export const Range: Story = {
   render() {
     return html`
-      <w-slider label="Range" min="0" max="100">
-        <w-slider-thumb
-          slot="from"
-          aria-label="From value"
-          name="from"
-        ></w-slider-thumb>
-        <w-slider-thumb
-          slot="to"
-          aria-label="To value"
-          name="to"
-        ></w-slider-thumb>
-      </w-slider>
+      <form>
+        <w-slider label="Range" min="0" max="100">
+          <w-slider-thumb
+            slot="from"
+            aria-label="From value"
+            name="from"
+          ></w-slider-thumb>
+          <w-slider-thumb
+            slot="to"
+            aria-label="To value"
+            name="to"
+          ></w-slider-thumb>
+        </w-slider>
+        <div class="py-8">
+          <w-button type="reset">Reset</w-button>
+          <w-button type="submit">Submit</w-button>
+        </div>
+      </form>
     `;
   },
 };

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -250,6 +250,11 @@ class WarpSlider extends LitElement {
     }
   }
 
+  #onThumbReset(e: CustomEvent) {
+    const input = e.target as WarpSliderThumb;
+    this.#updateActiveTrack(input);
+  }
+
   #onInput(e: InputEvent) {
     const input = e.target as WarpSliderThumb;
     this.#updateActiveTrack(input);
@@ -382,6 +387,7 @@ class WarpSlider extends LitElement {
         @input="${this.#onInput}"
         @focusout="${this.#onBlur}"
         @slidervalidity="${this.#onSliderValidity}"
+        @thumbreset="${this.#onThumbReset}"
         @keydown="${this.#handleKeyDown}"
         aria-invalid="${this.errorText ? 'true' : nothing}"
         ?disabled="${this.disabled}"


### PR DESCRIPTION
The native form reset didn't work as expected.