### PR TITLE
fix: handle edge case for open-ended sliders and arrow keys

### DIFF
--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -335,6 +335,36 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
     }
   }
 
+  async #onInputFieldKeyDown(e: KeyboardEvent): Promise<void> {
+    // Handle the case where an open ended slider that has
+    // no current value (Min or Max) and the user presses
+    // the up or down arrow in the input field.
+    
+    if (this.textfield.value) {
+      // If the field has a value let the native browser behavior do its thing
+      return;
+    }
+
+    e.preventDefault();
+
+    let value = "";
+    if (this.slot === 'from') {
+      if (e.key === 'ArrowUp') {
+        value = String(Number(this.min) + 1) || "1";  
+      } else if(e.key === 'ArrowDown') {
+        value = String(Number(this.min)) || "0";
+      }
+    } else {
+      if (e.key === 'ArrowUp') {
+        value = String(Number(this.max)) || "100";  
+      } else if(e.key === 'ArrowDown') {
+        value = String(Number(this.max) - 1) || "99";
+      }
+    }
+
+    await this.#handleValueChange(value, true);
+  }
+
   async connectedCallback() {
     super.connectedCallback();
     this.#initialValue = this.value;
@@ -634,6 +664,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
           step="${ifDefined(this.step)}"
           ?invalid="${Boolean(this.invalid)}"
           @input="${this.#onInput}"
+          @keydown="${this.#onInputFieldKeyDown}"
           ?disabled="${this.disabled}"
         >
           ${(this.suffix ?? '') ? html`<w-affix slot="suffix" label="${this.suffix ?? ''}"></w-affix>` : nothing}

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -107,19 +107,59 @@ test('can increment and decrement the slider values with arrow keys in the numbe
 
   await userEvent.type(page.getByRole('spinbutton').first(), '{ArrowUp}');
 
-  await expect.element(page.getByRole('spinbutton').first()).toHaveValue('1951');
-  await expect.element(page.getByLabelText('From year').first()).toHaveValue(1951); // keeps value in sync between inputs
+  // Go from Min "beyond" 1950 to 1950
+  await expect.element(page.getByRole('spinbutton').first()).toHaveValue(1950);
+  await expect.element(page.getByLabelText('From year').first()).toHaveValue('1950'); // keeps value in sync between inputs
   
   await userEvent.type(page.getByRole('spinbutton').last(), '{ArrowDown}');
 
-  await expect.element(page.getByRole('spinbutton').last()).toHaveValue('2024');
-  await expect.element(page.getByLabelText('To year').first()).toHaveValue(2024); // keeps value in sync between inputs
-
-
+  // Go from Max "beyond" 2025 to 2025
+  await expect.element(page.getByRole('spinbutton').last()).toHaveValue(2025);
+  await expect.element(page.getByLabelText('To year').first()).toHaveValue('2025'); // keeps value in sync between inputs
 
   const formData = new FormData(page.getByTestId('form').element() as HTMLFormElement);
-  expect(formData.get('from-year')).toBe('1951');
-  expect(formData.get('to-year')).toBe('2024');
+  expect(formData.get('from-year')).toBe('1950');
+  expect(formData.get('to-year')).toBe('2025');
+});
+
+test('going down from Min and up from Max sets value to min - 1 and max + a respectively', async () => {
+  const component = html`
+    <form data-testid="form">
+      <w-slider
+        label="Model year"
+        min="1950"
+        max="2025"
+        open-ended
+      >
+        <w-slider-thumb
+          slot="from"
+          aria-label="From year"
+          name="from-year"
+        ></w-slider-thumb>
+        <w-slider-thumb
+          slot="to"
+          aria-label="To year"
+          name="to-year"
+        ></w-slider-thumb>
+      </w-slider>
+    </form>
+  `;
+
+  const page = render(component);
+
+  await userEvent.type(page.getByRole('spinbutton').first(), '{ArrowDown}');
+
+  await expect.element(page.getByRole('spinbutton').first()).toHaveValue(1949);
+  await expect.element(page.getByLabelText('From year').first()).toHaveValue('1949'); // keeps value in sync between inputs
+  
+  await userEvent.type(page.getByRole('spinbutton').last(), '{ArrowUp}');
+
+  await expect.element(page.getByRole('spinbutton').last()).toHaveValue(2026);
+  await expect.element(page.getByLabelText('To year').first()).toHaveValue('2026'); // keeps value in sync between inputs
+
+  const formData = new FormData(page.getByTestId('form').element() as HTMLFormElement);
+  expect(formData.get('from-year')).toBe('1949');
+  expect(formData.get('to-year')).toBe('2026');
 });
 
 test('slider without suffix syncs empty suffix to thumb', async () => {

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -80,6 +80,48 @@ test('can set slider value via the number input', async () => {
   expect(formData.get('value')).toBe('50');
 });
 
+test('can increment and decrement the slider values with arrow keys in the number input', async () => {
+  const component = html`
+    <form data-testid="form">
+      <w-slider
+        label="Model year"
+        min="1950"
+        max="2025"
+        open-ended
+      >
+        <w-slider-thumb
+          slot="from"
+          aria-label="From year"
+          name="from-year"
+        ></w-slider-thumb>
+        <w-slider-thumb
+          slot="to"
+          aria-label="To year"
+          name="to-year"
+        ></w-slider-thumb>
+      </w-slider>
+    </form>
+  `;
+
+  const page = render(component);
+
+  await userEvent.type(page.getByRole('spinbutton').first(), '{ArrowUp}');
+
+  await expect.element(page.getByRole('spinbutton').first()).toHaveValue('1951');
+  await expect.element(page.getByLabelText('From year').first()).toHaveValue(1951); // keeps value in sync between inputs
+  
+  await userEvent.type(page.getByRole('spinbutton').last(), '{ArrowDown}');
+
+  await expect.element(page.getByRole('spinbutton').last()).toHaveValue('2024');
+  await expect.element(page.getByLabelText('To year').first()).toHaveValue(2024); // keeps value in sync between inputs
+
+
+
+  const formData = new FormData(page.getByTestId('form').element() as HTMLFormElement);
+  expect(formData.get('from-year')).toBe('1951');
+  expect(formData.get('to-year')).toBe('2024');
+});
+
 test('slider without suffix syncs empty suffix to thumb', async () => {
   render(html`
     <w-slider label="Single" min="0" max="100">


### PR DESCRIPTION
Where first interaction is through the input field with up and down arrow keys. Silly users.

Fixes https://github.com/warp-ds/elements/issues/524