### PR TITLE
fix(datepicker): ensure correct input value on date select and improve React event support

### DIFF
--- a/packages/datepicker/datepicker.ts
+++ b/packages/datepicker/datepicker.ts
@@ -386,12 +386,14 @@ class WarpDatepicker extends FormControlMixin(LitElement) {
         // Prevents whitespace from being added to the input field
         event.preventDefault();
         this.value = isoDate;
+        this.shadowRoot.querySelector('input').value = this.value;
         this.isCalendarOpen = false;
         this.toggleButton.focus();
         this.#dispatchChangeEvent();
       }
     } else {
       this.value = isoDate;
+      this.shadowRoot.querySelector('input').value = this.value;
       this.isCalendarOpen = false;
       this.#dispatchChangeEvent();
     }

--- a/packages/datepicker/react.ts
+++ b/packages/datepicker/react.ts
@@ -14,5 +14,9 @@ export const DatePicker = createComponent({
   events: {
     onChange: 'change',
     onchange: 'change',
+    onBlur: 'blur',
+    onblur: 'blur',
+    onInput: 'input',
+    oninput: 'input',
   },
 });


### PR DESCRIPTION
This PR is an improvement for what was suggested in [PR #623](https://github.com/warp-ds/elements/pull/623#issuecomment-4343710526). Thanks @wkillerud for the help again! 🙏 

## Summary
- Manually set the input element's `value` when a date is selected from the calendar, ensuring the displayed value stays in sync with the component's internal state. When selecting a date from the calendar popover, the component's `value` property was updated but the underlying `<input>` element's displayed value was not refreshed. 
- Add `blur` and `input` event mappings to the React wrapper, allowing consumers of the React-wrapped `DatePicker` to listen for value updates via a single `onBlur` handler rather than needing both `onInput` and `onChange`.

## Demo

https://github.com/user-attachments/assets/f03b0af6-cbb2-4d08-8bcc-f8c4ccd4e7e2

