### PR TITLE
fix: use unsafeCSS in generated styles to prevent SWC escaping corruption

### DIFF
--- a/build/styles.js
+++ b/build/styles.js
@@ -49,7 +49,7 @@ const buildCSS = async (
   });
   output = code.toString();
 
-  return output.replace(/\\/g, '\\\\');
+  return output;
 };
 
 /**
@@ -71,7 +71,7 @@ const plugin = ({ filter = /\.ts$/, placeholder = '@warp-css;', minify = true } 
           const css = await buildCSS(contents, { minify });
           await writeFile(
             path.dirname(args.path) + '/styles.ts',
-            `import { css } from 'lit'; export const styles = css\`${css}\`;
+            `import { unsafeCSS } from 'lit'; export const styles = unsafeCSS(${JSON.stringify(css)});
 `,
           );
         }


### PR DESCRIPTION
PR #682 introduced @rollup/plugin-swc for browserslist compilation. SWC corrupts backslash escaping inside css`` tagged template literals in the generated styles.ts files. Specifically, \\[ (double-escaped bracket) gets reduced to \[, which the CSS parser interprets as a bare [ — breaking the selector and causing replaceSync() to silently drop all subsequent CSS rules.

This makes w-switch (and other components using Tailwind-like arbitrary value selectors like bg-[--w-color-...]) invisible because their utility CSS (w-44, h-24, block, etc.) never reaches the shadow DOM's adoptedStyleSheets.

Fix: use unsafeCSS() with JSON.stringify() instead of the css`` tagged template literal. unsafeCSS is Lit's official API for programmatically generated CSS strings, and JSON.stringify handles all escaping correctly without being affected by SWC transpilation.

Verified on iOS 15.2 simulator (Safari 15) — all components render correctly with the patched bundle.