### PR TITLE
chore: update actions to get off Node 20

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: 'pnpm'
-          node-version: lts/*
+          node-version: 24.15.0
       - run: pnpm i
       - name: Validate extracted messages
         run: pnpm messages:compile

--- a/.github/workflows/lint.pr.yaml
+++ b/.github/workflows/lint.pr.yaml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: "pnpm"
-          node-version: lts/*
+          node-version: 24.15.0
       - run: pnpm i
 
       - name: Lint

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: 'pnpm'
-          node-version: lts/*
+          node-version: 24.15.0
       - run: pnpm i
       - name: Build storybook
         run: pnpm run build:storybook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: "pnpm"
-          node-version: lts/*
+          node-version: 24.15.0
       - run: pnpm i
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: 'pnpm'
-          node-version: lts/*
+          node-version: 24.15.0
       - run: pnpm i
       - name: Build storybook
         run: pnpm run build:storybook

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Rebase next to main
         run: |
             git fetch --unshallow


### PR DESCRIPTION
Temporarily pin Node version to avoid the install problem in 24.16.0 that hits Playwright.