### PR TITLE
docs: colocate textfield docs, generate from CEM

### DIFF
--- a/.cem/custom-element-manifest.config.js
+++ b/.cem/custom-element-manifest.config.js
@@ -92,10 +92,6 @@ export default {
         return modulePath.replace('packages', './packages');
       },
     }),
-    jsDocTagsPlugin({
-      tags: {
-        description: {},
-      },
-    }),
+    jsDocTagsPlugin(),
   ],
 };

--- a/build/docs-watch.js
+++ b/build/docs-watch.js
@@ -1,0 +1,47 @@
+import { exec } from "node:child_process";
+import { watch } from "node:fs";
+import { join } from "node:path";
+
+async function pexec(command) {
+    return new Promise((resolve, reject) => {
+        exec(command, (error, stdout, stderr) => {
+            console.log(stdout);
+            if (error) {
+                console.error(stderr);
+                console.error(error);
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+watch(join(process.cwd(), "packages"), { recursive: true }, async (eventType, fileName) => {
+    if (!fileName) return;
+    
+    if (fileName.endsWith(".md")) {
+        console.log(`${fileName} changed, rebuilding docs...`);
+        await pexec("pnpm run build:docs");
+        return;
+    }
+
+    if (fileName.endsWith(".test.ts")) {
+        // Vitest has its own built-in watcher that's smarter than ours
+        return;
+    }
+    
+    if (fileName.includes(".stories.ts")) {
+        // Storybook has live updates
+        return;
+    }
+
+    if (fileName.endsWith(".ts")) {
+        console.log(`${fileName} changed, rebuilding...`);
+        await pexec("pnpm run build:manifest");
+        await pexec("pnpm run build:docs");
+        return;
+    }
+});
+
+console.log("Watching packages/ for changes...");

--- a/build/docs.js
+++ b/build/docs.js
@@ -47,7 +47,7 @@ const normalizeText = (value, fallback = '') => {
     return fallback;
   }
 
-  return String(value);
+  return String(value).replaceAll("|", "\\|");
 };
 
 const readOptionalFile = (path) => {
@@ -87,7 +87,18 @@ const buildPropertyTable = (members = [], typesMap = new Map()) => {
       table += `| ${normalizeText(item.name, '-')}`;
       table += ` | ${renderType(item.type?.text, typesMap)}`;
       table += ` | \`${normalizeText(item.default, '-')}\``;
-      table += ` | ${normalizeText(item.summary, '-')} |\n`;
+
+      let summary = "";
+      if (item.deprecated && !item.summary) {
+        summary = `**Deprecated**: ${item.deprecated}`;
+      } else if (item.deprecated && item.summary) {
+        summary = `${item.summary}. **Deprecated**: ${item.deprecated}`;
+      } else if (item.summary) {
+        summary = item.summary;
+      } else {
+        summary = "-";
+      }
+      table += ` | ${summary} |\n`;
     }
   });
 
@@ -100,6 +111,9 @@ const buildPropertyDetails = (members = [], typesMap = new Map()) => {
   members.forEach((item) => {
     if (item.kind === 'field' && item.privacy !== 'private') {
       details += `#### ${normalizeText(item.name, '-')}\n\n`;
+      if (item.deprecated) {
+        details += `**Deprecated**: ${item.deprecated}\n\n`;
+      }
       details += `${normalizeText(item.description, '')}\n\n`;
       details += `- Type: ${renderType(item.type?.text, typesMap)}\n`;
       details += `- Default: \`${normalizeText(item.default, '-')}\`\n\n`;

--- a/build/docs.js
+++ b/build/docs.js
@@ -50,6 +50,16 @@ const normalizeText = (value, fallback = '') => {
   return String(value).replaceAll("|", "\\|");
 };
 
+const getSummary = (item, fallback = '') => {
+  if (item.summary) return item.summary;
+  if (item.description) {
+    return item.description
+      .split("\n")
+      .at(0);
+  }
+  return fallback;
+}
+
 const readOptionalFile = (path) => {
   if (!existsSync(path)) {
     return '';
@@ -82,25 +92,29 @@ const buildTypesMap = (members = []) => {
 const buildPropertyTable = (members = [], typesMap = new Map()) => {
   let table = '| Name | Type | Default | Summary |\n|-|-|-|-|\n';
 
-  members.forEach((item) => {
-    if (item.kind === 'field' && item.privacy !== 'private') {
-      table += `| ${normalizeText(item.name, '-')}`;
-      table += ` | ${renderType(item.type?.text, typesMap)}`;
-      table += ` | \`${normalizeText(item.default, '-')}\``;
+  members
+    .sort((a, b) => {
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    })
+    .forEach((item) => {
+      if (item.kind === 'field' && item.privacy !== 'private') {
+        table += `| ${normalizeText(item.name, '-')}`;
+        table += ` | ${renderType(item.type?.text, typesMap)}`;
+        table += ` | \`${normalizeText(item.default, '-')}\``;
 
-      let summary = "";
-      if (item.deprecated && !item.summary) {
-        summary = `**Deprecated**: ${item.deprecated}`;
-      } else if (item.deprecated && item.summary) {
-        summary = `${item.summary}. **Deprecated**: ${item.deprecated}`;
-      } else if (item.summary) {
-        summary = item.summary;
-      } else {
-        summary = "-";
+        let summary = getSummary(item);
+        if (item.deprecated && !summary) {
+          summary = `**Deprecated**: ${item.deprecated}`;
+        } else if (item.deprecated && summary) {
+          summary = `${summary}. **Deprecated**: ${item.deprecated}`;
+        } else if (!summary) {
+          summary = "-";
+        }
+        table += ` | ${summary} |\n`;
       }
-      table += ` | ${summary} |\n`;
-    }
-  });
+    });
 
   return table;
 };
@@ -108,17 +122,23 @@ const buildPropertyTable = (members = [], typesMap = new Map()) => {
 const buildPropertyDetails = (members = [], typesMap = new Map()) => {
   let details = '';
 
-  members.forEach((item) => {
-    if (item.kind === 'field' && item.privacy !== 'private') {
-      details += `#### ${normalizeText(item.name, '-')}\n\n`;
-      if (item.deprecated) {
-        details += `**Deprecated**: ${item.deprecated}\n\n`;
+  members
+    .sort((a, b) => {
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    })
+    .forEach((item) => {
+      if (item.kind === 'field' && item.privacy !== 'private') {
+        details += `#### ${normalizeText(item.name, '-')}\n\n`;
+        if (item.deprecated) {
+          details += `**Deprecated**: ${item.deprecated}\n\n`;
+        }
+        details += `${normalizeText(item.description, '')}\n\n`;
+        details += `- Type: ${renderType(item.type?.text, typesMap)}\n`;
+        details += `- Default: \`${normalizeText(item.default, '-')}\`\n\n`;
       }
-      details += `${normalizeText(item.description, '')}\n\n`;
-      details += `- Type: ${renderType(item.type?.text, typesMap)}\n`;
-      details += `- Default: \`${normalizeText(item.default, '-')}\`\n\n`;
-    }
-  });
+    });
 
   return details;
 };

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "test:module-resolution": "cd tests/module-resolution && ./setup.sh && ./test.sh",
     "test:output-validation": "node tests/output-validation/validate-eik-output.js",
     "test:eik-backwards-compat": "node tests/output-validation/validate-eik-backwards-compat.js",
-    "watch:npm": "npx esbuild ./index.js --outdir=dist/ --target=es2017 --bundle --sourcemap --format=esm --minify --watch"
+    "watch:docs": "node ./build/docs-watch.js"
   },
   "repository": {
     "type": "git",

--- a/packages/textfield/docs/accessibility.md
+++ b/packages/textfield/docs/accessibility.md
@@ -1,1 +1,16 @@
 ## Accessibility
+
+If a visible label isn't specified, an `aria-label` must be provided to the text field for accessibility. If the field is labeled by a separate element, an `aria-labelledby` property must be provided using the `id` of the labeling element instead.
+
+- Always provide a visible label (do not rely on `placeholder` alone).
+- Do not rely on color alone for interaction feedback (e.g. error states).
+- Interaction patterns should follow platform-native expectations (e.g. tap zones, keyboard navigation, etc) and must not block accessibility tools.
+
+### When used with an affix
+
+When `search` or `clear` set on the [affix](#with-affix) component it renders a button and a default `aria-label`. If the `aria-label` incorrect for your context, you may provide your own describing the action.
+
+```html
+<w-affix search aria-label="Ad Search"></w-affix>
+<w-affix clear aria-label="Clear text input"></w-affix>
+```

--- a/packages/textfield/docs/examples.md
+++ b/packages/textfield/docs/examples.md
@@ -1,1 +1,148 @@
 ## Examples
+
+### Placeholder
+
+Placeholder text can be used to describe the expected value or formatting for the textfield.
+
+Placeholder text will only appear when the textfield is empty, and must not be used as a
+substitute for labeling the element with a visible label.
+
+<style-isolate>
+    <w-textfield label="Email" placeholder="ola.nordmann@finn.no"></w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Email" placeholder="ola.nordmann@finn.no"></w-textfield>
+```
+
+### Prefix label
+
+<style-isolate>
+  <w-textfield label="Price">
+    <w-affix slot="prefix" label="kr"></w-affix>
+  </w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Price">
+  <w-affix slot="prefix" label="kr"></w-affix>
+</w-textfield>
+```
+
+### Suffix Label
+
+<style-isolate>
+  <w-textfield label="Price">
+    <w-affix slot="suffix" label="kr"></w-affix>
+  </w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Price">
+  <w-affix slot="suffix" label="kr"></w-affix>
+</w-textfield>
+```
+
+### Prefix Search Icon
+
+<style-isolate>
+  <w-textfield label="Search">
+    <w-affix slot="prefix" search></w-affix>
+  </w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Search">
+  <w-affix slot="prefix" search></w-affix>
+</w-textfield>
+```
+
+### Suffix Search Icon
+
+If you wrap the textfield with affix in a form element, clicking the search button will automatically submit the form
+
+<style-isolate>
+  <form>
+    <w-textfield label="Search">
+      <w-affix slot="suffix" search></w-affix>
+    </w-textfield>
+  </form>
+</style-isolate>
+
+```html
+<form>
+  <w-textfield label="Search">
+    <w-affix slot="prefix" search></w-affix>
+  </w-textfield>
+</form>
+```
+
+### Suffix Clear Icon
+
+Clicking the clear button will reset the textfield
+
+<style-isolate>
+  <w-textfield label="Search input">
+    <w-affix slot="suffix" clear></w-affix>
+  </w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Search input">
+  <w-affix slot="suffix" clear></w-affix>
+</w-textfield>
+```
+
+### Affix with arbitrary icon
+
+<style-isolate>
+  <w-textfield label="Award">
+    <w-affix slot="prefix" icon="AwardMedal"></w-affix>
+  </w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Award">
+  <w-affix slot="prefix" icon="AwardMedal"></w-affix>
+</w-textfield>
+```
+
+### Disabled
+
+Keep in mind that using disabled in its current form is an anti-pattern.
+
+There will always be users who don't understand why an element is disabled, or users who can't even see that
+it is disabled because of poor lighting conditions or other reasons.
+
+Please consider more informative alternatives before choosing to use disabled on an element.
+
+<style-isolate>
+    <div class="flex flex-col space-y-32">
+        <w-textfield label="Email" disabled value="ola.nordmann@finn.no"></w-textfield>
+        <w-textfield label="Email" disabled></w-textfield>
+    </div>
+</style-isolate>
+
+```html
+<div class="flex flex-col space-y-32">
+  <w-textfield label="Email" disabled value="ola.nordmann@finn.no"></w-textfield>
+  <w-textfield label="Email" disabled></w-textfield>
+</div>
+```
+
+### Read only
+
+The readonly boolean attribute makes the w-textfield's text content immutable. Unlike disabled the w-textfield remains focusable and the contents can still be copied. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/readOnly) for more information.
+
+<style-isolate>
+  <w-textfield label="Email" type="email" value="ola.nordmann@finn.no" readonly></w-textfield>
+</style-isolate>
+
+```html
+<w-textfield 
+  label="Email" 
+  type="email" 
+  value="ola.nordmann@finn.no" 
+  readonly
+></w-textfield>
+```

--- a/packages/textfield/docs/usage.md
+++ b/packages/textfield/docs/usage.md
@@ -1,1 +1,31 @@
 ## Usage
+
+<style-isolate>
+    <w-textfield label="Email" type="email"></w-textfield>
+</style-isolate>
+
+```html
+<w-textfield label="Email" type="email"></w-textfield>
+```
+
+### Validation
+
+Set the `invalid` attribute to display a textfield as invalid.
+
+`invalid` should be paired with `help-text` to provide feedback to the user about how to correct the error.
+
+<style-isolate>
+    <w-textfield 
+        label="Email"
+        invalid
+        help-text="An email should have an @ sign and a domain name, for example ola.nordmann@finn.no"
+    ></w-textfield>
+</style-isolate>
+
+```html
+<w-textfield 
+    label="Email"
+    invalid
+    help-text="An email should have an @ sign and a domain name, for example ola.nordmann@finn.no"
+></w-textfield>
+```

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -133,7 +133,8 @@ class WarpTextField extends FormControlMixin(LitElement) {
   @property({ type: String, reflect: true })
   placeholder: string;
 
-  /** @deprecated Use the native readonly attribute instead.
+  /** 
+   * @deprecated Use the native readonly attribute instead.
    * @summary
    * @description
    */

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -39,153 +39,160 @@ const ccHelpText = {
 };
 
 /**
- * A single line text input element.
- *
- * [See Storybook for usage examples](https://warp-ds.github.io/elements/?path=/docs/forms-textfield--docs)
+ * A single-line input component used for entering and editing textual or numeric data.
+ * 
+ * @slot suffix - Use with `<w-affix>` to include a suffix, for example the unit for a number (e. g. km or sek).
+ * @slot prefix - Use with `<w-affix>` to include a prefix, for example a search icon.
  */
 class WarpTextField extends FormControlMixin(LitElement) {
+  /** @internal */
   static shadowRootOptions = {
     ...LitElement.shadowRootOptions,
     delegatesFocus: true,
   };
 
   /**
-   * @summary
-   * @description
+   * Keep in mind that using disabled in its current form is an anti-pattern.
+   * 
+   * There will always be users who don't understand why an element is disabled, or users who can't even see that it is disabled because of poor lighting conditions or other reasons.
+   * 
+   * Please consider more informative alternatives before choosing to use disabled on an element.
+   * 
+   * @summary Makes the element not focusable and hides it from form submits
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
   /**
-   * @summary
-   * @description
+   * Mark the form field as invalid. Make sure to also set a `help-text` to help users fix the validation problem.
+   * 
+   * @summary Mark the form field as invalid.
    */
   @property({ type: Boolean, reflect: true })
   invalid = false;
 
   /**
-   * @summary
-   * @description
-   */
-  @property({ type: String, reflect: true })
-  id: string;
-
-  /**
-   * @summary
-   * @description
+   * Either a `label` or an `aria-label` must be provided.
    */
   @property({ type: String, reflect: true })
   label: string;
 
   /**
-   * @summary
-   * @description
+   * Use in combination with `invalid` to show as a validation error message,
+   * or on its own to show a help text.
+   * 
+   * @summary Description shown below the input field
    */
   @property({ type: String, reflect: true, attribute: 'help-text' })
   helpText: string;
 
   /**
-   * @summary
-   * @description
+   * Sets the [size](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#size) (width) of the input field to fit the expected length of inputs.
    */
   @property({ type: String, reflect: true })
   size: string;
 
   /**
-   * @summary
-   * @description
+   * Use with `type="number"` to set the [maximum allowed value](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#maxlength).
    */
   @property({ type: Number, reflect: true })
   max: number;
 
   /**
-   * @summary
-   * @description
+   * Use with `type="number"` to set the [minimum allowed value](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#minlength).
    */
   @property({ type: Number, reflect: true })
   min: number;
 
   /**
-   * @summary
-   * @description
+   * @deprecated Use the native `minlength` attribute
    */
   @property({ type: Number, reflect: true, attribute: 'min-length' })
   minLength: number;
-
+  
   /**
-   * @summary
-   * @description
+   * For `text`, `search`, `url`, `tel`, `email` and `password` fields, sets the [minimum string length](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#minlength) required.
+   */
+  @property({ type: Number, reflect: true })
+  minlength: number;
+  
+  /**
+   * @deprecated Use the native `maxlength` attribute
    */
   @property({ type: Number, reflect: true, attribute: 'max-length' })
   maxLength: number;
 
   /**
-   * @summary
-   * @description
+   * For `text`, `search`, `url`, `tel`, `email` and `password` fields, sets the [maximum string length](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#maxlength) allowed.
+   */
+  @property({ type: Number, reflect: true })
+  maxlength: number;
+
+  /**
+   * Sets a [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions) that the input's value must [match to pass validation](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#pattern)
    */
   @property({ type: String, reflect: true })
   pattern: string;
 
   /**
-   * @summary
-   * @description
+   * Set a text that is shown in the textfield when it doesn't have a value.
+   * 
+   * Placeholder text should not be used as a substitute for labeling the element with a visible label.
+   * 
+   * @summary Shown in the textfield when it doesn't have a value
    */
   @property({ type: String, reflect: true })
   placeholder: string;
 
   /** 
    * @deprecated Use the native readonly attribute instead.
-   * @summary
-   * @description
    */
   @property({ type: Boolean, reflect: true, attribute: 'read-only' })
   readOnly = false;
 
   /**
-   * @summary
-   * @description
+   * Whether the input can be selected but not changed by the user.
    */
   @property({ type: Boolean, reflect: true })
   readonly = false;
 
   /**
-   * @summary
-   * @description
+   * Whether user input is required on the input before form submission.
    */
   @property({ type: Boolean, reflect: true })
   required = false;
 
   /**
-   * @summary
-   * @description
+   * The [type of input](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#input_types).
    */
   @property({ type: String, reflect: true })
   type: string;
 
   /**
-   * @summary
-   * @description
+   * Lets you set the current value.
    */
   @property({ type: String, reflect: true })
   value: string;
 
   /**
-   * @summary
-   * @description
+   * The [name](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#name) of the input field when submitting the form.
    */
   @property({ type: String, reflect: true })
   name: string;
 
   /**
-   * @summary
-   * @description
+   * When used with `number` this attribute forces inputs to be a whole number of `step`.
+   * 
+   * For example with a `step="5"` only values that divide evenly on 5 are allowed.
+   * Using arrow up and down in the input field increments and decrements by 5.
+   * 
+   * @summary Forces `number` inputs to be a whole number of `step`
    */
   @property({ type: Number, reflect: true })
   step: number;
 
   /**
-   * @summary
-   * @description
+   * A space-separated string that hints to browsers [what type of content it can suggest](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#value) to autofill.
    */
   @property({ type: String, reflect: true })
   autocomplete?: string;
@@ -194,13 +201,10 @@ class WarpTextField extends FormControlMixin(LitElement) {
    * Function to format value when the input field.
    *
    * Only active when the input field does not have focus,
-   * similar to the accessible input masking example from Filament Group
+   * similar to the accessible input [masking example from Filament Group](https://filamentgroup.github.io/politespace/demo/demo.html).
    *
-   * https://css-tricks.com/input-masking/
-   * https://filamentgroup.github.io/politespace/demo/demo.html
-   
-   * @summary
-   * @description
+   * @summary Function to format value when the input field
+   * @link https://css-tricks.com/input-masking/
   */
   @property({ attribute: false })
   formatter: (value: string) => string;
@@ -209,17 +213,11 @@ class WarpTextField extends FormControlMixin(LitElement) {
   @query('.w-textfield__mask')
   mask: HTMLDivElement;
 
-  /** @internal
-   * @summary
-   * @description
-   */
+  /** @internal */
   @property({ type: Boolean })
   _hasPrefix = false;
 
-  /** @internal
-   * @summary
-   * @description
-   */
+  /** @internal */
   @property({ type: Boolean })
   _hasSuffix = false;
 
@@ -339,8 +337,8 @@ class WarpTextField extends FormControlMixin(LitElement) {
             min="${ifDefined(this.min)}"
             max="${ifDefined(this.max)}"
             size="${ifDefined(this.size)}"
-            minlength="${ifDefined(this.minLength)}"
-            maxlength="${ifDefined(this.maxLength)}"
+            minlength="${ifDefined(this.minLength || this.minlength)}"
+            maxlength="${ifDefined(this.maxLength || this.maxlength)}"
             name="${ifDefined(this.name)}"
             pattern="${ifDefined(this.pattern)}"
             placeholder="${ifDefined(this.placeholder)}"


### PR DESCRIPTION
Colocate textfield docs and adjust the docs build slightly.

- Remove the redundant description jsdoc tag
- If no summary tag, use the first line of the jsdoc body/description
- Sort members alphabetically in the table and property list