### PR TITLE
feat(types): add improved React type support to types

### DIFF
--- a/.cem/custom-element-manifest.config.js
+++ b/.cem/custom-element-manifest.config.js
@@ -31,6 +31,8 @@ function reactJsxIntrinsicPropsPlugin() {
         throw new Error('Unable to derive custom element types from dist/index.d.ts');
       }
 
+      // Keep the generated CustomElements/Solid types intact and add a React-only
+      // intrinsic map where React props and component props are merged by precedence.
       const reactCustomElementsTypes = `type ReactElementProps<T extends HTMLElement> = import("react").DOMAttributes<T> &
   import("react").AriaAttributes &
   import("react").RefAttributes<T> &
@@ -42,6 +44,8 @@ function reactJsxIntrinsicPropsPlugin() {
     | "suppressHydrationWarning"
   >;
 
+// Merge order matters: component props must win over React/global/base props
+// when names collide, e.g. w-attention's boolean popover prop.
 type ReactCustomElementProps<T extends HTMLElement, Props> = Omit<
   BaseProps<T> & BaseEvents,
   keyof ReactElementProps<T> | keyof Props

--- a/.cem/custom-element-manifest.config.js
+++ b/.cem/custom-element-manifest.config.js
@@ -7,9 +7,9 @@ import { getTsProgram, typeParserPlugin } from '@wc-toolkit/type-parser';
 
 const jsxTypesPath = fileURLToPath(new URL('../dist/index.d.ts', import.meta.url));
 
-function collisionSafeJsxIntrinsicPropsPlugin() {
+function reactJsxIntrinsicPropsPlugin() {
   return {
-    name: 'collision-safe-jsx-intrinsic-props',
+    name: 'react-jsx-intrinsic-props',
     packageLinkPhase() {
       const source = readFileSync(jsxTypesPath, 'utf8');
       const customElementsStart = source.indexOf('export type CustomElements = {');
@@ -22,8 +22,6 @@ function collisionSafeJsxIntrinsicPropsPlugin() {
       const customElementsBlock = source.slice(customElementsStart, solidElementsStart);
       const customElementPattern =
         /"([^"]+)":\s*Partial<\s*([A-Za-z_$][\w$]*Props)\s*&\s*BaseProps<([^>]+)>\s*&\s*BaseEvents\s*>;/g;
-      const solidCustomElementPattern =
-        /"([^"]+)":\s*Partial<\s*([A-Za-z_$][\w$]*Props)\s*&\s*([A-Za-z_$][\w$]*SolidJsProps)\s*&\s*BaseProps<([^>]+)>\s*&\s*BaseEvents\s*>;/g;
       const customElements = Array.from(
         customElementsBlock.matchAll(customElementPattern),
         ([, tagName, propsType, elementType]) => ({ tagName, propsType, elementType }),
@@ -33,20 +31,7 @@ function collisionSafeJsxIntrinsicPropsPlugin() {
         throw new Error('Unable to derive custom element types from dist/index.d.ts');
       }
 
-      const customElementPropsTypes = `type CustomElementProps<Props, T extends HTMLElement> = Omit<BaseProps<T> & BaseEvents, keyof Props> &
-  Props;
-
-type SolidCustomElementProps<Props, SolidProps, T extends HTMLElement> = Omit<
-  BaseProps<T> & BaseEvents,
-  keyof Props | keyof SolidProps
-> &
-  Props &
-  SolidProps;
-
-`;
-
-      const reactCustomElementsTypes = `
-type ReactElementProps<T extends HTMLElement> = import("react").DOMAttributes<T> &
+      const reactCustomElementsTypes = `type ReactElementProps<T extends HTMLElement> = import("react").DOMAttributes<T> &
   import("react").AriaAttributes &
   import("react").RefAttributes<T> &
   Pick<
@@ -80,31 +65,10 @@ export type ReactCustomElements = {
 
 `;
 
-      let updatedSource = `${source.slice(0, customElementsStart)}${customElementPropsTypes}${source.slice(
-        customElementsStart,
+      const withReactTypes = `${source.slice(0, solidElementsStart)}${reactCustomElementsTypes}${source.slice(
+        solidElementsStart,
       )}`;
-
-      updatedSource = updatedSource
-        .replace(
-          customElementPattern,
-          (_, tagName, propsType, elementType) =>
-            `"${tagName}": Partial<CustomElementProps<${propsType}, ${elementType}>>;`,
-        )
-        .replace(
-          solidCustomElementPattern,
-          (_, tagName, propsType, solidPropsType, elementType) =>
-            `"${tagName}": Partial<SolidCustomElementProps<${propsType}, ${solidPropsType}, ${elementType}>>;`,
-        );
-
-      const updatedSolidElementsStart = updatedSource.indexOf('export type CustomElementsSolidJs = {');
-      if (updatedSolidElementsStart === -1) {
-        throw new Error('Unable to find generated CustomElementsSolidJs types in dist/index.d.ts');
-      }
-
-      updatedSource = `${updatedSource.slice(0, updatedSolidElementsStart)}${reactCustomElementsTypes}${updatedSource.slice(
-        updatedSolidElementsStart,
-      )}`;
-      updatedSource = updatedSource.replace(
+      const updatedSource = withReactTypes.replace(
         /(declare module ["']react["']\s*\{\s*namespace JSX\s*\{\s*interface IntrinsicElements extends )CustomElements(\s*\{\})/,
         '$1ReactCustomElements$2',
       );
@@ -201,6 +165,9 @@ export default {
     jsxTypesPlugin({
       outdir: 'dist/',
       fileName: 'index.d.ts',
+      stronglyTypedEvents: true,
+      includeDefaultDOMEvents: true,
+      allowUnknownProps: false,
       /* @wc-toolkit/jsx-types uses the paths recorded in your Custom Elements Manifest to build the imports for JSX type generation.
     Specifically:
       •	It reads modulePath or declaration.module values from the CEM.
@@ -211,7 +178,7 @@ export default {
         return modulePath.replace('packages', './packages');
       },
     }),
-    collisionSafeJsxIntrinsicPropsPlugin(),
+    reactJsxIntrinsicPropsPlugin(),
     cemValidatorPlugin({
       rules: {
         manifest: {

--- a/.cem/custom-element-manifest.config.js
+++ b/.cem/custom-element-manifest.config.js
@@ -1,8 +1,122 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { cemValidatorPlugin } from '@wc-toolkit/cem-validator';
 import { jsDocTagsPlugin } from '@wc-toolkit/jsdoc-tags';
 import { jsxTypesPlugin } from '@wc-toolkit/jsx-types';
 import { getTsProgram, typeParserPlugin } from '@wc-toolkit/type-parser';
 
+const jsxTypesPath = fileURLToPath(new URL('../dist/index.d.ts', import.meta.url));
+
+function collisionSafeJsxIntrinsicPropsPlugin() {
+  return {
+    name: 'collision-safe-jsx-intrinsic-props',
+    packageLinkPhase() {
+      const source = readFileSync(jsxTypesPath, 'utf8');
+      const customElementsStart = source.indexOf('export type CustomElements = {');
+      const solidElementsStart = source.indexOf('export type CustomElementsSolidJs = {');
+
+      if (customElementsStart === -1 || solidElementsStart === -1) {
+        throw new Error('Unable to find generated CustomElements types in dist/index.d.ts');
+      }
+
+      const customElementsBlock = source.slice(customElementsStart, solidElementsStart);
+      const customElementPattern =
+        /"([^"]+)":\s*Partial<\s*([A-Za-z_$][\w$]*Props)\s*&\s*BaseProps<([^>]+)>\s*&\s*BaseEvents\s*>;/g;
+      const solidCustomElementPattern =
+        /"([^"]+)":\s*Partial<\s*([A-Za-z_$][\w$]*Props)\s*&\s*([A-Za-z_$][\w$]*SolidJsProps)\s*&\s*BaseProps<([^>]+)>\s*&\s*BaseEvents\s*>;/g;
+      const customElements = Array.from(
+        customElementsBlock.matchAll(customElementPattern),
+        ([, tagName, propsType, elementType]) => ({ tagName, propsType, elementType }),
+      );
+
+      if (customElements.length === 0) {
+        throw new Error('Unable to derive custom element types from dist/index.d.ts');
+      }
+
+      const customElementPropsTypes = `type CustomElementProps<Props, T extends HTMLElement> = Omit<BaseProps<T> & BaseEvents, keyof Props> &
+  Props;
+
+type SolidCustomElementProps<Props, SolidProps, T extends HTMLElement> = Omit<
+  BaseProps<T> & BaseEvents,
+  keyof Props | keyof SolidProps
+> &
+  Props &
+  SolidProps;
+
+`;
+
+      const reactCustomElementsTypes = `
+type ReactElementProps<T extends HTMLElement> = import("react").DOMAttributes<T> &
+  import("react").AriaAttributes &
+  import("react").RefAttributes<T> &
+  Pick<
+    import("react").HTMLAttributes<T>,
+    | "className"
+    | "style"
+    | "suppressContentEditableWarning"
+    | "suppressHydrationWarning"
+  >;
+
+type ReactCustomElementProps<T extends HTMLElement, Props> = Omit<
+  BaseProps<T> & BaseEvents,
+  keyof ReactElementProps<T> | keyof Props
+> &
+  Omit<ReactElementProps<T>, keyof Props> &
+  Props;
+
+type CustomElementInstances = {
+${customElements.map(({ tagName, elementType }) => `  "${tagName}": ${elementType};`).join('\n')}
+};
+
+type CustomElementComponentProps = {
+${customElements.map(({ tagName, propsType }) => `  "${tagName}": ${propsType};`).join('\n')}
+};
+
+export type ReactCustomElements = {
+  [Tag in keyof CustomElementComponentProps]: Tag extends keyof CustomElementInstances
+    ? Partial<ReactCustomElementProps<CustomElementInstances[Tag], CustomElementComponentProps[Tag]>>
+    : never;
+};
+
+`;
+
+      let updatedSource = `${source.slice(0, customElementsStart)}${customElementPropsTypes}${source.slice(
+        customElementsStart,
+      )}`;
+
+      updatedSource = updatedSource
+        .replace(
+          customElementPattern,
+          (_, tagName, propsType, elementType) =>
+            `"${tagName}": Partial<CustomElementProps<${propsType}, ${elementType}>>;`,
+        )
+        .replace(
+          solidCustomElementPattern,
+          (_, tagName, propsType, solidPropsType, elementType) =>
+            `"${tagName}": Partial<SolidCustomElementProps<${propsType}, ${solidPropsType}, ${elementType}>>;`,
+        );
+
+      const updatedSolidElementsStart = updatedSource.indexOf('export type CustomElementsSolidJs = {');
+      if (updatedSolidElementsStart === -1) {
+        throw new Error('Unable to find generated CustomElementsSolidJs types in dist/index.d.ts');
+      }
+
+      updatedSource = `${updatedSource.slice(0, updatedSolidElementsStart)}${reactCustomElementsTypes}${updatedSource.slice(
+        updatedSolidElementsStart,
+      )}`;
+      updatedSource = updatedSource.replace(
+        /(declare module ["']react["']\s*\{\s*namespace JSX\s*\{\s*interface IntrinsicElements extends )CustomElements(\s*\{\})/,
+        '$1ReactCustomElements$2',
+      );
+
+      if (!updatedSource.includes('interface IntrinsicElements extends ReactCustomElements')) {
+        throw new Error('Unable to update React JSX IntrinsicElements in dist/index.d.ts');
+      }
+
+      writeFileSync(jsxTypesPath, updatedSource);
+    },
+  };
+}
 
 export default {
   overrideModuleCreation: ({ ts, globs }) => {
@@ -97,6 +211,7 @@ export default {
         return modulePath.replace('packages', './packages');
       },
     }),
+    collisionSafeJsxIntrinsicPropsPlugin(),
     cemValidatorPlugin({
       rules: {
         manifest: {
@@ -107,8 +222,8 @@ export default {
           modulePath: 'off',
           definitionPath: 'off',
           typeDefinitionPath: 'off',
-        }
-      }
+        },
+      },
     }),
   ],
 };

--- a/tests/module-resolution/react-jsx-test.tsx
+++ b/tests/module-resolution/react-jsx-test.tsx
@@ -1,0 +1,61 @@
+import '@warp-ds/elements';
+import * as React from 'react';
+
+const buttonWithReactEvents = (
+  <w-button
+    onBlur={() => {}}
+    onClick={(event) => {
+      event.currentTarget.resetFormControl();
+    }}
+    onFocus={() => {}}
+    onMouseEnter={() => {}}
+    onMouseLeave={() => {}}
+    variant="primary"
+  >
+    Ok
+  </w-button>
+);
+
+const buttonWithReactAttributes = (
+  <w-button aria-label="Close" className="primary-action" class="legacy-class" style={{ color: 'red' }}>
+    Ok
+  </w-button>
+);
+
+const buttonWithTypedRef = (
+  <w-button
+    ref={(button) => {
+      button?.resetFormControl();
+    }}
+    variant="primary"
+  >
+    Ok
+  </w-button>
+);
+
+const breadcrumbsWithHydrationProps = (
+  // biome-ignore lint/security/noDangerouslySetInnerHtml: verifies React hydration props on raw custom elements.
+  <w-breadcrumbs dangerouslySetInnerHTML={{ __html: '<a href="/">Home</a>' }} suppressHydrationWarning />
+);
+
+const attentionWithComponentBooleanProps = (
+  <w-attention popover show tooltip>
+    Notice
+  </w-attention>
+);
+
+// @ts-expect-error Invalid button variant values should still be rejected.
+const invalidButtonVariant = <w-button variant="not-a-variant">No</w-button>;
+
+// @ts-expect-error Component-specific boolean popover should override the native popover attribute.
+const invalidAttentionPopover = <w-attention popover="auto">No</w-attention>;
+
+export const reactJsxTypeCases = [
+  buttonWithReactEvents,
+  buttonWithReactAttributes,
+  buttonWithTypedRef,
+  breadcrumbsWithHydrationProps,
+  attentionWithComponentBooleanProps,
+  invalidButtonVariant,
+  invalidAttentionPopover,
+];

--- a/tests/module-resolution/tsconfig.bundler.json
+++ b/tests/module-resolution/tsconfig.bundler.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "baseUrl": "."
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "*.tsx"]
 }

--- a/tests/module-resolution/tsconfig.node.json
+++ b/tests/module-resolution/tsconfig.node.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "baseUrl": "."
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "*.tsx"]
 }

--- a/tests/module-resolution/tsconfig.node16.json
+++ b/tests/module-resolution/tsconfig.node16.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "baseUrl": "."
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "*.tsx"]
 }

--- a/tests/module-resolution/tsconfig.nodenext.json
+++ b/tests/module-resolution/tsconfig.nodenext.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "baseUrl": "."
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "*.tsx"]
 }


### PR DESCRIPTION
Discovered that properly typing the custom elements usage in recommerce-bet-front resulted in quite a bit of type wrapping so this PR is me getting Codex to patch the types output to get a "it just works" result in React apps. Ive tested the build output in recommerce-bet-front and it seems to be working. 

The issues were:
1. using react properties with Warp elements were not supported out of the box. eg.

```jsx
<w-button onClick={...} onBlur={...} className="..." style={...} />
<w-breadcrumbs suppressHydrationWarning dangerouslySetInnerHTML={...} />
<w-attention ref={...} popover />
```

2. name clash for popover
Once we added in the React types, popover is already in there and so our popover in Warp Elements gets overwritten.
The fix for this is nasty 
```ts
type ReactCustomElementProps<T extends HTMLElement, Props> =
  Omit<BaseProps<T> & BaseEvents, keyof ReactElementProps<T> | keyof Props> &
  Omit<ReactElementProps<T>, keyof Props> &
  Props;
```
...essentially, remove all props and re-ad them with the Warp props last so they win.

So this PR makes it so Warp Elements owns the React JSX custom-element typings, letting consuming apps delete their hand-written React augmentation shims and rely on the package as the single source of truth.

The code here in my opinion is pretty much unreadable garbage but I only partly blame AI for this. The biggest culprit in my mind is the combo of the sheer complexity of this kind of typing combined with the procedural generation of these types out of JS...

I feel dirty.