### PR TITLE
feat(combobox): add support for option element children

### DIFF
--- a/packages/combobox/combobox.a11y.test.ts
+++ b/packages/combobox/combobox.a11y.test.ts
@@ -55,7 +55,37 @@ describe('w-combobox accessibility (WCAG 2.2)', () => {
     });
 
     test('open on focus state has no violations', async () => {
-      const page = render(html`<w-combobox label="Select a fruit" open-on-focus .options="${sampleOptions}"></w-combobox>`);
+      const page = render(
+        html`<w-combobox label="Select a fruit" open-on-focus .options="${sampleOptions}"></w-combobox>`,
+      );
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('with light-DOM option children has no violations', async () => {
+      const page = render(html`
+        <w-combobox label="Select a fruit">
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="orange">Orange</option>
+        </w-combobox>
+      `);
+      await expect(page).toHaveNoAxeViolations();
+    });
+
+    test('open with light-DOM option children has no violations', async () => {
+      const page = render(html`
+        <w-combobox data-testid="combobox" label="Select a fruit" open-on-focus>
+          <option value="apple">Apple</option>
+          <option value="banana">Banana</option>
+          <option value="orange">Orange</option>
+        </w-combobox>
+      `);
+      const el = (await page.getByTestId('combobox').element()) as HTMLElement;
+      const input = el?.shadowRoot?.querySelector('w-textfield')?.shadowRoot?.querySelector('input');
+
+      input?.focus();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
       await expect(page).toHaveNoAxeViolations();
     });
   });

--- a/packages/combobox/combobox.hydration.test.ts
+++ b/packages/combobox/combobox.hydration.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
 import { setupHydrationWarningCapture, testHydration } from '../../tests/react-hydration';
 
 import './combobox.js';
@@ -86,6 +87,53 @@ describe('w-combobox React SSR hydration', () => {
 
       // Give the custom element a tick to upgrade and reflect defaults
       // before React hydrates the tree.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      function App() {
+        return React.createElement('section', {
+          className: 'example',
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: test reproduces React hydration mismatch path
+          dangerouslySetInnerHTML: { __html: innerHtml },
+        });
+      }
+
+      hydrateRoot(container, React.createElement(App), {
+        onRecoverableError: (error: unknown) => {
+          const msg = error instanceof Error ? error.message : String(error);
+          if (
+            msg.includes('Hydration') ||
+            msg.includes('hydrat') ||
+            msg.includes('did not match') ||
+            msg.includes("didn't match")
+          ) {
+            window.__HYDRATION_WARNINGS__.push(msg);
+          }
+        },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(window.__HYDRATION_WARNINGS__).toEqual([]);
+    } finally {
+      document.body.removeChild(container);
+    }
+  });
+
+  test('declarative option children hydrate without attribute mismatch warnings', async () => {
+    const container = document.createElement('div');
+    container.id = 'hydration-options-root';
+    document.body.appendChild(container);
+
+    const innerHtml = [
+      '<w-combobox id="demo-combobox" label="Search">',
+      '<option value="apple">Apple</option>',
+      '<option value="banana">Banana</option>',
+      '</w-combobox>',
+    ].join('');
+
+    try {
+      container.innerHTML = `<section class="example">${innerHtml}</section>`;
+
       await new Promise((resolve) => setTimeout(resolve, 50));
 
       function App() {

--- a/packages/combobox/combobox.stories.ts
+++ b/packages/combobox/combobox.stories.ts
@@ -15,7 +15,11 @@ const meta: Meta<typeof args> = {
   title: 'Forms/Combobox',
   component: 'w-combobox',
   render(args) {
-    return html` <w-combobox ${spread(prespread(args))} .options="${sampleOptions}"></w-combobox> `;
+    return html`
+      <w-combobox ${spread(prespread(args))}>
+        ${sampleOptionElements}
+      </w-combobox>
+    `;
   },
   parameters: {
     docs: {
@@ -44,24 +48,36 @@ const sampleOptions = [
   { value: 'mango', label: 'Mango' },
 ];
 
+const sampleOptionElements = html`
+  <option value="apple">Apple</option>
+  <option value="banana">Banana</option>
+  <option value="orange">Orange</option>
+  <option value="grape">Grape</option>
+  <option value="strawberry">Strawberry</option>
+  <option value="pineapple">Pineapple</option>
+  <option value="mango">Mango</option>
+`;
+
 export const Default: Story = {
   args: {},
   render: () =>
-    html` <w-combobox label="Select a fruit" placeholder="Type to search..." .options="${sampleOptions}"></w-combobox> `,
+    html`
+      <w-combobox label="Select a fruit" placeholder="Type to search...">
+        ${sampleOptionElements}
+      </w-combobox>
+    `,
 };
 
 export const WithValue: Story = {
   args: {
-    options: sampleOptions,
     label: 'Select a fruit',
     placeholder: 'Type to search...',
-    value: 'Apple',
+    value: 'apple',
   },
 };
 
 export const OpenOnFocus: Story = {
   args: {
-    options: sampleOptions,
     label: 'Select a fruit',
     placeholder: 'Type to search...',
     openOnFocus: true,
@@ -70,7 +86,6 @@ export const OpenOnFocus: Story = {
 
 export const WithTextMatching: Story = {
   args: {
-    options: sampleOptions,
     label: 'Select a fruit',
     placeholder: 'Type to search...',
     matchTextSegments: true,
@@ -79,7 +94,6 @@ export const WithTextMatching: Story = {
 
 export const Invalid: Story = {
   args: {
-    options: sampleOptions,
     label: 'Select a fruit',
     placeholder: 'Type to search...',
     value: 'Invalid fruit',
@@ -90,17 +104,15 @@ export const Invalid: Story = {
 
 export const Disabled: Story = {
   args: {
-    options: sampleOptions,
     label: 'Select a fruit',
     placeholder: 'Type to search...',
-    value: 'Apple',
+    value: 'apple',
     disabled: true,
   },
 };
 
 export const Optional: Story = {
   args: {
-    options: sampleOptions,
     label: 'Select a fruit',
     placeholder: 'Type to search...',
     optional: true,
@@ -144,17 +156,19 @@ export const FormSubmission: Story = {
         name="warp-combo-1"
         label="Select a fruit (dynamic)"
         placeholder="Type to search..."
-        .options="${sampleOptions}"
-      ></w-combobox>
+      >
+        ${sampleOptionElements}
+      </w-combobox>
       <br>
       <w-combobox
         id="form-submission"
         name="warp-combo-2"
         label="Select a fruit (dynamic)"
-        value="Banana"
+        value="banana"
         placeholder="Type to search..."
-        .options="${sampleOptions}"
-      ></w-combobox>
+      >
+        ${sampleOptionElements}
+      </w-combobox>
         <button type="reset">Reset</button>
         <button type="submit">Submit</button>
     </form>

--- a/packages/combobox/combobox.test.ts
+++ b/packages/combobox/combobox.test.ts
@@ -181,3 +181,143 @@ test('announces suggestion count when opened on focus with empty input', async (
   const statusText = el.shadowRoot?.querySelector('[role="status"]')?.textContent?.trim();
   expect(statusText).toBe('3 suggestions');
 });
+
+test('renders light-DOM option children in the generated popup', async () => {
+  const component = html`
+    <w-combobox data-testid="combobox" open-on-focus>
+      <option value="no">Norway</option>
+      <option value="se">Sweden</option>
+      <option value="dk">Denmark</option>
+    </w-combobox>
+  `;
+
+  const page = render(component);
+  const locator = page.getByTestId('combobox');
+  await expect.element(locator).toBeVisible();
+  const el = (await locator.element()) as HTMLElement;
+  const input = el.shadowRoot?.querySelector('w-textfield')?.shadowRoot?.querySelector('input');
+
+  input?.focus();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const visibleOptions = el.shadowRoot?.querySelectorAll('[role="listbox"] [role="option"]');
+  const optionTexts = Array.from(visibleOptions || []).map((opt) => opt.textContent?.trim());
+
+  expect(optionTexts).toEqual(['Norway', 'Sweden', 'Denmark']);
+});
+
+test('filters light-DOM options by label attribute and stores option value on select', async () => {
+  const component = html`
+    <w-combobox data-testid="combobox" open-on-focus>
+      <option value="us" label="United States">US</option>
+      <option value="uk" label="United Kingdom">UK</option>
+      <option value="no">Norway</option>
+    </w-combobox>
+  `;
+
+  const page = render(component);
+  const locator = page.getByTestId('combobox');
+  await expect.element(locator).toBeVisible();
+  const el = (await locator.element()) as HTMLElement & { value: string };
+  const input = el.shadowRoot?.querySelector('w-textfield')?.shadowRoot?.querySelector('input') as HTMLInputElement;
+  const selectEvents: CustomEvent[] = [];
+
+  el.addEventListener('select', (event) => selectEvents.push(event as CustomEvent));
+
+  input.focus();
+  input.value = 'United';
+  input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const visibleOptions = el.shadowRoot?.querySelectorAll('[role="listbox"] [role="option"]');
+  const optionTexts = Array.from(visibleOptions || []).map((opt) => opt.textContent?.trim());
+
+  expect(optionTexts).toEqual(['United States', 'United Kingdom']);
+
+  visibleOptions?.[1]?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  expect(input.value).toBe('United Kingdom');
+  expect(el.value).toBe('uk');
+  expect(selectEvents.at(-1)?.detail).toEqual({ value: 'uk' });
+});
+
+test('uses light-DOM options to display an initial value label', async () => {
+  const component = html`
+    <w-combobox data-testid="combobox" value="no">
+      <option value="se">Sweden</option>
+      <option value="no">Norway</option>
+    </w-combobox>
+  `;
+
+  const page = render(component);
+  const locator = page.getByTestId('combobox');
+  await expect.element(locator).toBeVisible();
+  const el = (await locator.element()) as HTMLElement & { value: string };
+  const input = el.shadowRoot?.querySelector('w-textfield')?.shadowRoot?.querySelector('input') as HTMLInputElement;
+
+  expect(input.value).toBe('Norway');
+  expect(el.value).toBe('no');
+});
+
+test('syncs dynamic light-DOM option child changes', async () => {
+  const component = html`
+    <w-combobox data-testid="combobox" open-on-focus>
+      <option value="no">Norway</option>
+      <option value="se">Sweden</option>
+    </w-combobox>
+  `;
+
+  const page = render(component);
+  const locator = page.getByTestId('combobox');
+  await expect.element(locator).toBeVisible();
+  const el = (await locator.element()) as HTMLElement;
+  const input = el.shadowRoot?.querySelector('w-textfield')?.shadowRoot?.querySelector('input') as HTMLInputElement;
+
+  const denmark = document.createElement('option');
+  denmark.value = 'dk';
+  denmark.textContent = 'Denmark';
+  el.appendChild(denmark);
+
+  const sweden = el.querySelector('option[value="se"]');
+  sweden?.remove();
+
+  const norway = el.querySelector('option[value="no"]');
+  norway?.setAttribute('value', 'nor');
+  if (norway) {
+    norway.textContent = 'Norge';
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  input.focus();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const visibleOptions = el.shadowRoot?.querySelectorAll('[role="listbox"] [role="option"]');
+  const optionTexts = Array.from(visibleOptions || []).map((opt) => opt.textContent?.trim());
+
+  expect(optionTexts).toEqual(['Norge', 'Denmark']);
+});
+
+test('non-empty options property takes precedence over light-DOM option children', async () => {
+  const options = [{ value: 'apple', label: 'Apple' }];
+  const component = html`
+    <w-combobox data-testid="combobox" open-on-focus .options="${options}">
+      <option value="banana">Banana</option>
+    </w-combobox>
+  `;
+
+  const page = render(component);
+  const locator = page.getByTestId('combobox');
+  await expect.element(locator).toBeVisible();
+  const el = (await locator.element()) as HTMLElement;
+  const input = el.shadowRoot?.querySelector('w-textfield')?.shadowRoot?.querySelector('input') as HTMLInputElement;
+
+  input.focus();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const visibleOptions = el.shadowRoot?.querySelectorAll('[role="listbox"] [role="option"]');
+  const optionTexts = Array.from(visibleOptions || []).map((opt) => opt.textContent?.trim());
+
+  expect(optionTexts).toEqual(['Apple']);
+});

--- a/packages/combobox/combobox.ts
+++ b/packages/combobox/combobox.ts
@@ -46,107 +46,122 @@ interface OptionWithIdAndMatch extends ComboboxOption {
  * [See Storybook for usage examples](https://warp-ds.github.io/elements/?path=/docs/forms-combobox--docs)
  */
 export class WarpCombobox extends FormControlMixin(LitElement) {
-  /** The available options to select from
-   * @summary
-   * @description
+  /**
+   * The available options to select from.
+   *
+   * Use this for framework usage, application state, or remote search results. When `options` contains entries, it is used instead of child `<option>` elements.
    */
   @property({ type: Array })
   options: ComboboxOption[] = [];
 
-  /** Label above input
-   * @summary
-   * @description
+  /**
+   * The label displayed above the input.
+   *
+   * Use this to give the combobox a visible and accessible name.
    */
   @property({ type: String, reflect: true, useDefault: true })
   label?: string = '';
 
-  /** Input placeholder
-   * @summary
-   * @description
+  /**
+   * Placeholder text displayed when the input is empty.
+   *
+   * Use this as a short hint for the expected input. Do not use placeholder text as a replacement for a label.
    */
   @property({ type: String, reflect: true, useDefault: true })
   placeholder?: string = '';
 
-  /** The input value
-   * @summary
-   * @description
+  /**
+   * The selected or typed value.
+   *
+   * When an option is selected, this is set to the option value. The displayed text may differ when the option has a separate label.
    */
   @property({ type: String, reflect: true, useDefault: true })
   value = '';
 
-  /** Whether the popover opens when focus is on the text field
-   * @summary
-   * @description
+  /**
+   * Whether the option list opens when the input receives focus.
+   *
+   * Use this when users should see available options before they start typing.
    */
   @property({ type: Boolean, attribute: 'open-on-focus', reflect: true })
   openOnFocus = false;
 
-  /** Select active option on blur
-   * @summary
-   * @description
+  /**
+   * Whether the active option is selected when the input loses focus.
+   *
+   * When enabled, the combobox selects the keyboard-highlighted option, or an option whose value exactly matches the current input value, on blur.
    */
   @property({ type: Boolean, attribute: 'select-on-blur', reflect: true, useDefault: true })
   selectOnBlur = true;
 
-  /** Whether the matching text segments in the options should be highlighted
-   * @summary
-   * @description
+  /**
+   * Whether matching text segments in options are highlighted.
+   *
+   * Use this to visually emphasize the part of each option that matches the current input value.
    */
   @property({ type: Boolean, attribute: 'match-text-segments', reflect: true })
   matchTextSegments = false;
 
-  /** Disable client-side static filtering
-   * @summary
-   * @description
+  /**
+   * Whether built-in client-side filtering is disabled.
+   *
+   * Use this for remote search or externally filtered results. When disabled, all entries in `options` are rendered as provided.
    */
   @property({ type: Boolean, attribute: 'disable-static-filtering', reflect: true })
   disableStaticFiltering = false;
 
-  /** Renders the input field in an invalid state
-   * @summary
-   * @description
+  /**
+   * Whether the combobox is visually invalid.
+   *
+   * Use this to show an externally managed validation error. Pair it with `help-text` to explain how to fix the error.
    */
   @property({ type: Boolean, reflect: true })
   invalid = false;
 
-  /** The content to display as the help text
-   * @summary
-   * @description
+  /**
+   * Help text displayed below the input.
+   *
+   * Use this for supporting guidance or validation feedback.
    */
   @property({ type: String, attribute: 'help-text', reflect: true, useDefault: true })
   helpText?: string = '';
 
-  /** Whether the element is disabled
-   * @summary
-   * @description
+  /**
+   * Whether the combobox is disabled.
+   *
+   * Disabled comboboxes cannot be focused, changed, or submitted with form data.
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
 
-  /** Whether the element is required
-   * @summary
-   * @description
+  /**
+   * Whether the combobox is required before form submission.
+   *
+   * Use this when the user must provide a value before submitting the form.
    */
   @property({ type: Boolean, reflect: true })
   required = false;
 
-  /** Whether to show optional text
-   * @summary
-   * @description
+  /**
+   * Whether to show optional text next to the label.
+   *
+   * Use this to indicate that the combobox is not required.
    */
   @property({ type: Boolean, reflect: true })
   optional = false;
 
-  /** Name attribute for form submission
-   * @summary
-   * @description
+  /**
+   * The name submitted with the combobox value.
+   *
+   * Use this when the combobox belongs to a form and its value should be included in form data.
    */
   @property({ type: String, reflect: true, useDefault: true })
   name?: string = '';
 
-  /** Autocomplete attribute for the input field
-   * @summary
-   * @description
+  /**
+   * The autocomplete attribute passed to the internal input.
+   *
+   * Defaults to `off`. Set this when browser autocomplete should be enabled or scoped to a specific autocomplete token.
    */
   @property({ type: String, reflect: true, useDefault: true })
   autocomplete?: string = 'off';

--- a/packages/combobox/combobox.ts
+++ b/packages/combobox/combobox.ts
@@ -163,6 +163,10 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
   @state()
   private _currentOptions: OptionWithIdAndMatch[] = [];
 
+  /** @internal Options parsed from light-DOM <option> children */
+  @state()
+  private _lightDomOptions: ComboboxOption[] = [];
+
   /** @internal Unique identifier counter for options */
   @state()
   private _optionIdCounter = 0;
@@ -180,6 +184,7 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
 
   // capture the initial value using firstUpdated and #initialValue
   #initialValue: string | null = null;
+  #lightDomObserver?: MutationObserver;
 
   firstUpdated(changedProps: Map<string, unknown>) {
     this.#initialValue = this.value;
@@ -195,6 +200,28 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
     this.value = this.#initialValue;
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.#syncOptionsFromLightDom();
+
+    this.#lightDomObserver = new MutationObserver(() => {
+      this.#syncOptionsFromLightDom();
+    });
+    this.#lightDomObserver.observe(this, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['label', 'value'],
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#lightDomObserver?.disconnect();
+  }
+
   private get _listboxId() {
     return `${this._id}-listbox`;
   }
@@ -205,6 +232,10 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
 
   private get _helpId() {
     return this.helpText ? `${this._id}__hint` : undefined;
+  }
+
+  private get _sourceOptions() {
+    return Array.isArray(this.options) && this.options.length ? this.options : this._lightDomOptions;
   }
 
   /** Get the display text for the navigation option or current display value */
@@ -228,6 +259,23 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
       key: option.key || option.value,
       currentInputValue,
     }));
+  }
+
+  #getOptionNodes() {
+    return Array.from(this.children).filter((child) => child.tagName.toLowerCase() === 'option') as HTMLOptionElement[];
+  }
+
+  #syncOptionsFromLightDom() {
+    this._lightDomOptions = this.#getOptionNodes().map((option) => {
+      const value = option.getAttribute('value') ?? '';
+      const label = option.hasAttribute('label') ? (option.getAttribute('label') ?? '') : (option.textContent ?? '');
+
+      return {
+        value,
+        label,
+        key: value,
+      };
+    });
   }
 
   /** Get ARIA text for screen readers */
@@ -496,10 +544,11 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
   }
 
   protected willUpdate(changedProperties: PropertyValues<this>) {
-    const options = Array.isArray(this.options) ? this.options : [];
+    const options = this._sourceOptions;
+    const lightDomOptionsChanged = (changedProperties as Map<string, unknown>).has('_lightDomOptions');
 
     // Sync _displayValue when value or options change externally (before filtering)
-    if (changedProperties.has('value') || changedProperties.has('options')) {
+    if (changedProperties.has('value') || changedProperties.has('options') || lightDomOptionsChanged) {
       const matchingOption = options.find((o) => o.value === this.value);
       // Only sync if this is an external value change (not from user typing)
       // We detect this by checking if _displayValue doesn't match the expected label
@@ -515,6 +564,7 @@ export class WarpCombobox extends FormControlMixin(LitElement) {
 
     if (
       changedProperties.has('options') ||
+      lightDomOptionsChanged ||
       changedProperties.has('value') ||
       changedProperties.has('disableStaticFiltering') ||
       (changedProperties as Map<string, unknown>).has('_displayValue')

--- a/packages/combobox/docs/accessibility.md
+++ b/packages/combobox/docs/accessibility.md
@@ -1,1 +1,72 @@
 ## Accessibility
+
+Combobox renders an input with `role="combobox"` and a popup list with `role="listbox"`. Each suggestion is rendered with `role="option"`, and the active suggestion is connected to the input with `aria-activedescendant`.
+
+### Provide A Label
+
+Always provide a visible label.
+
+```html
+<w-combobox label="Country" placeholder="Search">
+  <option value="no">Norway</option>
+  <option value="se">Sweden</option>
+  <option value="dk">Denmark</option>
+</w-combobox>
+```
+
+Do not rely on placeholder text as the only label. Placeholder text disappears as soon as the user types and is not a reliable accessible name.
+
+### Help Text And Errors
+
+Use `help-text` for extra guidance or validation feedback.
+
+```html
+<w-combobox label="Country" help-text="Start typing to filter countries">
+  <option value="no">Norway</option>
+  <option value="se">Sweden</option>
+  <option value="dk">Denmark</option>
+</w-combobox>
+```
+
+When the combobox is invalid, pair `invalid` with help text that explains how to correct the error.
+
+```html
+<w-combobox label="Country" invalid help-text="Select a country from the list">
+  <option value="no">Norway</option>
+  <option value="se">Sweden</option>
+  <option value="dk">Denmark</option>
+</w-combobox>
+```
+
+Do not rely on invalid styling alone.
+
+### Keyboard Interaction
+
+The input follows common combobox keyboard behavior:
+
+- Arrow Down and Arrow Up open the list and move between suggestions.
+- Home and End move to the first and last suggestion.
+- Page Up and Page Down move through suggestions in larger steps.
+- Enter selects the active suggestion.
+- Escape closes the list. When the list is already closed, Escape clears the value.
+- Tab closes the list and moves focus onward.
+
+### Suggestions
+
+The component announces the number of available suggestions through a screen-reader-only status message while the list is open.
+
+Keep option labels short and unique enough to distinguish. If the submitted `value` differs from what users should read, provide a clear option label.
+
+```html
+<w-combobox label="Country" placeholder="Search">
+  <option value="us" label="United States">US</option>
+  <option value="uk" label="United Kingdom">UK</option>
+  <option value="no">Norway</option>
+</w-combobox>
+```
+
+### Disabled Comboboxes
+
+Avoid disabled comboboxes where possible. Disabled controls can be hard to discover and do not explain why the field is unavailable.
+
+Prefer leaving the combobox enabled and showing validation or explanatory feedback when the user tries to continue.

--- a/packages/combobox/docs/examples.md
+++ b/packages/combobox/docs/examples.md
@@ -1,1 +1,45 @@
 ## Examples
+
+<elements-example>
+
+```html
+<w-combobox label="Fruit" placeholder="Type to search">
+    <option value="apple">Apple</option>
+    <option value="banana">Banana</option>
+    <option value="orange">Orange</option>
+</w-combobox>
+```
+
+</elements-example>
+
+### Different label and value
+
+Use the `label` attribute when the visible suggestion should differ from the selected value.
+
+<elements-example>
+
+```html
+<w-combobox label="Country" placeholder="Search">
+    <option value="us" label="United States">US</option>
+    <option value="uk" label="United Kingdom">UK</option>
+    <option value="no">Norway</option>
+</w-combobox>
+```
+
+</elements-example>
+
+### Dynamic options
+
+Use the `options` property when options come from application state or a remote search.
+
+```js
+const combobox = document.querySelector('w-combobox');
+
+combobox.options = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'orange', label: 'Orange' },
+];
+```
+
+Child option content is plain text. Rich option content is not supported.

--- a/packages/combobox/docs/usage.md
+++ b/packages/combobox/docs/usage.md
@@ -1,1 +1,29 @@
 ## Usage
+
+Use child `<option>` elements for declarative HTML usage.
+
+<elements-example>
+
+```html
+<w-combobox label="Country" placeholder="Search">
+    <option value="no">Norway</option>
+    <option value="se">Sweden</option>
+    <option value="dk">Denmark</option>
+</w-combobox>
+```
+
+</elements-example>
+
+The option text is used as the visible suggestion. The `value` attribute is used as the submitted and selected value.
+
+For framework usage or dynamic data, you may set the `options` property instead.
+
+```js
+combobox.options = [
+  { value: 'no', label: 'Norway' },
+  { value: 'se', label: 'Sweden' },
+  { value: 'dk', label: 'Denmark' },
+];
+```
+
+When `options` contains entries, it is used instead of child `<option>` elements.


### PR DESCRIPTION
This had been irking me for a while so decided to fix while I was looking at the docs.
Essentially mirrors how select works and allows option elements to be used as children to define options for the combobox.

```js
<w-combobox label="Select a fruit">
  <option value="apple">Apple</option>
  <option value="banana">Banana</option>
  <option value="orange">Orange</option>
</w-combobox>
```

Also still supports the .options property syntax

Also adds docs