### PR TITLE
fix(modal-header): prevent close and back buttons from inheriting modal title tooltip

### DIFF
--- a/packages/modal-header/modal-header.ts
+++ b/packages/modal-header/modal-header.ts
@@ -64,16 +64,15 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   }
 
   get backButton() {
-    const backLabel = i18n._({
-      id: 'modal.aria.back',
-      message: 'Back',
-      comment: 'Aria label for the back button in modal',
-    });
     return this.back && !this._hasTopContent // Not showing back button when there is a top image
       ? html`<button
           type="button"
-          title="${backLabel}"
-          aria-label="${backLabel}"
+          title=""
+          aria-label="${i18n._({
+            id: 'modal.aria.back',
+            message: 'Back',
+            comment: 'Aria label for the back button in modal',
+          })}"
           class="header-button header-button-left"
           @click="${this.emitBack}">
           <w-icon name="ArrowLeft" size="small" locale="${detectLocale()}" style="display: flex;" class="flex"></w-icon>
@@ -82,16 +81,15 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   }
   get closeButton() {
     if (this.noClose) return nothing;
-    const closeLabel = i18n._({
-      id: 'modal.aria.close',
-      message: 'Close',
-      comment: 'Aria label for the close button in modal',
-    });
     return html`<div class="header-close-button-container">
         <w-button
             type="button"
-            title="${closeLabel}"
-            aria-label="${closeLabel}"
+            title=""
+            aria-label="${i18n._({
+              id: 'modal.aria.close',
+              message: 'Close',
+              comment: 'Aria label for the close button in modal',
+            })}"
             variant="pill"
             small=""
             @click="${this.close}">

--- a/packages/modal-header/modal-header.ts
+++ b/packages/modal-header/modal-header.ts
@@ -64,14 +64,16 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   }
 
   get backButton() {
+    const backLabel = i18n._({
+      id: 'modal.aria.back',
+      message: 'Back',
+      comment: 'Aria label for the back button in modal',
+    });
     return this.back && !this._hasTopContent // Not showing back button when there is a top image
       ? html`<button
           type="button"
-          aria-label="${i18n._({
-            id: 'modal.aria.back',
-            message: 'Back',
-            comment: 'Aria label for the back button in modal',
-          })}"
+          title="${backLabel}"
+          aria-label="${backLabel}"
           class="header-button header-button-left"
           @click="${this.emitBack}">
           <w-icon name="ArrowLeft" size="small" locale="${detectLocale()}" style="display: flex;" class="flex"></w-icon>
@@ -80,14 +82,16 @@ export class ModalHeader extends CanCloseMixin(LitElement) {
   }
   get closeButton() {
     if (this.noClose) return nothing;
+    const closeLabel = i18n._({
+      id: 'modal.aria.close',
+      message: 'Close',
+      comment: 'Aria label for the close button in modal',
+    });
     return html`<div class="header-close-button-container">
         <w-button
             type="button"
-            aria-label="${i18n._({
-              id: 'modal.aria.close',
-              message: 'Close',
-              comment: 'Aria label for the close button in modal',
-            })}"
+            title="${closeLabel}"
+            aria-label="${closeLabel}"
             variant="pill"
             small=""
             @click="${this.close}">


### PR DESCRIPTION
## Description
The close and back buttons inside modal-header were inheriting the host element's title attribute (the modal heading text) as a tooltip on hover. This happened because the title property on the Lit component maps to the native HTML title attribute, which browsers propagate to all descendant elements.

### Changes
Extract the i18n label into a const in both closeButton and backButton getters to avoid duplication
Set title on both buttons to match their aria-label, so hovering shows "Close" / "Back" (localized) instead of the modal heading