### PR TITLE
fix(button): wrap react button wrapper and map camel case to snake case

### DIFF
--- a/.storybook-react/main.ts
+++ b/.storybook-react/main.ts
@@ -1,12 +1,35 @@
 import type { StorybookConfig } from '@storybook/react-vite';
+import { presetWarp } from '@warp-ds/uno';
+import uno from 'unocss/vite';
+import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
   framework: '@storybook/react-vite',
   core: {
+    builder: '@storybook/builder-vite',
     disableTelemetry: true,
   },
   stories: ['../packages/**/*.react.stories.tsx'],
   docs: {},
+
+  viteFinal(config, { configType }) {
+    return mergeConfig(config, {
+      base: process.env.STORYBOOK_BASE || '',
+      build: {
+        target: 'esnext',
+      },
+      plugins: [
+        uno({
+          presets: [presetWarp()],
+        }),
+        configType === 'DEVELOPMENT' &&
+          uno({
+            mode: 'shadow-dom',
+            presets: [presetWarp()],
+          }),
+      ],
+    });
+  },
 };
 
 export default config;

--- a/.storybook-react/preview.ts
+++ b/.storybook-react/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import 'virtual:uno.css';
 
 const preview: Preview = {
   parameters: {

--- a/packages/button/button.react.test.ts
+++ b/packages/button/button.react.test.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+
+import { Button } from './react.js';
+
+describe('Button React SSR', () => {
+  test('renders fullWidth as the full-width attribute', () => {
+    const html = renderToString(React.createElement(Button, { fullWidth: true }, 'Full width'));
+
+    expect(html).toContain('full-width');
+    expect(html).not.toContain('fullWidth');
+  });
+
+  test('renders iconOnly as the icon-only attribute', () => {
+    const html = renderToString(React.createElement(Button, { iconOnly: true }, 'Icon only'));
+
+    expect(html).toContain('icon-only');
+    expect(html).not.toContain('iconOnly');
+  });
+});

--- a/packages/button/react.ts
+++ b/packages/button/react.ts
@@ -5,19 +5,7 @@ import React from 'react';
 import { WarpButton } from './button.js';
 
 // decouple from CDN by providing a dummy class
-class Component extends LitElement {
-  get fullWidth(): boolean {
-    return false;
-  }
-
-  set fullWidth(_value: boolean) {}
-
-  get iconOnly(): boolean {
-    return false;
-  }
-
-  set iconOnly(_value: boolean) {}
-}
+class Component extends LitElement {}
 
 const BaseButton = createComponent({
   tagName: 'w-button',
@@ -35,8 +23,6 @@ type ButtonProps = Omit<BaseButtonProps, 'full-width' | 'icon-only'> & {
 export const Button = React.forwardRef<WarpButton, ButtonProps>(({ fullWidth, iconOnly, ...props }, ref) =>
   React.createElement(BaseButton, {
     ...props,
-    ...(fullWidth !== undefined ? { fullWidth } : {}),
-    ...(iconOnly !== undefined ? { iconOnly } : {}),
     ...(fullWidth ? { 'full-width': true } : {}),
     ...(iconOnly ? { 'icon-only': true } : {}),
     ref,

--- a/packages/button/react.ts
+++ b/packages/button/react.ts
@@ -5,10 +5,45 @@ import React from 'react';
 import { WarpButton } from './button.js';
 
 // decouple from CDN by providing a dummy class
-class Component extends LitElement {}
+class Component extends LitElement {
+  get fullWidth(): boolean {
+    return false;
+  }
 
-export const Button = createComponent({
+  set fullWidth(_value: boolean) {}
+
+  get iconOnly(): boolean {
+    return false;
+  }
+
+  set iconOnly(_value: boolean) {}
+}
+
+const BaseButton = createComponent({
   tagName: 'w-button',
   elementClass: Component as unknown as typeof WarpButton,
   react: React,
 });
+
+type BaseButtonProps = React.ComponentPropsWithoutRef<typeof BaseButton>;
+
+type ButtonProps = Omit<BaseButtonProps, 'full-width' | 'icon-only'> & {
+  fullWidth?: boolean;
+  iconOnly?: boolean;
+};
+
+export const Button = React.forwardRef<WarpButton, ButtonProps>(({ fullWidth, iconOnly, ...props }, ref) =>
+  React.createElement(BaseButton, {
+    ...props,
+    ...(fullWidth !== undefined ? { fullWidth } : {}),
+    ...(iconOnly !== undefined ? { iconOnly } : {}),
+    ...(fullWidth ? { 'full-width': true } : {}),
+    ...(iconOnly ? { 'icon-only': true } : {}),
+    ref,
+  } as React.ComponentProps<typeof BaseButton> & {
+    'full-width'?: boolean;
+    'icon-only'?: boolean;
+  }),
+);
+
+Button.displayName = 'Button';


### PR DESCRIPTION
Fixes an issue reported regarding camel case property names in React wrappers. We will need to do this for all components that use any camel case properties.