### PR TITLE
fix(icon): narrow type for icon size

### DIFF
--- a/packages/icon/icon.ts
+++ b/packages/icon/icon.ts
@@ -6,6 +6,8 @@ import { styles } from './style.js';
 // Generic parser for fetch responses
 type ResponseParser<T> = (response: Response) => Promise<T>;
 
+type PixelValue = `${number}px`;
+
 interface CacheFetchOptions<T> {
   responseParser?: ResponseParser<T>;
 }
@@ -41,7 +43,7 @@ export class WarpIcon extends LitElement {
    * @default "medium"
    */
   @property({ type: String, reflect: true })
-  size: 'small' | 'medium' | 'large' | string;
+  size: 'small' | 'medium' | 'large' | PixelValue;
 
   /** 
    * Locale used for `<title>` text.


### PR DESCRIPTION
Improves the type hints for the `size` prop by adding a pixel value type and dropping the `string` type, which made the type collaps down to just `string`