### PR TITLE
docs(breadcrumbs): add documentation for breadcrumb item css properties

### DIFF
--- a/packages/breadcrumbs/docs/styling.md
+++ b/packages/breadcrumbs/docs/styling.md
@@ -2,11 +2,72 @@
 
 ### Breadcrumbs
 
-The styling API for the Breadcrumbs component is under construction.
+The breadcrumbs components support styling through **component tokens** (CSS custom properties with a `--w-c-` prefix) and **parts**.
+
+`w-breadcrumbs` does not expose component-specific tokens. Set `w-breadcrumb-item` tokens on `w-breadcrumbs` or another ancestor to style all items in a breadcrumb trail.
+
+```css
+w-breadcrumbs {
+	--w-c-breadcrumb-item-link-color: var(--w-s-color-text-link);
+	--w-c-breadcrumb-item-separator-spacing: 1.2rem;
+}
+```
 
 ### Breadcrumb Item
 
-The w-breadcrumb-item component supports styling through **parts**.
+The `w-breadcrumb-item` component supports styling through **component tokens** and **parts**.
+
+#### Component tokens
+
+Set these on `w-breadcrumb-item` to override one item, or on `w-breadcrumbs` to let the values inherit into all item children.
+
+```css
+w-breadcrumb-item {
+	--w-c-breadcrumb-item-link-color-hover: var(--w-s-color-text-link-hover);
+	--w-c-breadcrumb-item-font-weight: 700;
+}
+```
+
+##### Layout and typography
+
+| Token                               | Purpose                                 | Default             |
+| ----------------------------------- | --------------------------------------- | ------------------- |
+| `--w-c-breadcrumb-item-font-size`   | Font size for the label and separator   | inherited font size |
+| `--w-c-breadcrumb-item-line-height` | Line height for the label and separator | `1.5`               |
+| `--w-c-breadcrumb-item-font-weight` | Font weight for the label and separator | `400`               |
+| `--w-c-breadcrumb-item-padding-x`   | Inline padding for linked items         | `0`                 |
+| `--w-c-breadcrumb-item-padding-y`   | Block padding for linked items          | `0`                 |
+
+##### Link color
+
+| Token                                     | Purpose                                    | Default                      |
+| ----------------------------------------- | ------------------------------------------ | ---------------------------- |
+| `--w-c-breadcrumb-item-link-color`        | Color for linked items                     | `var(--w-s-color-text-link)` |
+| `--w-c-breadcrumb-item-link-color-hover`  | Color for linked items on hover            | link color                   |
+| `--w-c-breadcrumb-item-link-color-active` | Color for linked items in the active state | link color                   |
+
+##### Text color
+
+| Token                              | Purpose                    | Default                 |
+| ---------------------------------- | -------------------------- | ----------------------- |
+| `--w-c-breadcrumb-item-text-color` | Color for non-linked items | `var(--w-s-color-text)` |
+
+##### Separator
+
+| Token                                     | Purpose                                     | Default                 |
+| ----------------------------------------- | ------------------------------------------- | ----------------------- |
+| `--w-c-breadcrumb-item-separator-color`   | Color for the separator                     | `var(--w-s-color-icon)` |
+| `--w-c-breadcrumb-item-separator-spacing` | Inline margin on each side of the separator | `0.8rem`                |
+
+The separator uses `--w-c-breadcrumb-item-font-size`, `--w-c-breadcrumb-item-line-height`, and `--w-c-breadcrumb-item-font-weight`.
+
+##### Focus
+
+| Token                                  | Purpose                               | Default              |
+| -------------------------------------- | ------------------------------------- | -------------------- |
+| `--w-c-breadcrumb-item-outline-width`  | Focus outline width for linked items  | native focus outline |
+| `--w-c-breadcrumb-item-outline-color`  | Focus outline color for linked items  | native focus outline |
+| `--w-c-breadcrumb-item-outline-offset` | Focus outline offset for linked items | native focus outline |
 
 #### Parts
 
@@ -20,11 +81,11 @@ Example:
 
 ```css
 w-breadcrumb-item::part(link) {
-  text-decoration-thickness: 2px;
+	text-decoration-thickness: 2px;
 }
 
 w-breadcrumb-item::part(separator) {
-  margin-inline: 1.2rem;
+	margin-inline: 1.2rem;
 }
 ```
 
@@ -32,3 +93,5 @@ w-breadcrumb-item::part(separator) {
 
 - `separator` is not rendered when `current-page` is set.
 - Use `link` for linked breadcrumb items and `text` for non-linked breadcrumb items.
+- Link color, padding, and focus tokens apply only when `href` is set.
+- Focus tokens do not make non-linked breadcrumb items keyboard-focusable.


### PR DESCRIPTION
While this is just adding some missing documentation, might be a good chance to discuss the naming of the latest breadcrumbs item as well before we cut a release.

A. How does the styling API look here?
B. Is w-breadcrumb-item the right name for the child component?

Should it be w-breadcrumbs-item to match the parent w-breadcrumbs plurality?
Should it be something else entirely? 

w-breadcrumbs-segment
w-breadcrumbs-item
w-breadcrumbs-list-item
??