### PR TITLE
fix: list open-wc/form-control as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@lit/react": "^1.0.8",
+    "@open-wc/form-control": "^1.0.0",
     "lit": "3.x"
   },
   "devDependencies": {
@@ -328,7 +329,6 @@
     "@lingui/core": "5.9.5",
     "@lit-labs/rollup-plugin-minify-html-literals": "^0.2.0",
     "@oddbird/css-anchor-positioning": "^0.9.0",
-    "@open-wc/form-control": "^1.0.0",
     "@open-wc/lit-helpers": "^0.7.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-node-resolve": "^16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@lit/react':
         specifier: ^1.0.8
         version: 1.0.8(@types/react@19.2.15)
+      '@open-wc/form-control':
+        specifier: ^1.0.0
+        version: 1.0.0
       lit:
         specifier: 3.x
         version: 3.3.3
@@ -45,9 +48,6 @@ importers:
       '@oddbird/css-anchor-positioning':
         specifier: ^0.9.0
         version: 0.9.0
-      '@open-wc/form-control':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@open-wc/lit-helpers':
         specifier: ^0.7.0
         version: 0.7.0(lit@3.3.3)


### PR DESCRIPTION
Fixes #711

We bundle it, so it's technically not required at runtime, but it affects the public API of the components for TypeScript, so not having it listed leads to a poor dev experience for TS users in the components that use the mixins.