### PR TITLE
docs: fix modal react wrapper example, highlight gotcha in JSDoc

### DIFF
--- a/packages/modal/modal.react.stories.tsx
+++ b/packages/modal/modal.react.stories.tsx
@@ -19,10 +19,11 @@ export const Default: StoryObj = {
     const [back, setBack] = useState(false);
     return (
       <>
+        <p>If you keep the <code>open</code> state, listen to <code>onHidden</code> so you can update the state when the user clicks the backdrop, close button, or presses <kbd>Escape</kbd>.</p>
         <Button variant="primary" onClick={() => setOpen(true)}>
           Open Modal
         </Button>
-        <Modal show={open} id="example-modal-one">
+        <Modal show={open} id="example-modal-one" onHidden={() => setOpen(false)} onShown={() => setOpen(true)}>
           <ModalHeader slot="header" title="An example modal" back={back} />
           <div slot="content">
             <div style={{ marginBottom: '12px' }}>

--- a/packages/modal/react.ts
+++ b/packages/modal/react.ts
@@ -1,4 +1,4 @@
-import { createComponent } from '@lit/react';
+import { createComponent, EventName } from '@lit/react';
 import { LitElement } from 'lit';
 import React from 'react';
 
@@ -16,10 +16,10 @@ const BaseModal = createComponent({
   elementClass: Component as unknown as typeof WarpModal,
   react: React,
   events: {
-    onShown: 'shown',
-    onshown: 'shown',
-    onHidden: 'hidden',
-    onhidden: 'hidden',
+    onShown: 'shown' as EventName<CustomEvent>,
+    onshown: 'shown' as EventName<CustomEvent>,
+    onHidden: 'hidden' as EventName<CustomEvent>,
+    onhidden: 'hidden' as EventName<CustomEvent>,
   },
 });
 
@@ -30,6 +30,36 @@ type ModalProps = Omit<BaseModalProps, 'content-id' | 'ignore-backdrop-clicks'> 
   ignoreBackdropClicks?: boolean;
 };
 
+/**
+ * Modals (or dialogs) display important information that users need to acknowledge.
+ *
+ * If you keep the <code>open</code> state, listen to <code>onHidden</code> so you can update the state when the user clicks the backdrop, close button, or presses <kbd>Escape</kbd>.
+ *
+ * @example
+ * ```jsx
+ * const [open, setOpen] = useState(false);
+ * return (
+ *   <>
+ *     <Button variant="primary" onClick={() => setOpen(true)}>
+ *       Open modal
+ *     </Button>
+ *     <Modal show={open} id="example-modal-one" onHidden={() => setOpen(false)} onShown={() => setOpen(true)}>
+ *       <ModalHeader slot="header" title="An example modal" />
+ *       <div slot="content">
+ *         <p>
+ *           <!-- modal content -->
+ *         </p>
+ *       </div>
+ *       <ModalFooter slot="footer">
+ *         <Button variant="primary" id="modal-close-button-one" onClick={() => setOpen(false)}>
+ *           OK
+ *         </Button>
+ *       </ModalFooter>
+ *     </Modal>
+ *   </>
+ * );
+ * ```
+ */
 export const Modal = React.forwardRef<WarpModal, ModalProps>(({ contentId, ignoreBackdropClicks, ...props }, ref) =>
   React.createElement(BaseModal, {
     ...props,


### PR DESCRIPTION
Not sure if this is the exact issue in #680, but I saw something similar in Storybook which this fixes.