### PR TITLE
docs(radio-group): enhance styling documentation with complete token …

### DIFF
--- a/packages/radio-group/docs/styling.md
+++ b/packages/radio-group/docs/styling.md
@@ -1,26 +1,121 @@
-## Styling API
+# Radio and Radio Group Styling
 
-This section documents the supported styling hooks for `<w-radio>` and `<w-radio-group>`.
+This document covers the styling API for both `<w-radio>` (individual radio buttons) and `<w-radio-group>` (the container that manages them).
 
-Use these hooks to customize appearance without relying on internal structure or selectors.
+## Quick Start
 
-Before changing the default styles, remember that doing so can result in less consistent experiences for users across the product. Prefer defaults.
+```html
+<w-radio-group label="Choose a size" name="size">
+  <w-radio value="small">Small</w-radio>
+  <w-radio value="medium">Medium</w-radio>
+  <w-radio value="large">Large</w-radio>
+</w-radio-group>
+```
 
-- Prefer **component tokens** for size, spacing, and state styling.
-- Use **parts** only for small, local tweaks.
-- Avoid relying on internal class names or selectors.
+Customize via component tokens:
+
+```css
+/* Style all radio groups in a section */
+.settings {
+  --w-c-radio-group-gap: 12px;
+  --w-c-radio-size: 2.4rem;
+}
+```
+
+---
+
+## Styling Philosophy
+
+Before customizing, remember that changing defaults can create inconsistent experiences. Prefer the defaults.
+
+- **Component tokens** for size, spacing, color, and state styling
+- **Parts** only for small, one-off tweaks
+- Avoid relying on internal class names
+
+---
+
+## Radio Group (`<w-radio-group>`)
 
 ### Parts
 
-The radio exposes a small set of parts that can be targeted for last‑mile layout or typography tweaks.
+| Part | Targets | Use Case |
+|------|---------|----------|
+| `form-control` | The `<fieldset>` wrapper | Outer container tweaks |
+| `form-control-label` | The group label element | Label typography overrides |
+| `form-control-input` | Container for radio buttons | Adjust layout/flow of radios |
+| `help-text` | Help text / error message | Style hint text |
 
-| Part | Targets | Typical use |
-|---|---|---|
-| `control` | radio control (circle) | minor alignment or sizing tweaks |
-| `label` | label content | typography tweaks |
+**Example:**
+```css
+w-radio-group::part(form-control-label) {
+  text-transform: uppercase;
+}
 
-Example:
+w-radio-group::part(form-control-input) {
+  flex-direction: row; /* horizontal radios */
+}
+```
 
+### Component Tokens
+
+#### Label
+
+| Token | Purpose | Default |
+|-------|---------|---------|
+| `--w-c-radio-group-label-font-size` | Label font size | `var(--w-font-size-s)` |
+| `--w-c-radio-group-label-line-height` | Label line height | `var(--w-line-height-s)` |
+| `--w-c-radio-group-label-font-weight` | Label font weight | `700` |
+| `--w-c-radio-group-label-color` | Label text color | `var(--w-s-color-text)` |
+| `--w-c-radio-group-label-color-disabled` | Label color when disabled | `var(--w-s-color-text-disabled)` |
+| `--w-c-radio-group-label-padding-bottom` | Space below label | `16px` |
+
+#### Optional Indicator
+
+| Token | Purpose | Default |
+|-------|---------|---------|
+| `--w-c-radio-group-optional-font-weight` | "Optional" text weight | `400` |
+| `--w-c-radio-group-optional-color` | "Optional" text color | `var(--w-s-color-text-subtle)` |
+| `--w-c-radio-group-optional-margin-inline-start` | Space before "Optional" | `0.5rem` |
+
+#### Radio Spacing
+
+| Token | Purpose | Default |
+|-------|---------|---------|
+| `--w-c-radio-group-gap` | Gap between radio buttons | `16px` |
+
+#### Help Text
+
+| Token | Purpose | Default |
+|-------|---------|---------|
+| `--w-c-radio-group-help-text-margin-block-start` | Space above help text | `16px` |
+| `--w-c-radio-group-help-text-font-size` | Help text font size | `var(--w-font-size-xs)` |
+| `--w-c-radio-group-help-text-line-height` | Help text line height | `var(--w-line-height-xs)` |
+| `--w-c-radio-group-help-text-color` | Help text color | `var(--w-s-color-text-subtle)` |
+| `--w-c-radio-group-help-text-color-disabled` | Help text color when disabled | `var(--w-s-color-text-disabled)` |
+| `--w-c-radio-group-help-text-color-error` | Help text color when invalid | `var(--w-s-color-text-negative)` |
+
+**Example:**
+```css
+w-radio-group {
+  --w-c-radio-group-gap: 12px;
+  --w-c-radio-group-label-font-weight: 600;
+  --w-c-radio-group-help-text-color: var(--w-s-color-text);
+}
+```
+
+---
+
+## Individual Radio (`<w-radio>`)
+
+### Parts
+
+| Part | Targets | Use Case |
+|------|---------|----------|
+| `base` | Wrapper containing control and label | Container-level adjustments |
+| `control` | Radio control (circle) | Alignment or sizing tweaks |
+| `label` | Label content | Typography overrides |
+
+**Example:**
 ```css
 w-radio::part(label) {
   font-weight: 600;
@@ -31,88 +126,108 @@ w-radio::part(control) {
 }
 ```
 
-Parts are intended as an **escape hatch**.
-Prefer component tokens for anything state‑ or size‑related.
+### Component Tokens
 
-
-### Component tokens
-
-Component tokens (`--w-c-radio-*`) act as inputs to the radio styling.
-They can be set directly on the component or inherited from a parent container.
-
-```css
-.settings-panel {
-  --w-c-radio-gap: 12px;
-}
-```
-
-Defaults are defined internally; setting a token is always optional.
-
-
-#### Layout & size
+#### Layout & Size
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-gap` | space between control and label | `8px` |
-| `--w-c-radio-size` | width/height of the control | `2rem` |
-| `--w-c-radio-radius` | border radius of the control | `50%` |
-| `--w-c-radio-border-width` | border width | `1px` |
-| `--w-c-radio-checked-border-width` | border width when checked | `0.6rem` |
-
+|-------|---------|---------|
+| `--w-c-radio-gap` | Space between control and label | `8px` |
+| `--w-c-radio-size` | Width/height of control | `2rem` |
+| `--w-c-radio-radius` | Border radius | `50%` |
+| `--w-c-radio-border-width` | Border width | `1px` |
+| `--w-c-radio-checked-border-width` | Border width when checked | `0.6rem` |
 
 #### Colors
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-bg` | control background | theme default |
-| `--w-c-radio-border-color` | control border color | theme default |
-| `--w-c-radio-border-color-checked` | border color when checked | theme default |
-| `--w-c-radio-label-color` | label text color | `currentColor` |
+|-------|---------|---------|
+| `--w-c-radio-bg` | Control background | `var(--w-s-color-background)` |
+| `--w-c-radio-border-color` | Control border color | `var(--w-s-color-border-strong)` |
+| `--w-c-radio-border-color-checked` | Border when checked | `var(--w-s-color-border-selected)` |
+| `--w-c-radio-border-color-invalid` | Border when invalid | `var(--w-s-color-border-negative)` |
+| `--w-c-radio-label-color` | Label text color | `currentColor` |
 
-
-#### Invalid state
-
-| Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-border-color-invalid` | border color when invalid | theme default |
-
-
-#### Disabled state
+#### Disabled State
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-bg-disabled` | background when disabled | theme default |
-| `--w-c-radio-border-color-disabled` | border when disabled | theme default |
-| `--w-c-radio-label-color-disabled` | label color when disabled | theme default |
-| `--w-c-radio-cursor-disabled` | cursor when disabled | `not-allowed` |
+|-------|---------|---------|
+| `--w-c-radio-bg-disabled` | Background when disabled | `var(--w-s-color-background-disabled-subtle)` |
+| `--w-c-radio-border-color-disabled` | Border when disabled | `var(--w-s-color-border-disabled)` |
+| `--w-c-radio-label-color-disabled` | Label color when disabled | `var(--w-s-color-text-disabled)` |
+| `--w-c-radio-cursor-disabled` | Cursor when disabled | `not-allowed` |
 
 #### Typography
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-label-font-size` | label font size | theme default |
-| `--w-c-radio-label-line-height` | label line height | theme default |
-
+|-------|---------|---------|
+| `--w-c-radio-label-font-size` | Label font size | `var(--w-font-size-m)` |
+| `--w-c-radio-label-line-height` | Label line height | `var(--w-line-height-m)` |
 
 #### Focus
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-outline-width` | focus outline width | `2px` |
-| `--w-c-radio-outline-color` | focus outline color | theme default |
-| `--w-c-radio-outline-offset` | focus outline offset | theme default |
+|-------|---------|---------|
+| `--w-c-radio-outline-width` | Focus outline width | `2px` |
+| `--w-c-radio-outline-color` | Focus outline color | `var(--w-s-color-border-focus)` |
+| `--w-c-radio-outline-offset` | Focus outline offset | `var(--w-outline-offset, 1px)` |
 
 #### Interaction
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-cursor` | cursor in enabled state | `pointer` |
+|-------|---------|---------|
+| `--w-c-radio-cursor` | Cursor in enabled state | `pointer` |
 
 #### Motion
 
 | Token | Purpose | Default |
-|---|---|---|
-| `--w-c-radio-transition` | transition for control | `150ms cubic-bezier(0.4, 0, 0.2, 1)` |
+|-------|---------|---------|
+| `--w-c-radio-transition` | Transition for control | `border-color 150ms, border-width 150ms, background-color 150ms` |
 
-Transitions are automatically disabled when `prefers-reduced-motion: reduce` is active.
+**Note:** Transitions automatically disable when `prefers-reduced-motion: reduce` is active.
+
+---
+
+## Complete Examples
+
+### Horizontal Radio Group
+
+```css
+w-radio-group::part(form-control-input) {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+```
+
+### Larger Radio Buttons
+
+```css
+w-radio {
+  --w-c-radio-size: 2.4rem;
+  --w-c-radio-checked-border-width: 0.8rem;
+}
+```
+
+### Custom Colors
+
+```css
+w-radio {
+  --w-c-radio-border-color-checked: var(--w-s-color-border-success);
+}
+```
+
+### Tighter Spacing
+
+```css
+w-radio-group {
+  --w-c-radio-group-gap: 8px;
+  --w-c-radio-group-label-padding-bottom: 8px;
+}
+```
+
+---
+
+## Architecture Note
+
+**Radio-group uses `<fieldset>`** which is the semantic HTML element for grouping form controls. Note that `<w-checkbox-group>` currently uses `<div>` instead - this inconsistency may be addressed in a future major version to align both components on the more accessible `<fieldset>` approach.
 

--- a/packages/radio-group/radio-group.ts
+++ b/packages/radio-group/radio-group.ts
@@ -29,11 +29,20 @@ const REQUIRED_MESSAGE = () =>
 
 /**
  * Radios allow users to select a single option from a list of choices.
- * 
+ *
  * Use with `w-radio`.
- * 
+ *
  * @slot label - Alternative to the `label` attribute should you need custom HTML.
  * @slot help-text - Alternative to the `help-text` attribute should you need custom HTML.
+ *
+ * ## Architecture Note
+ * This component uses semantic <fieldset> element for grouping radio controls, which
+ * provides better accessibility and follows HTML best practices. Note that w-checkbox-group
+ * currently uses <div> instead - this inconsistency exists for historical reasons and may
+ * be addressed in a future major version to align both on the more semantic approach.
+ *
+ * TODO: Align w-checkbox-group to also use <fieldset> in a future major version after
+ * assessing backwards compatibility implications (CSS selectors, etc.).
  */
 export class WarpRadioGroup extends FormControlMixin(LitElement) {
   static styles = [hostStyles, styles];


### PR DESCRIPTION
…reference

Improved the existing styling.md to provide comprehensive documentation for both w-radio and w-radio-group components with practical examples.

Changes:
- Restructured docs with clear separation between radio-group and radio
- Added complete radio-group token documentation (was missing):
  - Label tokens (font-size, line-height, font-weight, color, padding)
  - Optional indicator tokens (font-weight, color, margin)
  - Radio spacing token (gap between radios)
  - Help text tokens (margin, font-size, line-height, colors for all states)
- Documented all parts for both components with use cases
- Added Quick Start section for immediate usability
- Added Complete Examples section showing common patterns:
  - Horizontal radio layout
  - Larger radio buttons
  - Custom colors
  - Tighter spacing
- Improved token tables with actual default values (not just "theme default")
- Better organization and navigation

Architecture documentation:
- Added note explaining radio-group uses semantic <fieldset> element
- Documented inconsistency with checkbox-group using <div>
- Added TODO for future alignment in component comment
- Explains accessibility benefits of fieldset approach

Assessment: Documentation now provides sufficient "meat on the bone" for developers to effectively customize both components without needing to inspect source code. All tokens are documented with purposes, defaults, and practical examples.

Completes Phase 2 radio-group documentation.