### PR TITLE
fix(modal): Modal dispatches spurious `hidden` event

### DIFF
--- a/packages/modal/modal.ts
+++ b/packages/modal/modal.ts
@@ -41,6 +41,8 @@ export class WarpModal extends ProvidesCanCloseToSlotsMixin(LitElement) {
   @query('.content-el')
   private contentEl: HTMLElement;
 
+  private _isClosing = false;
+
   constructor() {
     super();
     this.interceptEscape = this.interceptEscape.bind(this);
@@ -64,6 +66,10 @@ export class WarpModal extends ProvidesCanCloseToSlotsMixin(LitElement) {
   }
 
   async open() {
+    // Cancel any pending close animation/state to prevent spurious 'hidden' events
+    this._isClosing = false;
+    this.dialogEl.classList.remove('close');
+
     this.dialogEl.showModal();
     this.handleListeners();
     setupScrollLock(this.contentEl);
@@ -73,13 +79,19 @@ export class WarpModal extends ProvidesCanCloseToSlotsMixin(LitElement) {
 
   close() {
     if (!this.dialogEl?.open) return;
+    this._isClosing = true;
     this.handleListeners('removeEventListener');
     this.dialogEl.classList.add('close');
     this.dialogEl.addEventListener(
       'animationend',
-      async () => {
+      async (event: AnimationEvent) => {
+        // Only handle our modal's close animation, ignore backdrop animations
+        if (event.animationName !== 'w-modal-out') return;
+        // If close was cancelled (e.g. modal was reopened), don't proceed
+        if (!this._isClosing) return;
         this.dialogEl.classList.remove('close');
         this.dialogEl.close();
+        this._isClosing = false;
         teardownScrollLock();
         await this.updateComplete;
         this.dispatchEvent(new CustomEvent('hidden', { bubbles: true, composed: true }));


### PR DESCRIPTION
## Fix: Modal dispatches spurious `hidden` event when reopened after backdrop/Escape close

### Problem

The `w-modal` component dispatches a spurious `hidden` event immediately when reopened after being closed via backdrop click, Escape key, or the X button. This causes the modal to open briefly and then immediately close again.

The bug only manifests in environment builds and does not occur when closing programmatically (i.e., setting `show=false` from the parent framework).

### Root cause

When the web component initiates its own close (backdrop/Escape/X), the `animationend` listener on the dialog can fire for the backdrop's animation (`backdrop-out`) rather than the modal's animation (`w-modal-out`), or stale close state can persist into the next open cycle — leading to a spurious `hidden` event dispatch on reopen.

### Consumer workaround

Use React's `key` prop to force a fresh `w-modal` element on each open:

```tsx
const [modalKey, setModalKey] = useState(0);
const [open, setOpen] = useState(false);

// When opening:
setModalKey(k => k + 1);
setOpen(true);

// Render:
<Modal key={modalKey} show={open} onhidden={onDismiss}>
```

### Fix

Three complementary guards in `packages/modal/modal.ts`:

1. **`_isClosing` flag** — `close()` sets it to `true`; `open()` resets it to `false`. The `animationend` handler checks this flag before dispatching `hidden`, so a cancelled or already-completed close never emits the event.

2. **`animationName` check** — The `animationend` handler now verifies that the event corresponds to the `w-modal-out` animation, ignoring unrelated animations (e.g., `backdrop-out`).

3. **State cleanup in `open()`** — Removes the `close` CSS class and resets the flag before calling `showModal()`, ensuring no stale close-cycle state leaks into the new open cycle.

### Consumer impact

- No API changes; fully backwards-compatible.
- The `key`-prop workaround is no longer necessary (but still harmless if left in place).