### PR TITLE
chore: set up a simple watcher to rebuild docs on MD changes

### DIFF
--- a/build/docs-watch.js
+++ b/build/docs-watch.js
@@ -1,0 +1,47 @@
+import { exec } from "node:child_process";
+import { watch } from "node:fs";
+import { join } from "node:path";
+
+async function pexec(command) {
+    return new Promise((resolve, reject) => {
+        exec(command, (error, stdout, stderr) => {
+            console.log(stdout);
+            if (error) {
+                console.error(stderr);
+                console.error(error);
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+watch(join(process.cwd(), "packages"), { recursive: true }, async (eventType, fileName) => {
+    if (!fileName) return;
+    
+    if (fileName.endsWith(".md")) {
+        console.log(`${fileName} changed, rebuilding docs...`);
+        await pexec("pnpm run build:docs");
+        return;
+    }
+
+    if (fileName.endsWith(".test.ts")) {
+        // Vitest has its own built-in watcher that's smarter than ours
+        return;
+    }
+    
+    if (fileName.includes(".stories.ts")) {
+        // Storybook has live updates
+        return;
+    }
+
+    if (fileName.endsWith(".ts")) {
+        console.log(`${fileName} changed, rebuilding...`);
+        await pexec("pnpm run build:manifest");
+        await pexec("pnpm run build:docs");
+        return;
+    }
+});
+
+console.log("Watching packages/ for changes...");

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "test:module-resolution": "cd tests/module-resolution && ./setup.sh && ./test.sh",
     "test:output-validation": "node tests/output-validation/validate-eik-output.js",
     "test:eik-backwards-compat": "node tests/output-validation/validate-eik-backwards-compat.js",
-    "watch:npm": "npx esbuild ./index.js --outdir=dist/ --target=es2017 --bundle --sourcemap --format=esm --minify --watch"
+    "watch:docs": "node ./build/docs-watch.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Rebuilds the CEM and docs in the `dist/` folder when we change `.ts` and `.md` files, for maximum developer velocity.

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExazV6Y3VrMHNxbHN6YWY5Zjhpa3J1Ymk1MThkcXhoZWNveWc1eGVkYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JbRiGMz415efwUYsgk/giphy.gif)

`watch:npm` doesn't work, assume it won't be missed.