### PR TITLE
fix: inconsistent use of optional in form elements

### DIFF
--- a/packages/affix/locales/da/messages.po
+++ b/packages/affix/locales/da/messages.po
@@ -6,15 +6,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: da\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Aria label for the clear input button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:125
+#: packages/affix/affix.ts:127
 msgid "affix.aria.clearInput"
 msgstr "Ryd input"
 
 #. Aria label for the search button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:109
+#: packages/affix/affix.ts:100
 msgid "affix.aria.search"
 msgstr "Søg"

--- a/packages/affix/locales/en/messages.po
+++ b/packages/affix/locales/en/messages.po
@@ -6,15 +6,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Aria label for the clear input button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:125
+#: packages/affix/affix.ts:127
 msgid "affix.aria.clearInput"
 msgstr "Clear input"
 
 #. Aria label for the search button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:109
+#: packages/affix/affix.ts:100
 msgid "affix.aria.search"
 msgstr "Search"

--- a/packages/affix/locales/fi/messages.po
+++ b/packages/affix/locales/fi/messages.po
@@ -6,15 +6,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Aria label for the clear input button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:125
+#: packages/affix/affix.ts:127
 msgid "affix.aria.clearInput"
 msgstr "Tyhjennä syöte"
 
 #. Aria label for the search button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:109
+#: packages/affix/affix.ts:100
 msgid "affix.aria.search"
 msgstr "Hae"

--- a/packages/affix/locales/nb/messages.po
+++ b/packages/affix/locales/nb/messages.po
@@ -6,15 +6,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: nb\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Aria label for the clear input button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:125
+#: packages/affix/affix.ts:127
 msgid "affix.aria.clearInput"
 msgstr "Tøm inndata"
 
 #. Aria label for the search button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:109
+#: packages/affix/affix.ts:100
 msgid "affix.aria.search"
 msgstr "Søk"

--- a/packages/affix/locales/sv/messages.po
+++ b/packages/affix/locales/sv/messages.po
@@ -6,15 +6,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: sv\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Aria label for the clear input button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:125
+#: packages/affix/affix.ts:127
 msgid "affix.aria.clearInput"
 msgstr "Rensa inmatning"
 
 #. Aria label for the search button in affix
 #. js-lingui-explicit-id
-#: packages/affix/affix.ts:109
+#: packages/affix/affix.ts:100
 msgid "affix.aria.search"
 msgstr "Sök"

--- a/packages/attention/locales/da/messages.po
+++ b/packages/attention/locales/da/messages.po
@@ -19,54 +19,54 @@ msgstr ""
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:421
+#: packages/attention/attention.ts:543
 msgid "attention.aria.callout"
 msgstr "En grøn taleboble der introducerer noget nyt"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:313
+#: packages/attention/attention.ts:423
 msgid "attention.aria.close"
 msgstr "Luk"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:433
+#: packages/attention/attention.ts:557
 msgid "attention.aria.highlight"
 msgstr "En opmærksomhedsskabende taleboble med vigtig information"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:394
+#: packages/attention/attention.ts:513
 msgid "attention.aria.pointingDown"
 msgstr "peger nedad"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:402
+#: packages/attention/attention.ts:522
 msgid "attention.aria.pointingLeft"
 msgstr "peger til venstre"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:386
+#: packages/attention/attention.ts:504
 msgid "attention.aria.pointingRight"
 msgstr "peger til højre"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:378
+#: packages/attention/attention.ts:495
 msgid "attention.aria.pointingUp"
 msgstr "peger opad"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:427
+#: packages/attention/attention.ts:550
 msgid "attention.aria.popover"
 msgstr "En hvid taleboble med mere information"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:415
+#: packages/attention/attention.ts:536
 msgid "attention.aria.tooltip"
 msgstr "En sort taleboble med flere oplysninger"

--- a/packages/attention/locales/en/messages.po
+++ b/packages/attention/locales/en/messages.po
@@ -16,54 +16,54 @@ msgstr ""
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:421
+#: packages/attention/attention.ts:543
 msgid "attention.aria.callout"
 msgstr "A green speech bubble introducing something new"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:313
+#: packages/attention/attention.ts:423
 msgid "attention.aria.close"
 msgstr "Close"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:433
+#: packages/attention/attention.ts:557
 msgid "attention.aria.highlight"
 msgstr "An attention speech bubble with important information"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:394
+#: packages/attention/attention.ts:513
 msgid "attention.aria.pointingDown"
 msgstr "pointing down"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:402
+#: packages/attention/attention.ts:522
 msgid "attention.aria.pointingLeft"
 msgstr "pointing left"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:386
+#: packages/attention/attention.ts:504
 msgid "attention.aria.pointingRight"
 msgstr "pointing right"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:378
+#: packages/attention/attention.ts:495
 msgid "attention.aria.pointingUp"
 msgstr "pointing up"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:427
+#: packages/attention/attention.ts:550
 msgid "attention.aria.popover"
 msgstr "A white speech bubble providing additional information"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:415
+#: packages/attention/attention.ts:536
 msgid "attention.aria.tooltip"
 msgstr "A black speech bubble providing complementary information"

--- a/packages/attention/locales/fi/messages.po
+++ b/packages/attention/locales/fi/messages.po
@@ -19,54 +19,54 @@ msgstr ""
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:421
+#: packages/attention/attention.ts:543
 msgid "attention.aria.callout"
 msgstr "Vihreä puhekupla, joka esittelee jotain uutta"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:313
+#: packages/attention/attention.ts:423
 msgid "attention.aria.close"
 msgstr "Sulje"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:433
+#: packages/attention/attention.ts:557
 msgid "attention.aria.highlight"
 msgstr "Puhekupla, joka sisältää tärkeää tietoa"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:394
+#: packages/attention/attention.ts:513
 msgid "attention.aria.pointingDown"
 msgstr "osoittaa alas"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:402
+#: packages/attention/attention.ts:522
 msgid "attention.aria.pointingLeft"
 msgstr "osoittaa vasemmalle"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:386
+#: packages/attention/attention.ts:504
 msgid "attention.aria.pointingRight"
 msgstr "osoittaa oikealle"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:378
+#: packages/attention/attention.ts:495
 msgid "attention.aria.pointingUp"
 msgstr "osoittaa ylös"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:427
+#: packages/attention/attention.ts:550
 msgid "attention.aria.popover"
 msgstr "Valkoinen puhekupla, joka tarjoaa lisätietoa"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:415
+#: packages/attention/attention.ts:536
 msgid "attention.aria.tooltip"
 msgstr "Musta puhekupla, joka tarjoaa täydentävää tietoa"

--- a/packages/attention/locales/nb/messages.po
+++ b/packages/attention/locales/nb/messages.po
@@ -19,54 +19,54 @@ msgstr ""
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:421
+#: packages/attention/attention.ts:543
 msgid "attention.aria.callout"
 msgstr "Grønn taleboble som introduserer noe nytt"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:313
+#: packages/attention/attention.ts:423
 msgid "attention.aria.close"
 msgstr "Lukk"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:433
+#: packages/attention/attention.ts:557
 msgid "attention.aria.highlight"
 msgstr "En uthevet taleboble med viktig informasjon"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:394
+#: packages/attention/attention.ts:513
 msgid "attention.aria.pointingDown"
 msgstr "peker ned"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:402
+#: packages/attention/attention.ts:522
 msgid "attention.aria.pointingLeft"
 msgstr "peker til venstre"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:386
+#: packages/attention/attention.ts:504
 msgid "attention.aria.pointingRight"
 msgstr "peker til høyre"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:378
+#: packages/attention/attention.ts:495
 msgid "attention.aria.pointingUp"
 msgstr "peker opp"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:427
+#: packages/attention/attention.ts:550
 msgid "attention.aria.popover"
 msgstr "En hvit taleboble som gir tilleggsinformasjon"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:415
+#: packages/attention/attention.ts:536
 msgid "attention.aria.tooltip"
 msgstr "En svart taleboble som forklarer konteksten"

--- a/packages/attention/locales/sv/messages.po
+++ b/packages/attention/locales/sv/messages.po
@@ -19,54 +19,54 @@ msgstr ""
 
 #. Default screenreader message for callout speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:421
+#: packages/attention/attention.ts:543
 msgid "attention.aria.callout"
 msgstr "En grön pratbubbla som introducerar något nytt"
 
 #. Aria label for the close button in attention
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:313
+#: packages/attention/attention.ts:423
 msgid "attention.aria.close"
 msgstr "Stäng"
 
 #. Default screenreader message for highlighted speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:433
+#: packages/attention/attention.ts:557
 msgid "attention.aria.highlight"
 msgstr "En pratbubbla med viktig information"
 
 #. Default screenreader message for bottom direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:394
+#: packages/attention/attention.ts:513
 msgid "attention.aria.pointingDown"
 msgstr "pekar ned"
 
 #. Default screenreader message for left direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:402
+#: packages/attention/attention.ts:522
 msgid "attention.aria.pointingLeft"
 msgstr "pekar vänster"
 
 #. Default screenreader message for right direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:386
+#: packages/attention/attention.ts:504
 msgid "attention.aria.pointingRight"
 msgstr "pekar höger"
 
 #. Default screenreader message for top direction in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:378
+#: packages/attention/attention.ts:495
 msgid "attention.aria.pointingUp"
 msgstr "pekar upp"
 
 #. Default screenreader message for popover speech bubble in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:427
+#: packages/attention/attention.ts:550
 msgid "attention.aria.popover"
 msgstr "En vit pratbubbla som ger ytterligare information"
 
 #. Default screenreader message for tooltip in the attention component
 #. js-lingui-explicit-id
-#: packages/attention/attention.ts:415
+#: packages/attention/attention.ts:536
 msgid "attention.aria.tooltip"
 msgstr "En svart pratbubbla som ger kompletterande information"

--- a/packages/breadcrumbs/locales/da/messages.po
+++ b/packages/breadcrumbs/locales/da/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Default screen reader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/breadcrumbs.ts:43
+#: packages/breadcrumbs/breadcrumbs.ts:51
 msgid "breadcrumbs.ariaLabel"
 msgstr "Du er her"

--- a/packages/breadcrumbs/locales/en/messages.po
+++ b/packages/breadcrumbs/locales/en/messages.po
@@ -16,6 +16,6 @@ msgstr ""
 
 #. Default screen reader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/breadcrumbs.ts:43
+#: packages/breadcrumbs/breadcrumbs.ts:51
 msgid "breadcrumbs.ariaLabel"
 msgstr "You are here"

--- a/packages/breadcrumbs/locales/fi/messages.po
+++ b/packages/breadcrumbs/locales/fi/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Default screen reader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/breadcrumbs.ts:43
+#: packages/breadcrumbs/breadcrumbs.ts:51
 msgid "breadcrumbs.ariaLabel"
 msgstr "Olet tässä"

--- a/packages/breadcrumbs/locales/nb/messages.po
+++ b/packages/breadcrumbs/locales/nb/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Default screen reader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/breadcrumbs.ts:43
+#: packages/breadcrumbs/breadcrumbs.ts:51
 msgid "breadcrumbs.ariaLabel"
 msgstr "Her er du"

--- a/packages/breadcrumbs/locales/sv/messages.po
+++ b/packages/breadcrumbs/locales/sv/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Default screen reader message for the breadcrumb component
 #. js-lingui-explicit-id
-#: packages/breadcrumbs/breadcrumbs.ts:43
+#: packages/breadcrumbs/breadcrumbs.ts:51
 msgid "breadcrumbs.ariaLabel"
 msgstr "Du är här"

--- a/packages/button/locales/da/messages.po
+++ b/packages/button/locales/da/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screen reader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/button.ts:221
+#: packages/button/button.ts:208
 msgid "button.aria.loading"
 msgstr "Indlæser..."

--- a/packages/button/locales/en/messages.po
+++ b/packages/button/locales/en/messages.po
@@ -16,6 +16,6 @@ msgstr ""
 
 #. Screen reader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/button.ts:221
+#: packages/button/button.ts:208
 msgid "button.aria.loading"
 msgstr "Loading..."

--- a/packages/button/locales/fi/messages.po
+++ b/packages/button/locales/fi/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screen reader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/button.ts:221
+#: packages/button/button.ts:208
 msgid "button.aria.loading"
 msgstr "Ladataan..."

--- a/packages/button/locales/nb/messages.po
+++ b/packages/button/locales/nb/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screen reader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/button.ts:221
+#: packages/button/button.ts:208
 msgid "button.aria.loading"
 msgstr "Laster..."

--- a/packages/button/locales/sv/messages.po
+++ b/packages/button/locales/sv/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screen reader message for buttons that are loading
 #. js-lingui-explicit-id
-#: packages/button/button.ts:221
+#: packages/button/button.ts:208
 msgid "button.aria.loading"
 msgstr "Laddar ..."

--- a/packages/card/locales/da/messages.po
+++ b/packages/card/locales/da/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/card/card.ts:79
+#: packages/card/card.ts:97
 msgid "card.button.text"
 msgstr "Vælg"

--- a/packages/card/locales/en/messages.po
+++ b/packages/card/locales/en/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/card/card.ts:79
+#: packages/card/card.ts:97
 msgid "card.button.text"
 msgstr "Select"

--- a/packages/card/locales/fi/messages.po
+++ b/packages/card/locales/fi/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/card/card.ts:79
+#: packages/card/card.ts:97
 msgid "card.button.text"
 msgstr "Valitse"

--- a/packages/card/locales/nb/messages.po
+++ b/packages/card/locales/nb/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/card/card.ts:79
+#: packages/card/card.ts:97
 msgid "card.button.text"
 msgstr "Velg"

--- a/packages/card/locales/sv/messages.po
+++ b/packages/card/locales/sv/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Screenreader message to indicate that the card is clickable
 #. js-lingui-explicit-id
-#: packages/card/card.ts:79
+#: packages/card/card.ts:97
 msgid "card.button.text"
 msgstr "Välj"

--- a/packages/checkbox-group/checkbox-group.test.ts
+++ b/packages/checkbox-group/checkbox-group.test.ts
@@ -5,12 +5,10 @@ import { render } from "vitest-browser-lit";
 
 import "./checkbox-group.js";
 import "../checkbox/checkbox.js";
+import { messages } from "./locales/en/messages.mjs";
 
 // Initialize i18n with English locale for tests
-i18n.load("en", {
-	"checkbox-group.label.optional": ["(optional)"],
-	"checkbox-group.validation.required": ["At least one selection is required."],
-});
+i18n.load("en", messages);
 i18n.activate("en");
 
 test("renders help text when provided", async () => {
@@ -50,7 +48,7 @@ test("renders label above the group and associates it", async () => {
 		.toBeVisible();
 });
 
-test("renders optional text when optional is true", async () => {
+test("renders optional indicator as 'Optional' without parentheses", async () => {
 	const page = render(html`
 		<w-checkbox-group label="Preferences" optional>
 			<w-checkbox>One</w-checkbox>
@@ -58,7 +56,20 @@ test("renders optional text when optional is true", async () => {
 		</w-checkbox-group>
 	`);
 
-	await expect.element(page.getByText("(optional)")).toBeVisible();
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
+});
+
+test("does not render optional indicator when both required and optional are set", async () => {
+	const page = render(html`
+		<w-checkbox-group label="Preferences" required optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	await expect.element(page.getByText("Preferences")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
 });
 
 test("required group toggles invalid state for group and children after submit and selection", async () => {

--- a/packages/checkbox-group/checkbox-group.test.ts
+++ b/packages/checkbox-group/checkbox-group.test.ts
@@ -72,6 +72,115 @@ test("does not render optional indicator when both required and optional are set
 	expect(page.getByText("Optional").query()).toBeNull();
 });
 
+test("includes optional indicator in the accessible name", async () => {
+	const page = render(html`
+		<w-checkbox-group label="Preferences" optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	await expect
+		.element(page.getByRole("group", { name: /Preferences.*Optional/ }))
+		.toBeVisible();
+});
+
+test("removes optional indicator when required is added dynamically", async () => {
+	const page = render(html`
+		<w-checkbox-group label="Preferences" optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	const group = document.querySelector("w-checkbox-group") as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	group.required = true;
+	await group.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("shows optional indicator when required is removed dynamically", async () => {
+	const page = render(html`
+		<w-checkbox-group label="Preferences" required optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	expect(page.getByText("Optional").query()).toBeNull();
+
+	const group = document.querySelector("w-checkbox-group") as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	group.required = false;
+	await group.updateComplete;
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+});
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(html`
+		<w-checkbox-group aria-label="Preferences" optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	const group = document.querySelector("w-checkbox-group") as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await group.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("excludes optional indicator from accessible name when required suppresses it", async () => {
+	const page = render(html`
+		<w-checkbox-group label="Preferences" required optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	const group = page.getByRole("group", { name: "Preferences" });
+	await expect.element(group).toBeVisible();
+
+	// Verify "Optional" is not part of the accessible name
+	expect(page.getByRole("group", { name: /Optional/ }).query()).toBeNull();
+});
+
+test("updates optional text when locale changes", async () => {
+	i18n.load("nb", {
+		"checkbox-group.label.optional": ["Valgfri"],
+	});
+
+	const page = render(html`
+		<w-checkbox-group label="Preferences" optional>
+			<w-checkbox>One</w-checkbox>
+			<w-checkbox>Two</w-checkbox>
+		</w-checkbox-group>
+	`);
+
+	const group = document.querySelector("w-checkbox-group") as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await group.updateComplete;
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	i18n.activate("nb");
+	await group.updateComplete;
+	await expect.element(page.getByText("Valgfri")).toBeVisible();
+
+	i18n.activate("en");
+});
+
 test("required group toggles invalid state for group and children after submit and selection", async () => {
 	const page = render(html`
 		<form>

--- a/packages/checkbox-group/checkbox-group.ts
+++ b/packages/checkbox-group/checkbox-group.ts
@@ -155,7 +155,7 @@ export class WarpCheckboxGroup extends FormControlMixin(LitElement) {
 					? html`
 							<div class="label" id="${labelId}">
 								<span>${this.label}</span>
-								${this.optional
+								${this.optional && !this.required
 									? html`
 											<span class="optional">
 												${i18n._({

--- a/packages/checkbox-group/locales/da/messages.po
+++ b/packages/checkbox-group/locales/da/messages.po
@@ -21,6 +21,6 @@ msgstr "Mindst én valgt mulighed er påkrævet."
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/checkbox-group/checkbox-group.ts:122
+#: packages/checkbox-group/checkbox-group.ts:161
 msgid "checkbox-group.label.optional"
 msgstr "Valgfri"

--- a/packages/checkbox-group/locales/en/messages.po
+++ b/packages/checkbox-group/locales/en/messages.po
@@ -21,6 +21,6 @@ msgstr "At least one selection is required."
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/checkbox-group/checkbox-group.ts:122
+#: packages/checkbox-group/checkbox-group.ts:161
 msgid "checkbox-group.label.optional"
 msgstr "Optional"

--- a/packages/checkbox-group/locales/fi/messages.po
+++ b/packages/checkbox-group/locales/fi/messages.po
@@ -21,6 +21,6 @@ msgstr "Vähintään yksi valinta vaaditaan."
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/checkbox-group/checkbox-group.ts:122
+#: packages/checkbox-group/checkbox-group.ts:161
 msgid "checkbox-group.label.optional"
 msgstr "Valinnainen"

--- a/packages/checkbox-group/locales/nb/messages.po
+++ b/packages/checkbox-group/locales/nb/messages.po
@@ -21,6 +21,6 @@ msgstr "Minst ett valg er påkrevd."
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/checkbox-group/checkbox-group.ts:122
+#: packages/checkbox-group/checkbox-group.ts:161
 msgid "checkbox-group.label.optional"
 msgstr "Valgfri"

--- a/packages/checkbox-group/locales/sv/messages.po
+++ b/packages/checkbox-group/locales/sv/messages.po
@@ -21,6 +21,6 @@ msgstr "Minst ett val krävs."
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/checkbox-group/checkbox-group.ts:122
+#: packages/checkbox-group/checkbox-group.ts:161
 msgid "checkbox-group.label.optional"
 msgstr "Valfritt"

--- a/packages/combobox/combobox.test.ts
+++ b/packages/combobox/combobox.test.ts
@@ -7,9 +7,11 @@ import { render } from "vitest-browser-lit";
 import "../textfield/textfield.js";
 import "./combobox.js";
 import { messages as textfieldMessages } from "../textfield/locales/en/messages.mjs";
+import { messages as textfieldNbMessages } from "../textfield/locales/nb/messages.mjs";
 
 // Initialize i18n with English locale for tests (combobox uses textfield's messages)
 i18n.load("en", textfieldMessages);
+i18n.load("nb", textfieldNbMessages);
 i18n.activate("en");
 
 test('renders with autocomplete="off" on inner textfield when attribute not provided', async () => {
@@ -463,4 +465,39 @@ test("does not render optional indicator when there is no label", async () => {
 
 	await expect.element(page.getByLabelText("Country")).toBeVisible();
 	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("excludes optional indicator from accessible name when required suppresses it", async () => {
+	const page = render(html`
+		<w-combobox label="Country" required optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	const input = page.getByRole("textbox", { name: "Country" });
+	await expect.element(input).toBeVisible();
+
+	// Verify "Optional" is not part of the accessible name
+	expect(page.getByRole("textbox", { name: /Optional/ }).query()).toBeNull();
+});
+
+test("renders localized optional text based on document lang", async () => {
+	const originalLang = document.documentElement.lang;
+	document.documentElement.lang = "nb";
+
+	const page = render(html`
+		<w-combobox label="Country" optional data-testid="field">
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await el.updateComplete;
+	await expect.element(page.getByText("Valgfri")).toBeVisible();
+
+	document.documentElement.lang = originalLang;
 });

--- a/packages/combobox/combobox.test.ts
+++ b/packages/combobox/combobox.test.ts
@@ -398,3 +398,69 @@ test("does not render optional indicator when both required and optional are set
 	await expect.element(page.getByText("Country")).toBeVisible();
 	expect(page.getByText("Optional").query()).toBeNull();
 });
+
+test("includes optional indicator in the accessible name", async () => {
+	const page = render(html`
+		<w-combobox label="Country" optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	// The inner textfield with role="combobox" should have accessible name including Optional
+	await expect
+		.element(page.getByRole("textbox", { name: /Country.*Optional/ }))
+		.toBeVisible();
+});
+
+test("removes optional indicator when required is added dynamically", async () => {
+	const page = render(html`
+		<w-combobox label="Country" optional data-testid="field">
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	el.required = true;
+	await el.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("shows optional indicator when required is removed dynamically", async () => {
+	const page = render(html`
+		<w-combobox label="Country" required optional data-testid="field">
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	expect(page.getByText("Optional").query()).toBeNull();
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	el.required = false;
+	await el.updateComplete;
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+});
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(html`
+		<w-combobox aria-label="Country" optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	await expect.element(page.getByLabelText("Country")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});

--- a/packages/combobox/combobox.test.ts
+++ b/packages/combobox/combobox.test.ts
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import { html } from "lit";
 
 import { expect, test } from "vitest";
@@ -5,6 +6,11 @@ import { render } from "vitest-browser-lit";
 
 import "../textfield/textfield.js";
 import "./combobox.js";
+import { messages as textfieldMessages } from "../textfield/locales/en/messages.mjs";
+
+// Initialize i18n with English locale for tests (combobox uses textfield's messages)
+i18n.load("en", textfieldMessages);
+i18n.activate("en");
 
 test('renders with autocomplete="off" on inner textfield when attribute not provided', async () => {
 	const component = html`<w-combobox data-testid="combobox"></w-combobox>`;
@@ -367,4 +373,28 @@ test("non-empty options property takes precedence over light-DOM option children
 	);
 
 	expect(optionTexts).toEqual(["Apple"]);
+});
+
+test("renders optional indicator as 'Optional' without parentheses", async () => {
+	const page = render(html`
+		<w-combobox label="Country" optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
+});
+
+test("does not render optional indicator when both required and optional are set", async () => {
+	const page = render(html`
+		<w-combobox label="Country" required optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-combobox>
+	`);
+
+	await expect.element(page.getByText("Country")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
 });

--- a/packages/combobox/locales/da/messages.po
+++ b/packages/combobox/locales/da/messages.po
@@ -31,12 +31,12 @@ msgstr ""
 
 #. Aria text for combobox when there are one or more suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:196
+#: packages/combobox/combobox.ts:334
 msgid "combobox.aria.pluralSuggestions"
 msgstr "{numSuggestions, plural, one {# forslag} other {# forslag}}"
 
 #. Aria text for combobox when no suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:203
+#: packages/combobox/combobox.ts:342
 msgid "combobox.aria.noSuggestions"
 msgstr "Ingen forslag"

--- a/packages/combobox/locales/en/messages.po
+++ b/packages/combobox/locales/en/messages.po
@@ -28,12 +28,12 @@ msgstr ""
 
 #. Aria text for combobox when there are one or more suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:196
+#: packages/combobox/combobox.ts:334
 msgid "combobox.aria.pluralSuggestions"
 msgstr "{numSuggestions, plural, one {# suggestion} other {# suggestions}}"
 
 #. Aria text for combobox when no suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:203
+#: packages/combobox/combobox.ts:342
 msgid "combobox.aria.noSuggestions"
 msgstr "No suggestions"

--- a/packages/combobox/locales/fi/messages.po
+++ b/packages/combobox/locales/fi/messages.po
@@ -31,12 +31,12 @@ msgstr ""
 
 #. Aria text for combobox when there are one or more suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:196
+#: packages/combobox/combobox.ts:334
 msgid "combobox.aria.pluralSuggestions"
 msgstr "{numSuggestions, plural, one {# ehdotus} other {# ehdotusta}}"
 
 #. Aria text for combobox when no suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:203
+#: packages/combobox/combobox.ts:342
 msgid "combobox.aria.noSuggestions"
 msgstr "Ei ehdotuksia"

--- a/packages/combobox/locales/nb/messages.po
+++ b/packages/combobox/locales/nb/messages.po
@@ -31,12 +31,12 @@ msgstr ""
 
 #. Aria text for combobox when there are one or more suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:196
+#: packages/combobox/combobox.ts:334
 msgid "combobox.aria.pluralSuggestions"
 msgstr "{numSuggestions, plural, one {# forslag} other {# forslag}}"
 
 #. Aria text for combobox when no suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:203
+#: packages/combobox/combobox.ts:342
 msgid "combobox.aria.noSuggestions"
 msgstr "Ingen forslag"

--- a/packages/combobox/locales/sv/messages.po
+++ b/packages/combobox/locales/sv/messages.po
@@ -31,12 +31,12 @@ msgstr ""
 
 #. Aria text for combobox when there are one or more suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:196
+#: packages/combobox/combobox.ts:334
 msgid "combobox.aria.pluralSuggestions"
 msgstr "{numSuggestions, plural, one {# förslag} other {# förslag}}"
 
 #. Aria text for combobox when no suggestions
 #. js-lingui-explicit-id
-#: packages/combobox/combobox.ts:203
+#: packages/combobox/combobox.ts:342
 msgid "combobox.aria.noSuggestions"
 msgstr "Inga förslag"

--- a/packages/datepicker/locales/da/messages.po
+++ b/packages/datepicker/locales/da/messages.po
@@ -15,30 +15,30 @@ msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is a selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:441
+#: packages/datepicker/datepicker.ts:507
 msgid "datepicker.toggle.changeDate"
 msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is no selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:448
+#: packages/datepicker/datepicker.ts:514
 msgid "datepicker.toggle.chooseDate"
 msgstr ""
 
 #. Used by screen readers to announce that the calendar element is a date picker.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:469
+#: packages/datepicker/datepicker.ts:544
 msgid "datepicker.calendar.roleDescription"
 msgstr ""
 
 #. Screen reader label for the next month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:500
+#: packages/datepicker/datepicker.ts:583
 msgid "datepicker.calendar.nextMonth"
 msgstr ""
 
 #. Screen reader label for the previous month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:482
+#: packages/datepicker/datepicker.ts:559
 msgid "datepicker.calendar.previousMonth"
 msgstr ""

--- a/packages/datepicker/locales/en/messages.po
+++ b/packages/datepicker/locales/en/messages.po
@@ -15,30 +15,30 @@ msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is a selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:441
+#: packages/datepicker/datepicker.ts:507
 msgid "datepicker.toggle.changeDate"
 msgstr "Change date, {currentDate}"
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is no selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:448
+#: packages/datepicker/datepicker.ts:514
 msgid "datepicker.toggle.chooseDate"
 msgstr "Choose date"
 
 #. Used by screen readers to announce that the calendar element is a date picker.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:469
+#: packages/datepicker/datepicker.ts:544
 msgid "datepicker.calendar.roleDescription"
 msgstr "Date picker"
 
 #. Screen reader label for the next month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:500
+#: packages/datepicker/datepicker.ts:583
 msgid "datepicker.calendar.nextMonth"
 msgstr "Next month"
 
 #. Screen reader label for the previous month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:482
+#: packages/datepicker/datepicker.ts:559
 msgid "datepicker.calendar.previousMonth"
 msgstr "Previous month"

--- a/packages/datepicker/locales/fi/messages.po
+++ b/packages/datepicker/locales/fi/messages.po
@@ -15,30 +15,30 @@ msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is a selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:441
+#: packages/datepicker/datepicker.ts:507
 msgid "datepicker.toggle.changeDate"
 msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is no selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:448
+#: packages/datepicker/datepicker.ts:514
 msgid "datepicker.toggle.chooseDate"
 msgstr ""
 
 #. Used by screen readers to announce that the calendar element is a date picker.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:469
+#: packages/datepicker/datepicker.ts:544
 msgid "datepicker.calendar.roleDescription"
 msgstr ""
 
 #. Screen reader label for the next month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:500
+#: packages/datepicker/datepicker.ts:583
 msgid "datepicker.calendar.nextMonth"
 msgstr ""
 
 #. Screen reader label for the previous month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:482
+#: packages/datepicker/datepicker.ts:559
 msgid "datepicker.calendar.previousMonth"
 msgstr ""

--- a/packages/datepicker/locales/nb/messages.po
+++ b/packages/datepicker/locales/nb/messages.po
@@ -15,30 +15,30 @@ msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is a selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:441
+#: packages/datepicker/datepicker.ts:507
 msgid "datepicker.toggle.changeDate"
 msgstr "Endre dato, {currentDate}"
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is no selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:448
+#: packages/datepicker/datepicker.ts:514
 msgid "datepicker.toggle.chooseDate"
 msgstr "Velg dato"
 
 #. Used by screen readers to announce that the calendar element is a date picker.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:469
+#: packages/datepicker/datepicker.ts:544
 msgid "datepicker.calendar.roleDescription"
 msgstr "datovelger"
 
 #. Screen reader label for the next month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:500
+#: packages/datepicker/datepicker.ts:583
 msgid "datepicker.calendar.nextMonth"
 msgstr "Gå til neste måned"
 
 #. Screen reader label for the previous month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:482
+#: packages/datepicker/datepicker.ts:559
 msgid "datepicker.calendar.previousMonth"
 msgstr "Gå til forrige måned"

--- a/packages/datepicker/locales/sv/messages.po
+++ b/packages/datepicker/locales/sv/messages.po
@@ -15,30 +15,30 @@ msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is a selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:441
+#: packages/datepicker/datepicker.ts:507
 msgid "datepicker.toggle.changeDate"
 msgstr ""
 
 #. Used by screen readers to describe the button that toggles open the calendar in a date picker when there is no selected date
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:448
+#: packages/datepicker/datepicker.ts:514
 msgid "datepicker.toggle.chooseDate"
 msgstr ""
 
 #. Used by screen readers to announce that the calendar element is a date picker.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:469
+#: packages/datepicker/datepicker.ts:544
 msgid "datepicker.calendar.roleDescription"
 msgstr ""
 
 #. Screen reader label for the next month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:500
+#: packages/datepicker/datepicker.ts:583
 msgid "datepicker.calendar.nextMonth"
 msgstr ""
 
 #. Screen reader label for the previous month button.
 #. js-lingui-explicit-id
-#: packages/datepicker/datepicker.ts:482
+#: packages/datepicker/datepicker.ts:559
 msgid "datepicker.calendar.previousMonth"
 msgstr ""

--- a/packages/modal/locales/da/messages.po
+++ b/packages/modal/locales/da/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Aria label for the back button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:70
+#: packages/modal-header/modal-header.ts:91
 msgid "modal.aria.back"
 msgstr "Tilbage"
 
 #. Aria label for the close button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:86
+#: packages/modal-header/modal-header.ts:116
 msgid "modal.aria.close"
 msgstr "Luk"

--- a/packages/modal/locales/en/messages.po
+++ b/packages/modal/locales/en/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #. Aria label for the back button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:70
+#: packages/modal-header/modal-header.ts:91
 msgid "modal.aria.back"
 msgstr "Back"
 
 #. Aria label for the close button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:86
+#: packages/modal-header/modal-header.ts:116
 msgid "modal.aria.close"
 msgstr "Close"

--- a/packages/modal/locales/fi/messages.po
+++ b/packages/modal/locales/fi/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Aria label for the back button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:70
+#: packages/modal-header/modal-header.ts:91
 msgid "modal.aria.back"
 msgstr "Takaisin"
 
 #. Aria label for the close button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:86
+#: packages/modal-header/modal-header.ts:116
 msgid "modal.aria.close"
 msgstr "Sulje"

--- a/packages/modal/locales/nb/messages.po
+++ b/packages/modal/locales/nb/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Aria label for the back button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:70
+#: packages/modal-header/modal-header.ts:91
 msgid "modal.aria.back"
 msgstr "Tilbake"
 
 #. Aria label for the close button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:86
+#: packages/modal-header/modal-header.ts:116
 msgid "modal.aria.close"
 msgstr "Lukk"

--- a/packages/modal/locales/sv/messages.po
+++ b/packages/modal/locales/sv/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Aria label for the back button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:70
+#: packages/modal-header/modal-header.ts:91
 msgid "modal.aria.back"
 msgstr "Tillbaka"
 
 #. Aria label for the close button in modal
 #. js-lingui-explicit-id
-#: packages/modal-header/modal-header.ts:86
+#: packages/modal-header/modal-header.ts:116
 msgid "modal.aria.close"
 msgstr "Stäng"

--- a/packages/page-indicator/locales/da/messages.po
+++ b/packages/page-indicator/locales/da/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Default screenreader message for page indicator group
 #. js-lingui-explicit-id
-#: packages/page-indicator/page-indicator.ts:57
+#: packages/page-indicator/page-indicator.ts:64
 msgid "page-indicator.aria.label"
 msgstr "Prik {selectedPage} er fremhævet i en række med {pageCount} prikker"

--- a/packages/page-indicator/locales/en/messages.po
+++ b/packages/page-indicator/locales/en/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Default screenreader message for page indicator group
 #. js-lingui-explicit-id
-#: packages/page-indicator/page-indicator.ts:57
+#: packages/page-indicator/page-indicator.ts:64
 msgid "page-indicator.aria.label"
 msgstr "Dot {selectedPage} is highlighted in a row of {pageCount} dots"

--- a/packages/page-indicator/locales/fi/messages.po
+++ b/packages/page-indicator/locales/fi/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Default screenreader message for page indicator group
 #. js-lingui-explicit-id
-#: packages/page-indicator/page-indicator.ts:57
+#: packages/page-indicator/page-indicator.ts:64
 msgid "page-indicator.aria.label"
 msgstr "Piste {selectedPage} on korostettuna {pageCount} pisteen rivissä"

--- a/packages/page-indicator/locales/nb/messages.po
+++ b/packages/page-indicator/locales/nb/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Default screenreader message for page indicator group
 #. js-lingui-explicit-id
-#: packages/page-indicator/page-indicator.ts:57
+#: packages/page-indicator/page-indicator.ts:64
 msgid "page-indicator.aria.label"
 msgstr "Prikk {selectedPage} er uthevet i en rad med {pageCount} prikker"

--- a/packages/page-indicator/locales/sv/messages.po
+++ b/packages/page-indicator/locales/sv/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Default screenreader message for page indicator group
 #. js-lingui-explicit-id
-#: packages/page-indicator/page-indicator.ts:57
+#: packages/page-indicator/page-indicator.ts:64
 msgid "page-indicator.aria.label"
 msgstr "Prick {selectedPage} är markerad i en rad med {pageCount} prickar"

--- a/packages/pagination/locales/da/messages.po
+++ b/packages/pagination/locales/da/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Default screenreader message for first page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:146
+#: packages/pagination/pagination.ts:161
 msgid "pagination.aria.first-page"
 msgstr "Første side"
 
@@ -27,30 +27,30 @@ msgstr "ikon"
 
 #. Default screenreader message for next page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:225
+#: packages/pagination/pagination.ts:252
 msgid "pagination.aria.next-page"
 msgstr "Næste side"
 
-#. Default message for current page label in the pagination component
-#. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:209
-msgid "pagination.label.current-page"
-msgstr "Side {currentPage}"
-
 #. Default screenreader message for page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:192
+#: packages/pagination/pagination.ts:217
 msgid "pagination.aria.page"
+msgstr "Side {currentPage}"
+
+#. Default message for current page label in the pagination component
+#. js-lingui-explicit-id
+#: packages/pagination/pagination.ts:236
+msgid "pagination.label.current-page"
 msgstr "Side {currentPage}"
 
 #. Default screenreader message for pagination container in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:129
+#: packages/pagination/pagination.ts:145
 msgid "pagination.aria.pagination"
 msgstr "Sider"
 
 #. Default screenreader message for previous page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:167
+#: packages/pagination/pagination.ts:186
 msgid "pagination.aria.prev-page"
 msgstr "Forrige side"

--- a/packages/pagination/locales/en/messages.po
+++ b/packages/pagination/locales/en/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Default screenreader message for first page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:146
+#: packages/pagination/pagination.ts:161
 msgid "pagination.aria.first-page"
 msgstr "First page"
 
@@ -27,30 +27,30 @@ msgstr "icon"
 
 #. Default screenreader message for next page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:225
+#: packages/pagination/pagination.ts:252
 msgid "pagination.aria.next-page"
 msgstr "Next page"
 
-#. Default message for current page label in the pagination component
-#. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:209
-msgid "pagination.label.current-page"
-msgstr "Page {currentPage}"
-
 #. Default screenreader message for page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:192
+#: packages/pagination/pagination.ts:217
 msgid "pagination.aria.page"
+msgstr "Page {currentPage}"
+
+#. Default message for current page label in the pagination component
+#. js-lingui-explicit-id
+#: packages/pagination/pagination.ts:236
+msgid "pagination.label.current-page"
 msgstr "Page {currentPage}"
 
 #. Default screenreader message for pagination container in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:129
+#: packages/pagination/pagination.ts:145
 msgid "pagination.aria.pagination"
 msgstr "Pages"
 
 #. Default screenreader message for previous page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:167
+#: packages/pagination/pagination.ts:186
 msgid "pagination.aria.prev-page"
 msgstr "Previous page"

--- a/packages/pagination/locales/fi/messages.po
+++ b/packages/pagination/locales/fi/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Default screenreader message for first page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:146
+#: packages/pagination/pagination.ts:161
 msgid "pagination.aria.first-page"
 msgstr "Ensimmäinen sivu"
 
@@ -27,30 +27,30 @@ msgstr "kuvake"
 
 #. Default screenreader message for next page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:225
+#: packages/pagination/pagination.ts:252
 msgid "pagination.aria.next-page"
 msgstr "Seuraava sivu"
 
-#. Default message for current page label in the pagination component
-#. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:209
-msgid "pagination.label.current-page"
-msgstr "Sivu {currentPage}"
-
 #. Default screenreader message for page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:192
+#: packages/pagination/pagination.ts:217
 msgid "pagination.aria.page"
+msgstr "Sivu {currentPage}"
+
+#. Default message for current page label in the pagination component
+#. js-lingui-explicit-id
+#: packages/pagination/pagination.ts:236
+msgid "pagination.label.current-page"
 msgstr "Sivu {currentPage}"
 
 #. Default screenreader message for pagination container in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:129
+#: packages/pagination/pagination.ts:145
 msgid "pagination.aria.pagination"
 msgstr "Sivut"
 
 #. Default screenreader message for previous page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:167
+#: packages/pagination/pagination.ts:186
 msgid "pagination.aria.prev-page"
 msgstr "Edellinen sivu"

--- a/packages/pagination/locales/nb/messages.po
+++ b/packages/pagination/locales/nb/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Default screenreader message for first page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:146
+#: packages/pagination/pagination.ts:161
 msgid "pagination.aria.first-page"
 msgstr "Første side"
 
@@ -27,30 +27,30 @@ msgstr "ikon"
 
 #. Default screenreader message for next page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:225
+#: packages/pagination/pagination.ts:252
 msgid "pagination.aria.next-page"
 msgstr "Neste side"
 
-#. Default message for current page label in the pagination component
-#. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:209
-msgid "pagination.label.current-page"
-msgstr "Side {currentPage}"
-
 #. Default screenreader message for page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:192
+#: packages/pagination/pagination.ts:217
 msgid "pagination.aria.page"
+msgstr "Side {currentPage}"
+
+#. Default message for current page label in the pagination component
+#. js-lingui-explicit-id
+#: packages/pagination/pagination.ts:236
+msgid "pagination.label.current-page"
 msgstr "Side {currentPage}"
 
 #. Default screenreader message for pagination container in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:129
+#: packages/pagination/pagination.ts:145
 msgid "pagination.aria.pagination"
 msgstr "Sider"
 
 #. Default screenreader message for previous page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:167
+#: packages/pagination/pagination.ts:186
 msgid "pagination.aria.prev-page"
 msgstr "Forrige side"

--- a/packages/pagination/locales/sv/messages.po
+++ b/packages/pagination/locales/sv/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #. Default screenreader message for first page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:146
+#: packages/pagination/pagination.ts:161
 msgid "pagination.aria.first-page"
 msgstr "Första sidan"
 
@@ -27,30 +27,30 @@ msgstr "ikon"
 
 #. Default screenreader message for next page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:225
+#: packages/pagination/pagination.ts:252
 msgid "pagination.aria.next-page"
 msgstr "Nästa sida"
 
-#. Default message for current page label in the pagination component
-#. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:209
-msgid "pagination.label.current-page"
-msgstr "Sida {currentPage}"
-
 #. Default screenreader message for page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:192
+#: packages/pagination/pagination.ts:217
 msgid "pagination.aria.page"
+msgstr "Sida {currentPage}"
+
+#. Default message for current page label in the pagination component
+#. js-lingui-explicit-id
+#: packages/pagination/pagination.ts:236
+msgid "pagination.label.current-page"
 msgstr "Sida {currentPage}"
 
 #. Default screenreader message for pagination container in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:129
+#: packages/pagination/pagination.ts:145
 msgid "pagination.aria.pagination"
 msgstr "Sidor"
 
 #. Default screenreader message for previous page link in the pagination component
 #. js-lingui-explicit-id
-#: packages/pagination/pagination.ts:167
+#: packages/pagination/pagination.ts:186
 msgid "pagination.aria.prev-page"
 msgstr "Föregående sida"

--- a/packages/pill/locales/da/messages.po
+++ b/packages/pill/locales/da/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Fallback screen reader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:66
+#: packages/pill/pill.ts:89
 msgid "pill.aria.openFilter"
 msgstr "Åbn filter"
 
 #. Fallback screen reader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:72
+#: packages/pill/pill.ts:95
 msgid "pill.aria.removeFilter"
 msgstr "Fjern filter {label}"

--- a/packages/pill/locales/en/messages.po
+++ b/packages/pill/locales/en/messages.po
@@ -16,12 +16,12 @@ msgstr ""
 
 #. Fallback screen reader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:66
+#: packages/pill/pill.ts:89
 msgid "pill.aria.openFilter"
 msgstr "Open filter"
 
 #. Fallback screen reader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:72
+#: packages/pill/pill.ts:95
 msgid "pill.aria.removeFilter"
 msgstr "Remove filter {label}"

--- a/packages/pill/locales/fi/messages.po
+++ b/packages/pill/locales/fi/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Fallback screen reader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:66
+#: packages/pill/pill.ts:89
 msgid "pill.aria.openFilter"
 msgstr "Avaa suodatin"
 
 #. Fallback screen reader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:72
+#: packages/pill/pill.ts:95
 msgid "pill.aria.removeFilter"
 msgstr "Tyhjennä suodatin {label}"

--- a/packages/pill/locales/nb/messages.po
+++ b/packages/pill/locales/nb/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Fallback screen reader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:66
+#: packages/pill/pill.ts:89
 msgid "pill.aria.openFilter"
 msgstr "Åpne filter"
 
 #. Fallback screen reader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:72
+#: packages/pill/pill.ts:95
 msgid "pill.aria.removeFilter"
 msgstr "Fjern filter {label}"

--- a/packages/pill/locales/sv/messages.po
+++ b/packages/pill/locales/sv/messages.po
@@ -19,12 +19,12 @@ msgstr ""
 
 #. Fallback screen reader message for open filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:66
+#: packages/pill/pill.ts:89
 msgid "pill.aria.openFilter"
 msgstr "Öppna filter"
 
 #. Fallback screen reader message for removal of the filter
 #. js-lingui-explicit-id
-#: packages/pill/pill.ts:72
+#: packages/pill/pill.ts:95
 msgid "pill.aria.removeFilter"
 msgstr "Ta bort filtret {label}"

--- a/packages/radio-group/locales/da/messages.po
+++ b/packages/radio-group/locales/da/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:427
+#: packages/radio-group/radio-group.ts:526
 msgid "radio-group.label.optional"
 msgstr "Valgfri"
 
 #. Shown when required radio group has no selections
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:25
+#: packages/radio-group/radio-group.ts:24
 msgid "radio-group.validation.required"
 msgstr "Vælg en mulighed."

--- a/packages/radio-group/locales/en/messages.po
+++ b/packages/radio-group/locales/en/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:427
+#: packages/radio-group/radio-group.ts:526
 msgid "radio-group.label.optional"
 msgstr "Optional"
 
 #. Shown when required radio group has no selections
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:25
+#: packages/radio-group/radio-group.ts:24
 msgid "radio-group.validation.required"
 msgstr "Please select an option."

--- a/packages/radio-group/locales/fi/messages.po
+++ b/packages/radio-group/locales/fi/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:427
+#: packages/radio-group/radio-group.ts:526
 msgid "radio-group.label.optional"
 msgstr "Valinnainen"
 
 #. Shown when required radio group has no selections
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:25
+#: packages/radio-group/radio-group.ts:24
 msgid "radio-group.validation.required"
 msgstr "Valitse vaihtoehto."

--- a/packages/radio-group/locales/nb/messages.po
+++ b/packages/radio-group/locales/nb/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:427
+#: packages/radio-group/radio-group.ts:526
 msgid "radio-group.label.optional"
 msgstr "Valgfri"
 
 #. Shown when required radio group has no selections
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:25
+#: packages/radio-group/radio-group.ts:24
 msgid "radio-group.validation.required"
 msgstr "Velg et alternativ."

--- a/packages/radio-group/locales/sv/messages.po
+++ b/packages/radio-group/locales/sv/messages.po
@@ -15,12 +15,12 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:427
+#: packages/radio-group/radio-group.ts:526
 msgid "radio-group.label.optional"
 msgstr "Valfritt"
 
 #. Shown when required radio group has no selections
 #. js-lingui-explicit-id
-#: packages/radio-group/radio-group.ts:25
+#: packages/radio-group/radio-group.ts:24
 msgid "radio-group.validation.required"
 msgstr "Välj ett alternativ."

--- a/packages/radio-group/radio-group.test.ts
+++ b/packages/radio-group/radio-group.test.ts
@@ -5,12 +5,10 @@ import { render } from "vitest-browser-lit";
 
 import "./radio-group.js";
 import "../radio/radio.js";
+import { messages } from "./locales/en/messages.mjs";
 
 // Initialize i18n with English locale for tests
-i18n.load("en", {
-	"radio-group.label.optional": ["(optional)"],
-	"radio-group.validation.required": ["Please select an option."],
-});
+i18n.load("en", messages);
 i18n.activate("en");
 
 test("selects radio on click and dispatches input/change", async () => {
@@ -100,7 +98,7 @@ test("disabled group renders help text in disabled color", async () => {
 	expect(getComputedStyle(helpText).color).toBe(disabledColor);
 });
 
-test("renders optional text when optional is true", async () => {
+test("renders optional indicator as 'Optional' without parentheses", async () => {
 	const page = render(html`
 		<w-radio-group name="choices" label="Choices" optional>
 			<w-radio value="alpha">Alpha</w-radio>
@@ -108,7 +106,20 @@ test("renders optional text when optional is true", async () => {
 		</w-radio-group>
 	`);
 
-	await expect.element(page.getByText("(optional)")).toBeVisible();
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
+});
+
+test("does not render optional indicator when both required and optional are set", async () => {
+	const page = render(html`
+		<w-radio-group name="choices" label="Choices" required optional>
+			<w-radio value="alpha">Alpha</w-radio>
+			<w-radio value="beta">Beta</w-radio>
+		</w-radio-group>
+	`);
+
+	await expect.element(page.getByText("Choices")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
 });
 
 test("associates selected value with form submission", async () => {
@@ -551,7 +562,7 @@ test("adds and removes tabindex on the host when invalid", async () => {
 
 test("updates optional text when locale changes", async () => {
 	i18n.load("fr", {
-		"radio-group.label.optional": ["(optionnel)"],
+		"radio-group.label.optional": ["Facultatif"],
 		"radio-group.validation.required": ["Please select an option."],
 	});
 
@@ -566,11 +577,11 @@ test("updates optional text when locale changes", async () => {
 		updateComplete: Promise<unknown>;
 	};
 	await group.updateComplete;
-	await expect.element(page.getByText("(optional)")).toBeVisible();
+	await expect.element(page.getByText("Optional")).toBeVisible();
 
 	i18n.activate("fr");
 	await group.updateComplete;
-	await expect.element(page.getByText("(optionnel)")).toBeVisible();
+	await expect.element(page.getByText("Facultatif")).toBeVisible();
 
 	i18n.activate("en");
 });

--- a/packages/radio-group/radio-group.test.ts
+++ b/packages/radio-group/radio-group.test.ts
@@ -122,6 +122,90 @@ test("does not render optional indicator when both required and optional are set
 	expect(page.getByText("Optional").query()).toBeNull();
 });
 
+test("includes optional indicator in the accessible name", async () => {
+	const page = render(html`
+		<w-radio-group name="choices" label="Choices" optional>
+			<w-radio value="alpha">Alpha</w-radio>
+			<w-radio value="beta">Beta</w-radio>
+		</w-radio-group>
+	`);
+
+	await expect
+		.element(page.getByRole("radiogroup", { name: /Choices.*Optional/ }))
+		.toBeVisible();
+});
+
+test("removes optional indicator when required is added dynamically", async () => {
+	const page = render(html`
+		<w-radio-group name="choices" label="Choices" optional>
+			<w-radio value="alpha">Alpha</w-radio>
+			<w-radio value="beta">Beta</w-radio>
+		</w-radio-group>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	const group = document.querySelector("w-radio-group") as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	group.required = true;
+	await group.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("shows optional indicator when required is removed dynamically", async () => {
+	const page = render(html`
+		<w-radio-group name="choices" label="Choices" required optional>
+			<w-radio value="alpha">Alpha</w-radio>
+			<w-radio value="beta">Beta</w-radio>
+		</w-radio-group>
+	`);
+
+	expect(page.getByText("Optional").query()).toBeNull();
+
+	const group = document.querySelector("w-radio-group") as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	group.required = false;
+	await group.updateComplete;
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+});
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(html`
+		<w-radio-group name="choices" aria-label="Choices" optional>
+			<w-radio value="alpha">Alpha</w-radio>
+			<w-radio value="beta">Beta</w-radio>
+		</w-radio-group>
+	`);
+
+	const group = document.querySelector("w-radio-group") as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await group.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("excludes optional indicator from accessible name when required suppresses it", async () => {
+	const page = render(html`
+		<w-radio-group name="choices" label="Choices" required optional>
+			<w-radio value="alpha">Alpha</w-radio>
+			<w-radio value="beta">Beta</w-radio>
+		</w-radio-group>
+	`);
+
+	const group = page.getByRole("radiogroup", { name: "Choices" });
+	await expect.element(group).toBeVisible();
+
+	// Verify "Optional" is not part of the accessible name
+	expect(page.getByRole("radiogroup", { name: /Optional/ }).query()).toBeNull();
+});
+
 test("associates selected value with form submission", async () => {
 	render(html`
 		<form>

--- a/packages/radio-group/radio-group.ts
+++ b/packages/radio-group/radio-group.ts
@@ -521,7 +521,7 @@ export class WarpRadioGroup extends FormControlMixin(LitElement) {
 								@click=${this.handleLabelClick}
 							>
 								<slot name="label">${this.label}</slot>
-								${this.optional
+								${this.optional && !this.required
 									? html`<span class="optional">
 											${i18n._({
 												id: "radio-group.label.optional",

--- a/packages/select/locales/da/messages.po
+++ b/packages/select/locales/da/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/select.ts:353
+#: packages/select/select.ts:430
 msgid "select.label.optional"
 msgstr "(valgfrit)"

--- a/packages/select/locales/da/messages.po
+++ b/packages/select/locales/da/messages.po
@@ -21,4 +21,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/select/select.ts:430
 msgid "select.label.optional"
-msgstr "(valgfrit)"
+msgstr "Valgfri"

--- a/packages/select/locales/en/messages.po
+++ b/packages/select/locales/en/messages.po
@@ -16,6 +16,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/select.ts:353
+#: packages/select/select.ts:430
 msgid "select.label.optional"
-msgstr "(optional)"
+msgstr "Optional"

--- a/packages/select/locales/fi/messages.po
+++ b/packages/select/locales/fi/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/select.ts:353
+#: packages/select/select.ts:430
 msgid "select.label.optional"
 msgstr "(vapaaehtoinen)"

--- a/packages/select/locales/fi/messages.po
+++ b/packages/select/locales/fi/messages.po
@@ -21,4 +21,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/select/select.ts:430
 msgid "select.label.optional"
-msgstr "(vapaaehtoinen)"
+msgstr "Valinnainen"

--- a/packages/select/locales/nb/messages.po
+++ b/packages/select/locales/nb/messages.po
@@ -21,4 +21,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/select/select.ts:430
 msgid "select.label.optional"
-msgstr "(valgfritt)"
+msgstr "Valgfri"

--- a/packages/select/locales/nb/messages.po
+++ b/packages/select/locales/nb/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/select.ts:353
+#: packages/select/select.ts:430
 msgid "select.label.optional"
 msgstr "(valgfritt)"

--- a/packages/select/locales/sv/messages.po
+++ b/packages/select/locales/sv/messages.po
@@ -19,6 +19,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/select/select.ts:353
+#: packages/select/select.ts:430
 msgid "select.label.optional"
 msgstr "(valfritt)"

--- a/packages/select/locales/sv/messages.po
+++ b/packages/select/locales/sv/messages.po
@@ -21,4 +21,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/select/select.ts:430
 msgid "select.label.optional"
-msgstr "(valfritt)"
+msgstr "Valfritt"

--- a/packages/select/select.test.ts
+++ b/packages/select/select.test.ts
@@ -6,9 +6,11 @@ import { render } from "vitest-browser-lit";
 
 import "./select.js";
 import { messages } from "./locales/en/messages.mjs";
+import { messages as nbMessages } from "./locales/nb/messages.mjs";
 
 // Initialize i18n with English locale for tests
 i18n.load("en", messages);
+i18n.load("nb", nbMessages);
 i18n.activate("en");
 
 test("works in a form", async () => {
@@ -428,4 +430,24 @@ test("does not render optional indicator when there is no label", async () => {
 
 	await expect.element(page.getByLabelText("Country")).toBeVisible();
 	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("renders localized optional text based on document lang", async () => {
+	const originalLang = document.documentElement.lang;
+	document.documentElement.lang = "nb";
+
+	const page = render(html`
+		<w-select label="Country" optional data-testid="field">
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-select>
+	`);
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await el.updateComplete;
+	await expect.element(page.getByText("Valgfri")).toBeVisible();
+
+	document.documentElement.lang = originalLang;
 });

--- a/packages/select/select.test.ts
+++ b/packages/select/select.test.ts
@@ -417,3 +417,15 @@ test("includes optional indicator in the accessible name", async () => {
 		.element(page.getByRole("combobox", { name: /Country.*Optional/ }))
 		.toBeVisible();
 });
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(html`
+		<w-select aria-label="Country" optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-select>
+	`);
+
+	await expect.element(page.getByLabelText("Country")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});

--- a/packages/select/select.test.ts
+++ b/packages/select/select.test.ts
@@ -1,9 +1,15 @@
+import { i18n } from "@lingui/core";
 import { server, userEvent } from "vitest/browser";
 import { html } from "lit";
 import { expect, test, vi } from "vitest";
 import { render } from "vitest-browser-lit";
 
 import "./select.js";
+import { messages } from "./locales/en/messages.mjs";
+
+// Initialize i18n with English locale for tests
+i18n.load("en", messages);
+i18n.activate("en");
 
 test("works in a form", async () => {
 	const component = html`
@@ -386,3 +392,28 @@ test.skipIf(server.browser === "chromium" && server.config.env.CI)(
 		expect(onSubmit).toHaveBeenCalled();
 	},
 );
+
+test("renders optional indicator as 'Optional' without parentheses", async () => {
+	const page = render(html`
+		<w-select label="Country" optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-select>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
+});
+
+test("includes optional indicator in the accessible name", async () => {
+	const page = render(html`
+		<w-select label="Country" optional>
+			<option value="no">Norway</option>
+			<option value="se">Sweden</option>
+		</w-select>
+	`);
+
+	await expect
+		.element(page.getByRole("combobox", { name: /Country.*Optional/ }))
+		.toBeVisible();
+});

--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -429,7 +429,7 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 								html`<span
 									>${i18n._({
 										id: "select.label.optional",
-										message: "(optional)",
+										message: "Optional",
 										comment: "Shown behind label when marked as optional",
 									})}</span
 								>`,

--- a/packages/slider/locales/da/messages.po
+++ b/packages/slider/locales/da/messages.po
@@ -38,7 +38,7 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/slider/slider.ts:474
 msgid "select.label.optional"
-msgstr ""
+msgstr "Valgfri"
 
 #. js-lingui-explicit-id
 #: packages/slider-thumb/slider-thumb.ts:275

--- a/packages/slider/locales/da/messages.po
+++ b/packages/slider/locales/da/messages.po
@@ -15,43 +15,49 @@ msgstr ""
 
 #. Accessible label for the 'from value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:340
-#: packages/slider-thumb/slider-thumb.ts:578
+#: packages/slider-thumb/slider-thumb.ts:442
+#: packages/slider-thumb/slider-thumb.ts:722
 msgid "slider.label.from"
 msgstr ""
 
 #. Max as in short for Maximum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:500
-#: packages/slider-thumb/slider-thumb.ts:519
+#: packages/slider-thumb/slider-thumb.ts:626
+#: packages/slider-thumb/slider-thumb.ts:645
 msgid "slider.placeholder.to"
 msgstr ""
 
 #. Min as in short for Minimum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:496
-#: packages/slider-thumb/slider-thumb.ts:525
+#: packages/slider-thumb/slider-thumb.ts:622
+#: packages/slider-thumb/slider-thumb.ts:651
 msgid "slider.placeholder.from"
 msgstr ""
 
+#. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:225
+#: packages/slider/slider.ts:474
+msgid "select.label.optional"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: packages/slider-thumb/slider-thumb.ts:275
 msgid "slider.error.overlap"
 msgstr "Maksimumværdien må ikke være mindre end minimumværdien"
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:200
+#: packages/slider-thumb/slider-thumb.ts:246
 msgid "slider.error.required"
 msgstr "Dette felt er påkrævet"
 
 #. Accessible label for the 'to value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:346
-#: packages/slider-thumb/slider-thumb.ts:585
+#: packages/slider-thumb/slider-thumb.ts:449
+#: packages/slider-thumb/slider-thumb.ts:729
 msgid "slider.label.to"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:186
+#: packages/slider-thumb/slider-thumb.ts:232
 msgid "slider.error.out_of_bounds"
 msgstr "Værdien skal være mellem {min} og {max}"

--- a/packages/slider/locales/en/messages.po
+++ b/packages/slider/locales/en/messages.po
@@ -15,43 +15,49 @@ msgstr ""
 
 #. Accessible label for the 'from value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:340
-#: packages/slider-thumb/slider-thumb.ts:578
+#: packages/slider-thumb/slider-thumb.ts:442
+#: packages/slider-thumb/slider-thumb.ts:722
 msgid "slider.label.from"
 msgstr "From"
 
 #. Max as in short for Maximum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:500
-#: packages/slider-thumb/slider-thumb.ts:519
+#: packages/slider-thumb/slider-thumb.ts:626
+#: packages/slider-thumb/slider-thumb.ts:645
 msgid "slider.placeholder.to"
 msgstr "Max"
 
 #. Min as in short for Minimum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:496
-#: packages/slider-thumb/slider-thumb.ts:525
+#: packages/slider-thumb/slider-thumb.ts:622
+#: packages/slider-thumb/slider-thumb.ts:651
 msgid "slider.placeholder.from"
 msgstr "Min"
 
+#. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:225
+#: packages/slider/slider.ts:474
+msgid "select.label.optional"
+msgstr "Optional"
+
+#. js-lingui-explicit-id
+#: packages/slider-thumb/slider-thumb.ts:275
 msgid "slider.error.overlap"
 msgstr "The maximum value cannot be less than the minimum"
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:200
+#: packages/slider-thumb/slider-thumb.ts:246
 msgid "slider.error.required"
 msgstr "This field is required"
 
 #. Accessible label for the 'to value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:346
-#: packages/slider-thumb/slider-thumb.ts:585
+#: packages/slider-thumb/slider-thumb.ts:449
+#: packages/slider-thumb/slider-thumb.ts:729
 msgid "slider.label.to"
 msgstr "To"
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:186
+#: packages/slider-thumb/slider-thumb.ts:232
 msgid "slider.error.out_of_bounds"
 msgstr "Value must be between {min} and {max}"

--- a/packages/slider/locales/fi/messages.po
+++ b/packages/slider/locales/fi/messages.po
@@ -15,43 +15,49 @@ msgstr ""
 
 #. Accessible label for the 'from value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:340
-#: packages/slider-thumb/slider-thumb.ts:578
+#: packages/slider-thumb/slider-thumb.ts:442
+#: packages/slider-thumb/slider-thumb.ts:722
 msgid "slider.label.from"
 msgstr ""
 
 #. Max as in short for Maximum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:500
-#: packages/slider-thumb/slider-thumb.ts:519
+#: packages/slider-thumb/slider-thumb.ts:626
+#: packages/slider-thumb/slider-thumb.ts:645
 msgid "slider.placeholder.to"
 msgstr ""
 
 #. Min as in short for Minimum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:496
-#: packages/slider-thumb/slider-thumb.ts:525
+#: packages/slider-thumb/slider-thumb.ts:622
+#: packages/slider-thumb/slider-thumb.ts:651
 msgid "slider.placeholder.from"
 msgstr ""
 
+#. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:225
+#: packages/slider/slider.ts:474
+msgid "select.label.optional"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: packages/slider-thumb/slider-thumb.ts:275
 msgid "slider.error.overlap"
 msgstr "Maksimiarvo ei voi olla pienempi kuin minimiarvo"
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:200
+#: packages/slider-thumb/slider-thumb.ts:246
 msgid "slider.error.required"
 msgstr "Tämä kenttä on pakollinen"
 
 #. Accessible label for the 'to value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:346
-#: packages/slider-thumb/slider-thumb.ts:585
+#: packages/slider-thumb/slider-thumb.ts:449
+#: packages/slider-thumb/slider-thumb.ts:729
 msgid "slider.label.to"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:186
+#: packages/slider-thumb/slider-thumb.ts:232
 msgid "slider.error.out_of_bounds"
 msgstr "Arvon on oltava välillä {min} - {max}"

--- a/packages/slider/locales/fi/messages.po
+++ b/packages/slider/locales/fi/messages.po
@@ -38,7 +38,7 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/slider/slider.ts:474
 msgid "select.label.optional"
-msgstr ""
+msgstr "Valinnainen"
 
 #. js-lingui-explicit-id
 #: packages/slider-thumb/slider-thumb.ts:275

--- a/packages/slider/locales/nb/messages.po
+++ b/packages/slider/locales/nb/messages.po
@@ -15,43 +15,49 @@ msgstr ""
 
 #. Accessible label for the 'from value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:340
-#: packages/slider-thumb/slider-thumb.ts:578
+#: packages/slider-thumb/slider-thumb.ts:442
+#: packages/slider-thumb/slider-thumb.ts:722
 msgid "slider.label.from"
 msgstr ""
 
 #. Max as in short for Maximum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:500
-#: packages/slider-thumb/slider-thumb.ts:519
+#: packages/slider-thumb/slider-thumb.ts:626
+#: packages/slider-thumb/slider-thumb.ts:645
 msgid "slider.placeholder.to"
 msgstr ""
 
 #. Min as in short for Minimum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:496
-#: packages/slider-thumb/slider-thumb.ts:525
+#: packages/slider-thumb/slider-thumb.ts:622
+#: packages/slider-thumb/slider-thumb.ts:651
 msgid "slider.placeholder.from"
 msgstr ""
 
+#. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:225
+#: packages/slider/slider.ts:474
+msgid "select.label.optional"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: packages/slider-thumb/slider-thumb.ts:275
 msgid "slider.error.overlap"
 msgstr "Maksimumsverdien kan ikke være mindre enn minimumsverdien"
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:200
+#: packages/slider-thumb/slider-thumb.ts:246
 msgid "slider.error.required"
 msgstr "Dette feltet er påkrevd"
 
 #. Accessible label for the 'to value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:346
-#: packages/slider-thumb/slider-thumb.ts:585
+#: packages/slider-thumb/slider-thumb.ts:449
+#: packages/slider-thumb/slider-thumb.ts:729
 msgid "slider.label.to"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:186
+#: packages/slider-thumb/slider-thumb.ts:232
 msgid "slider.error.out_of_bounds"
 msgstr "Verdien må være mellom {min} og {max}"

--- a/packages/slider/locales/nb/messages.po
+++ b/packages/slider/locales/nb/messages.po
@@ -38,7 +38,7 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/slider/slider.ts:474
 msgid "select.label.optional"
-msgstr ""
+msgstr "Valgfri"
 
 #. js-lingui-explicit-id
 #: packages/slider-thumb/slider-thumb.ts:275

--- a/packages/slider/locales/sv/messages.po
+++ b/packages/slider/locales/sv/messages.po
@@ -38,7 +38,7 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/slider/slider.ts:474
 msgid "select.label.optional"
-msgstr ""
+msgstr "Valfritt"
 
 #. js-lingui-explicit-id
 #: packages/slider-thumb/slider-thumb.ts:275

--- a/packages/slider/locales/sv/messages.po
+++ b/packages/slider/locales/sv/messages.po
@@ -15,43 +15,49 @@ msgstr ""
 
 #. Accessible label for the 'from value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:340
-#: packages/slider-thumb/slider-thumb.ts:578
+#: packages/slider-thumb/slider-thumb.ts:442
+#: packages/slider-thumb/slider-thumb.ts:722
 msgid "slider.label.from"
 msgstr ""
 
 #. Max as in short for Maximum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:500
-#: packages/slider-thumb/slider-thumb.ts:519
+#: packages/slider-thumb/slider-thumb.ts:626
+#: packages/slider-thumb/slider-thumb.ts:645
 msgid "slider.placeholder.to"
 msgstr ""
 
 #. Min as in short for Minimum
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:496
-#: packages/slider-thumb/slider-thumb.ts:525
+#: packages/slider-thumb/slider-thumb.ts:622
+#: packages/slider-thumb/slider-thumb.ts:651
 msgid "slider.placeholder.from"
 msgstr ""
 
+#. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:225
+#: packages/slider/slider.ts:474
+msgid "select.label.optional"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: packages/slider-thumb/slider-thumb.ts:275
 msgid "slider.error.overlap"
 msgstr "Maxvärdet kan inte vara mindre än minimivärdet"
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:200
+#: packages/slider-thumb/slider-thumb.ts:246
 msgid "slider.error.required"
 msgstr "Detta fält är obligatoriskt"
 
 #. Accessible label for the 'to value' input field in a range slider
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:346
-#: packages/slider-thumb/slider-thumb.ts:585
+#: packages/slider-thumb/slider-thumb.ts:449
+#: packages/slider-thumb/slider-thumb.ts:729
 msgid "slider.label.to"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: packages/slider-thumb/slider-thumb.ts:186
+#: packages/slider-thumb/slider-thumb.ts:232
 msgid "slider.error.out_of_bounds"
 msgstr "Värdet måste vara mellan {min} och {max}"

--- a/packages/slider/slider.stories.ts
+++ b/packages/slider/slider.stories.ts
@@ -54,11 +54,49 @@ export const SingleDisabled: Story = {
 	},
 };
 
+export const SingleOptional: Story = {
+	render() {
+		return html`
+			<form>
+				<w-slider label="Single" min="0" max="100" optional>
+					<w-slider-thumb name="value"></w-slider-thumb>
+				</w-slider>
+				<input type="submit" hidden />
+			</form>
+		`;
+	},
+};
+
 export const Range: Story = {
 	render() {
 		return html`
 			<form>
 				<w-slider label="Range" min="0" max="100">
+					<w-slider-thumb
+						slot="from"
+						aria-label="From value"
+						name="from"
+					></w-slider-thumb>
+					<w-slider-thumb
+						slot="to"
+						aria-label="To value"
+						name="to"
+					></w-slider-thumb>
+				</w-slider>
+				<div class="py-8">
+					<w-button type="reset">Reset</w-button>
+					<w-button type="submit">Submit</w-button>
+				</div>
+			</form>
+		`;
+	},
+};
+
+export const RangeOptional: Story = {
+	render() {
+		return html`
+			<form>
+				<w-slider label="Range" min="0" max="100" optional>
 					<w-slider-thumb
 						slot="from"
 						aria-label="From value"

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -12,9 +12,11 @@ import "./slider.js";
 import type { WarpSliderThumb } from "../slider-thumb/slider-thumb.js";
 import "../slider-thumb/slider-thumb.js";
 import { messages } from "./locales/en/messages.mjs";
+import { messages as nbMessages } from "./locales/nb/messages.mjs";
 
 // Initialize i18n with English locale for tests
 i18n.load("en", messages);
+i18n.load("nb", nbMessages);
 i18n.activate("en");
 
 test("single slider starts with a default value equal to max", async () => {
@@ -833,9 +835,93 @@ test("includes optional indicator in the slider legend", async () => {
 
 	const slider = document.querySelector("w-slider") as WarpSlider;
 	await slider.updateComplete;
+	await new Promise((resolve) => setTimeout(resolve, 0)); // Wait for the next microtask to ensure the legend is rendered
+
+	const legend = slider.shadowRoot!.querySelector("legend");
+	expect(legend).not.toBeNull();
+	console.log("Legend text content:", legend!.textContent);
+	expect(legend!.textContent).toContain("Price");
+	expect(legend!.textContent).toContain("Optional");
+});
+
+test("removes optional indicator when required is added dynamically", async () => {
+	const page = render(html`
+		<w-slider label="Price" min="0" max="100" optional data-testid="slider">
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	const slider = document.querySelector("w-slider") as WarpSlider & {
+		required: boolean;
+	};
+	slider.required = true;
+	await slider.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("shows optional indicator when required is removed dynamically", async () => {
+	const page = render(html`
+		<w-slider label="Price" min="0" max="100" required optional data-testid="slider">
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	expect(page.getByText("Optional").query()).toBeNull();
+
+	const slider = document.querySelector("w-slider") as WarpSlider & {
+		required: boolean;
+	};
+	slider.required = false;
+	await slider.updateComplete;
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+});
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(html`
+		<w-slider aria-label="Price" min="0" max="100" optional>
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	const slider = document.querySelector("w-slider") as WarpSlider;
+	await slider.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("excludes optional indicator from legend when required suppresses it", async () => {
+	render(html`
+		<w-slider label="Price" min="0" max="100" required optional>
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	const slider = document.querySelector("w-slider") as WarpSlider;
+	await slider.updateComplete;
 
 	const legend = slider.shadowRoot!.querySelector("legend");
 	expect(legend).not.toBeNull();
 	expect(legend!.textContent).toContain("Price");
-	expect(legend!.textContent).toContain("Optional");
+	expect(legend!.textContent).not.toContain("Optional");
+});
+
+test("renders localized optional text based on active locale", async () => {
+	const originalLang = document.documentElement.lang;
+	document.documentElement.lang = "nb";
+
+	const page = render(html`
+		<w-slider label="Price" min="0" max="100" optional>
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	const slider = document.querySelector("w-slider") as WarpSlider;
+	await slider.updateComplete;
+	await expect.element(page.getByText("Valgfri")).toBeVisible();
+
+	document.documentElement.lang = originalLang;
 });

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -864,7 +864,14 @@ test("removes optional indicator when required is added dynamically", async () =
 
 test("shows optional indicator when required is removed dynamically", async () => {
 	const page = render(html`
-		<w-slider label="Price" min="0" max="100" required optional data-testid="slider">
+		<w-slider
+			label="Price"
+			min="0"
+			max="100"
+			required
+			optional
+			data-testid="slider"
+		>
 			<w-slider-thumb name="price"></w-slider-thumb>
 		</w-slider>
 	`);

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import { userEvent } from "vitest/browser";
 import { html } from "lit";
 import { expect, test } from "vitest";
@@ -10,6 +11,11 @@ import type { WarpSlider } from "./slider.js";
 import "./slider.js";
 import type { WarpSliderThumb } from "../slider-thumb/slider-thumb.js";
 import "../slider-thumb/slider-thumb.js";
+import { messages } from "./locales/en/messages.mjs";
+
+// Initialize i18n with English locale for tests
+i18n.load("en", messages);
+i18n.activate("en");
 
 test("single slider starts with a default value equal to max", async () => {
 	const component = html`
@@ -794,4 +800,42 @@ test("aria-description is not set as host attribute (to avoid hydration mismatch
 	// But the properties should be set
 	expect(fromThumb.ariaDescription).toBeTruthy();
 	expect(toThumb.ariaDescription).toBeTruthy();
+});
+
+test("renders optional indicator as 'Optional' without parentheses", async () => {
+	const page = render(html`
+		<w-slider label="Price" min="0" max="100" optional>
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
+});
+
+test("does not render optional indicator when both required and optional are set", async () => {
+	const page = render(html`
+		<w-slider label="Price" min="0" max="100" required optional>
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	await expect.element(page.getByText("Price")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("includes optional indicator in the slider legend", async () => {
+	render(html`
+		<w-slider label="Price" min="0" max="100" optional>
+			<w-slider-thumb name="price"></w-slider-thumb>
+		</w-slider>
+	`);
+
+	const slider = document.querySelector("w-slider") as WarpSlider;
+	await slider.updateComplete;
+
+	const legend = slider.shadowRoot!.querySelector("legend");
+	expect(legend).not.toBeNull();
+	expect(legend!.textContent).toContain("Price");
+	expect(legend!.textContent).toContain("Optional");
 });

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -35,25 +35,38 @@ class WarpSlider extends LitElement {
 		delegatesFocus: true,
 	};
 
-	static styles = [reset, wSliderStyles, css`
-		:host {
-			/* Added style API for optional only just to mirror other optional implementations */
-			/* The rest of the styling API still needs to be implemented */
-			--_padding-left: var(--w-c-slider-optional-padding-left, 0.8rem);
-			--_font-weight: var(--w-c-slider-optional-font-weight, 400);
-			--_font-size: var(--w-c-slider-optional-font-size, var(--w-font-size-s));
-			--_line-height: var(--w-c-slider-optional-line-height, var(--w-line-height-s));
-			--_color: var(--w-c-slider-optional-color, var(--w-s-color-text-subtle));
-		}
-		
-		.w-slider__optional {
-			padding-left: var(--_padding-left);
-			font-weight: var(--_font-weight);
-			font-size: var(--_font-size);
-			line-height: var(--_line-height);
-			color: var(--_color);
-		}
-	`];
+	static styles = [
+		reset,
+		wSliderStyles,
+		css`
+			:host {
+				/* Added style API for optional only just to mirror other optional implementations */
+				/* The rest of the styling API still needs to be implemented */
+				--_padding-left: var(--w-c-slider-optional-padding-left, 0.8rem);
+				--_font-weight: var(--w-c-slider-optional-font-weight, 400);
+				--_font-size: var(
+					--w-c-slider-optional-font-size,
+					var(--w-font-size-s)
+				);
+				--_line-height: var(
+					--w-c-slider-optional-line-height,
+					var(--w-line-height-s)
+				);
+				--_color: var(
+					--w-c-slider-optional-color,
+					var(--w-s-color-text-subtle)
+				);
+			}
+
+			.w-slider__optional {
+				padding-left: var(--_padding-left);
+				font-weight: var(--_font-weight);
+				font-size: var(--_font-size);
+				line-height: var(--_line-height);
+				color: var(--_color);
+			}
+		`,
+	];
 
 	/**
 	 * The slider fieldset label. Required for proper accessibility.
@@ -488,17 +501,32 @@ class WarpSlider extends LitElement {
 	}
 
 	get _label() {
-		const optional = this._hasLabel && this.optional && !this.required ? html`<span class="w-slider__optional">${i18n._({
-			id: "select.label.optional",
-			message: "Optional",
-			comment: "Shown behind label when marked as optional",
-		})}</span>` : nothing;
+		const optional =
+			this._hasLabel && this.optional && !this.required
+				? html`<span class="w-slider__optional"
+						>${i18n._({
+							id: "select.label.optional",
+							message: "Optional",
+							comment: "Shown behind label when marked as optional",
+						})}</span
+					>`
+				: nothing;
 
 		return this.label
 			? html`<legend class="w-slider__label">
-					<slot id="label" name="label" @slotchange=${this._handleLabelSlotChange}>${this.label}</slot>${optional}
+					<slot
+						id="label"
+						name="label"
+						@slotchange=${this._handleLabelSlotChange}
+						>${this.label}</slot
+					>${optional}
 				</legend>`
-			: html`<slot id="label" name="label" @slotchange=${this._handleLabelSlotChange}></slot>${optional}`;
+			: html`<slot
+						id="label"
+						name="label"
+						@slotchange=${this._handleLabelSlotChange}
+					></slot
+					>${optional}`;
 	}
 
 	render() {

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -180,6 +180,10 @@ class WarpSlider extends LitElement {
 	@state()
 	_tabbableElements: Array<HTMLElement> = [];
 
+	/** @internal */
+	@state()
+	_hasLabel = false;
+
 	constructor() {
 		super();
 		activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
@@ -267,6 +271,9 @@ class WarpSlider extends LitElement {
 		}
 		if (this.openEnded) {
 			this.fieldset.style.setProperty("--over-under-offset", "1");
+		}
+		if (this.label) {
+			this._hasLabel = true;
 		}
 
 		const sliderThumbs =
@@ -470,8 +477,18 @@ class WarpSlider extends LitElement {
 		return this.error || this._invalidMessage;
 	}
 
+	private _handleLabelSlotChange(e: Event) {
+		const slot = e.target as HTMLSlotElement;
+
+		// assignedElements() ignores empty text/whitespaces, making it highly reliable
+		const slotContent = slot.assignedElements().length > 0;
+
+		this._hasLabel = slotContent || !!this.label;
+		console.log("Label content changed, has label:", this._hasLabel);
+	}
+
 	get _label() {
-		const optional = this.optional && !this.required ? html`<span class="w-slider__optional">${i18n._({
+		const optional = this._hasLabel && this.optional && !this.required ? html`<span class="w-slider__optional">${i18n._({
 			id: "select.label.optional",
 			message: "Optional",
 			comment: "Shown behind label when marked as optional",
@@ -479,9 +496,9 @@ class WarpSlider extends LitElement {
 
 		return this.label
 			? html`<legend class="w-slider__label">
-					<slot id="label" name="label">${this.label}</slot>${optional}
+					<slot id="label" name="label" @slotchange=${this._handleLabelSlotChange}>${this.label}</slot>${optional}
 				</legend>`
-			: html`<slot id="label" name="label"></slot>${optional}`;
+			: html`<slot id="label" name="label" @slotchange=${this._handleLabelSlotChange}></slot>${optional}`;
 	}
 
 	render() {

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -1,5 +1,6 @@
-import { html, LitElement, nothing, PropertyValues } from "lit";
+import { css, html, LitElement, nothing, PropertyValues } from "lit";
 import { property, query, state } from "lit/decorators.js";
+import { i18n } from "@lingui/core";
 import { activateI18n } from "../i18n.js";
 import type {
 	SliderSlot,
@@ -34,7 +35,25 @@ class WarpSlider extends LitElement {
 		delegatesFocus: true,
 	};
 
-	static styles = [reset, wSliderStyles];
+	static styles = [reset, wSliderStyles, css`
+		:host {
+			/* Added style API for optional only just to mirror other optional implementations */
+			/* The rest of the styling API still needs to be implemented */
+			--_padding-left: var(--w-c-slider-optional-padding-left, 0.8rem);
+			--_font-weight: var(--w-c-slider-optional-font-weight, 400);
+			--_font-size: var(--w-c-slider-optional-font-size, var(--w-font-size-s));
+			--_line-height: var(--w-c-slider-optional-line-height, var(--w-line-height-s));
+			--_color: var(--w-c-slider-optional-color, var(--w-s-color-text-subtle));
+		}
+		
+		.w-slider__optional {
+			padding-left: var(--_padding-left);
+			font-weight: var(--_font-weight);
+			font-size: var(--_font-size);
+			line-height: var(--_line-height);
+			color: var(--_color);
+		}
+	`];
 
 	/**
 	 * The slider fieldset label. Required for proper accessibility.
@@ -76,6 +95,12 @@ class WarpSlider extends LitElement {
 	 */
 	@property({ type: Boolean, reflect: true })
 	required = false;
+
+	/**
+	 * Whether to show the optional indicator after the label.
+	 */
+	@property({ type: Boolean, reflect: true })
+	optional = false;
 
 	/**
 	 * The minimum allowed value in the range inputs
@@ -445,6 +470,20 @@ class WarpSlider extends LitElement {
 		return this.error || this._invalidMessage;
 	}
 
+	get _label() {
+		const optional = this.optional && !this.required ? html`<span class="w-slider__optional">${i18n._({
+			id: "select.label.optional",
+			message: "Optional",
+			comment: "Shown behind label when marked as optional",
+		})}</span>` : nothing;
+
+		return this.label
+			? html`<legend class="w-slider__label">
+					<slot id="label" name="label">${this.label}</slot>${optional}
+				</legend>`
+			: html`<slot id="label" name="label"></slot>${optional}`;
+	}
+
 	render() {
 		return html`
 			<fieldset
@@ -458,11 +497,7 @@ class WarpSlider extends LitElement {
 				aria-invalid="${this.errorText ? "true" : nothing}"
 				?disabled="${this.disabled}"
 			>
-				${this.label
-					? html`<legend class="w-slider__label">
-							<slot id="label" name="label">${this.label}</slot>
-						</legend>`
-					: html`<slot id="label" name="label"></slot>`}
+				${this._label}
 				<slot class="w-slider__description" name="description"></slot>
 				${this.markers ? html`<div class="w-slider__markers"></div>` : nothing}
 				<div class="w-slider__range">

--- a/packages/snackbar/locales/da/messages.po
+++ b/packages/snackbar/locales/da/messages.po
@@ -6,9 +6,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: da\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Accessibility label for the button that closes the snackbar/toast popup
 #. js-lingui-explicit-id
-#: packages/snackbar-item/snackbar-item.ts:62
+#: packages/snackbar/snackbar.ts:319
 msgid "snackbar.aria.close"
 msgstr ""

--- a/packages/snackbar/locales/en/messages.po
+++ b/packages/snackbar/locales/en/messages.po
@@ -6,9 +6,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Accessibility label for the button that closes the snackbar/toast popup
 #. js-lingui-explicit-id
-#: packages/snackbar-item/snackbar-item.ts:62
+#: packages/snackbar/snackbar.ts:319
 msgid "snackbar.aria.close"
 msgstr "Dismiss message"

--- a/packages/snackbar/locales/fi/messages.po
+++ b/packages/snackbar/locales/fi/messages.po
@@ -6,9 +6,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: fi\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Accessibility label for the button that closes the snackbar/toast popup
 #. js-lingui-explicit-id
-#: packages/snackbar-item/snackbar-item.ts:62
+#: packages/snackbar/snackbar.ts:319
 msgid "snackbar.aria.close"
 msgstr ""

--- a/packages/snackbar/locales/nb/messages.po
+++ b/packages/snackbar/locales/nb/messages.po
@@ -6,9 +6,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: nb\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Accessibility label for the button that closes the snackbar/toast popup
 #. js-lingui-explicit-id
-#: packages/snackbar-item/snackbar-item.ts:62
+#: packages/snackbar/snackbar.ts:319
 msgid "snackbar.aria.close"
 msgstr ""

--- a/packages/snackbar/locales/sv/messages.po
+++ b/packages/snackbar/locales/sv/messages.po
@@ -6,9 +6,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: sv\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. Accessibility label for the button that closes the snackbar/toast popup
 #. js-lingui-explicit-id
-#: packages/snackbar-item/snackbar-item.ts:62
+#: packages/snackbar/snackbar.ts:319
 msgid "snackbar.aria.close"
 msgstr ""

--- a/packages/step/locales/da/messages.po
+++ b/packages/step/locales/da/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:100
+#: packages/step/step.ts:118
 msgid "steps.aria.emptyCircle"
 msgstr "Tom cirkel"
 
 #. Active circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:94
+#: packages/step/step.ts:112
 msgid "steps.aria.active"
 msgstr "Trinindikator aktiv cirkel"
 
 #. Completed circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:87
+#: packages/step/step.ts:105
 msgid "steps.aria.completed"
 msgstr "Trinindikator fuldført cirkel"

--- a/packages/step/locales/en/messages.po
+++ b/packages/step/locales/en/messages.po
@@ -16,18 +16,18 @@ msgstr ""
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:100
+#: packages/step/step.ts:118
 msgid "steps.aria.emptyCircle"
 msgstr "Empty circle"
 
 #. Active circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:94
+#: packages/step/step.ts:112
 msgid "steps.aria.active"
 msgstr "Step indicator active circle"
 
 #. Completed circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:87
+#: packages/step/step.ts:105
 msgid "steps.aria.completed"
 msgstr "Step indicator completed circle"

--- a/packages/step/locales/fi/messages.po
+++ b/packages/step/locales/fi/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:100
+#: packages/step/step.ts:118
 msgid "steps.aria.emptyCircle"
 msgstr "Tyhjä ympyrä"
 
 #. Active circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:94
+#: packages/step/step.ts:112
 msgid "steps.aria.active"
 msgstr "Vaiheilmaisin aktiivinen ympyrä"
 
 #. Completed circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:87
+#: packages/step/step.ts:105
 msgid "steps.aria.completed"
 msgstr "Vaiheilmaisin valmis ympyrä"

--- a/packages/step/locales/nb/messages.po
+++ b/packages/step/locales/nb/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:100
+#: packages/step/step.ts:118
 msgid "steps.aria.emptyCircle"
 msgstr "Tom sirkel"
 
 #. Active circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:94
+#: packages/step/step.ts:112
 msgid "steps.aria.active"
 msgstr "Stegindikator aktiv sirkel"
 
 #. Completed circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:87
+#: packages/step/step.ts:105
 msgid "steps.aria.completed"
 msgstr "Stegindikator hel sirkel"

--- a/packages/step/locales/sv/messages.po
+++ b/packages/step/locales/sv/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Empty circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:100
+#: packages/step/step.ts:118
 msgid "steps.aria.emptyCircle"
 msgstr "Tom cirkel"
 
 #. Active circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:94
+#: packages/step/step.ts:112
 msgid "steps.aria.active"
 msgstr "Stegindikator aktiv cirkel"
 
 #. Completed circle
 #. js-lingui-explicit-id
-#: packages/step/step.ts:87
+#: packages/step/step.ts:105
 msgid "steps.aria.completed"
 msgstr "Stegindikator fulländad cirkel"

--- a/packages/textarea/locales/da/messages.po
+++ b/packages/textarea/locales/da/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
-msgstr "(valgfrit)"
+msgstr "Valgfri"

--- a/packages/textarea/locales/da/messages.po
+++ b/packages/textarea/locales/da/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/textarea/textarea.ts:335
+#: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
 msgstr "(valgfrit)"

--- a/packages/textarea/locales/en/messages.po
+++ b/packages/textarea/locales/en/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/textarea/textarea.ts:335
+#: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
-msgstr "(optional)"
+msgstr "Optional"

--- a/packages/textarea/locales/fi/messages.po
+++ b/packages/textarea/locales/fi/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
-msgstr "(vapaaehtoinen)"
+msgstr "Valinnainen"

--- a/packages/textarea/locales/fi/messages.po
+++ b/packages/textarea/locales/fi/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/textarea/textarea.ts:335
+#: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
 msgstr "(vapaaehtoinen)"

--- a/packages/textarea/locales/nb/messages.po
+++ b/packages/textarea/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
-msgstr "(valgfritt)"
+msgstr "Valgfri"

--- a/packages/textarea/locales/nb/messages.po
+++ b/packages/textarea/locales/nb/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/textarea/textarea.ts:335
+#: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
 msgstr "(valgfritt)"

--- a/packages/textarea/locales/sv/messages.po
+++ b/packages/textarea/locales/sv/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
-msgstr "(valfritt)"
+msgstr "Valfritt"

--- a/packages/textarea/locales/sv/messages.po
+++ b/packages/textarea/locales/sv/messages.po
@@ -15,6 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
-#: packages/textarea/textarea.ts:335
+#: packages/textarea/textarea.ts:426
 msgid "textarea.label.optional"
 msgstr "(valfritt)"

--- a/packages/textarea/textarea.test.ts
+++ b/packages/textarea/textarea.test.ts
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import { userEvent } from "vitest/browser";
 import { html } from "lit";
 import { expect, test, vi } from "vitest";
@@ -5,6 +6,11 @@ import { render } from "vitest-browser-lit";
 
 import "./textarea.js";
 import { WarpTextarea } from "./textarea.js";
+import { messages } from "./locales/en/messages.mjs";
+
+// Initialize i18n with English locale for tests
+i18n.load("en", messages);
+i18n.activate("en");
 
 test("renders the textarea", async () => {
 	const component = html`<w-textarea label="Test label"></w-textarea>`;
@@ -285,4 +291,32 @@ test("restores original help text when validation passes", async () => {
 	await expect.poll(() => wTextArea.checkValidity()).toBe(true);
 	await expect.poll(() => wTextArea.invalid).toBe(false);
 	await expect.poll(() => wTextArea.helpText).toBe("Enter your message");
+});
+
+test("renders optional indicator as 'Optional' without parentheses", async () => {
+	const page = render(
+		html`<w-textarea label="Message" optional></w-textarea>`,
+	);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
+});
+
+test("does not render optional indicator when both required and optional are set", async () => {
+	const page = render(
+		html`<w-textarea label="Message" required optional></w-textarea>`,
+	);
+
+	await expect.element(page.getByText("Message")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("includes optional indicator in the accessible name", async () => {
+	const page = render(
+		html`<w-textarea label="Message" optional></w-textarea>`,
+	);
+
+	await expect
+		.element(page.getByRole("textbox", { name: /Message.*Optional/ }))
+		.toBeVisible();
 });

--- a/packages/textarea/textarea.test.ts
+++ b/packages/textarea/textarea.test.ts
@@ -296,9 +296,7 @@ test("restores original help text when validation passes", async () => {
 });
 
 test("renders optional indicator as 'Optional' without parentheses", async () => {
-	const page = render(
-		html`<w-textarea label="Message" optional></w-textarea>`,
-	);
+	const page = render(html`<w-textarea label="Message" optional></w-textarea>`);
 
 	await expect.element(page.getByText("Optional")).toBeVisible();
 	expect(page.getByText("(optional)").query()).toBeNull();
@@ -314,9 +312,7 @@ test("does not render optional indicator when both required and optional are set
 });
 
 test("includes optional indicator in the accessible name", async () => {
-	const page = render(
-		html`<w-textarea label="Message" optional></w-textarea>`,
-	);
+	const page = render(html`<w-textarea label="Message" optional></w-textarea>`);
 
 	await expect
 		.element(page.getByRole("textbox", { name: /Message.*Optional/ }))
@@ -325,7 +321,11 @@ test("includes optional indicator in the accessible name", async () => {
 
 test("removes optional indicator when required is added dynamically", async () => {
 	const page = render(
-		html`<w-textarea label="Message" optional data-testid="field"></w-textarea>`,
+		html`<w-textarea
+			label="Message"
+			optional
+			data-testid="field"
+		></w-textarea>`,
 	);
 
 	await expect.element(page.getByText("Optional")).toBeVisible();
@@ -388,7 +388,11 @@ test("renders localized optional text based on active locale", async () => {
 	document.documentElement.lang = "nb";
 
 	const page = render(
-		html`<w-textarea label="Message" optional data-testid="field"></w-textarea>`,
+		html`<w-textarea
+			label="Message"
+			optional
+			data-testid="field"
+		></w-textarea>`,
 	);
 
 	const el = page.getByTestId("field").element() as HTMLElement & {

--- a/packages/textarea/textarea.test.ts
+++ b/packages/textarea/textarea.test.ts
@@ -7,9 +7,11 @@ import { render } from "vitest-browser-lit";
 import "./textarea.js";
 import { WarpTextarea } from "./textarea.js";
 import { messages } from "./locales/en/messages.mjs";
+import { messages as nbMessages } from "./locales/nb/messages.mjs";
 
 // Initialize i18n with English locale for tests
 i18n.load("en", messages);
+i18n.load("nb", nbMessages);
 i18n.activate("en");
 
 test("renders the textarea", async () => {
@@ -319,4 +321,81 @@ test("includes optional indicator in the accessible name", async () => {
 	await expect
 		.element(page.getByRole("textbox", { name: /Message.*Optional/ }))
 		.toBeVisible();
+});
+
+test("removes optional indicator when required is added dynamically", async () => {
+	const page = render(
+		html`<w-textarea label="Message" optional data-testid="field"></w-textarea>`,
+	);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	el.required = true;
+	await el.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("shows optional indicator when required is removed dynamically", async () => {
+	const page = render(
+		html`<w-textarea
+			label="Message"
+			required
+			optional
+			data-testid="field"
+		></w-textarea>`,
+	);
+
+	expect(page.getByText("Optional").query()).toBeNull();
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	el.required = false;
+	await el.updateComplete;
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+});
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(
+		html`<w-textarea aria-label="Message" optional></w-textarea>`,
+	);
+
+	await expect.element(page.getByLabelText("Message")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("excludes optional indicator from accessible name when required suppresses it", async () => {
+	const page = render(
+		html`<w-textarea label="Message" required optional></w-textarea>`,
+	);
+
+	const textarea = page.getByRole("textbox", { name: "Message" });
+	await expect.element(textarea).toBeVisible();
+
+	// Verify "Optional" is not part of the accessible name
+	expect(page.getByRole("textbox", { name: /Optional/ }).query()).toBeNull();
+});
+
+test("renders localized optional text based on active locale", async () => {
+	const originalLang = document.documentElement.lang;
+	document.documentElement.lang = "nb";
+
+	const page = render(
+		html`<w-textarea label="Message" optional data-testid="field"></w-textarea>`,
+	);
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await el.updateComplete;
+	await expect.element(page.getByText("Valgfri")).toBeVisible();
+
+	document.documentElement.lang = originalLang;
 });

--- a/packages/textarea/textarea.ts
+++ b/packages/textarea/textarea.ts
@@ -420,12 +420,12 @@ class WarpTextarea extends FormControlMixin(LitElement) {
 				? html`
 						<label for="${this._id}">
 							${this.label}
-							${this.optional
+							${this.optional && !this.required
 								? html`
 										<span>
 											${i18n._({
 												id: "textarea.label.optional",
-												message: "(optional)",
+												message: "Optional",
 												comment: "Shown behind label when marked as optional",
 											})}
 										</span>

--- a/packages/textarea/textarea.ts
+++ b/packages/textarea/textarea.ts
@@ -10,6 +10,12 @@ import { reset } from "../styles.js";
 import { uniqueId } from "../utils.js";
 import { styles } from "./styles.js";
 import { inputLabelStyles, inputHelpTextStyles } from "./input-styles.js";
+import { activateI18n } from "../i18n.js";
+import { messages as daMessages } from "./locales/da/messages.mjs";
+import { messages as enMessages } from "./locales/en/messages.mjs";
+import { messages as fiMessages } from "./locales/fi/messages.mjs";
+import { messages as nbMessages } from "./locales/nb/messages.mjs";
+import { messages as svMessages } from "./locales/sv/messages.mjs";
 
 // NOTE: Label and help-text are rendered inline using shared input styles.
 // In a future major version, we could extract these into separate w-label and w-help-text components
@@ -167,6 +173,11 @@ class WarpTextarea extends FormControlMixin(LitElement) {
 
 	// Track whether the user has interacted with the field
 	#hasInteracted = false;
+
+	constructor() {
+		super();
+		activateI18n(enMessages, nbMessages, fiMessages, daMessages, svMessages);
+	}
 
 	updated(changedProperties: PropertyValues<this>) {
 		if (changedProperties.has("value") && typeof this.value !== "undefined") {

--- a/packages/textfield/locales/da/messages.po
+++ b/packages/textfield/locales/da/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
-msgstr "(valgfri)"
+msgstr "Valgfri"

--- a/packages/textfield/locales/da/messages.po
+++ b/packages/textfield/locales/da/messages.po
@@ -15,5 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
+#: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
 msgstr "(valgfri)"

--- a/packages/textfield/locales/en/messages.po
+++ b/packages/textfield/locales/en/messages.po
@@ -15,5 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
+#: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
 msgstr "Optional"

--- a/packages/textfield/locales/en/messages.po
+++ b/packages/textfield/locales/en/messages.po
@@ -16,4 +16,4 @@ msgstr ""
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
 msgid "textfield.label.optional"
-msgstr "(optional)"
+msgstr "Optional"

--- a/packages/textfield/locales/fi/messages.po
+++ b/packages/textfield/locales/fi/messages.po
@@ -15,5 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
+#: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
 msgstr "(valinnainen)"

--- a/packages/textfield/locales/fi/messages.po
+++ b/packages/textfield/locales/fi/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
-msgstr "(valinnainen)"
+msgstr "Valinnainen"

--- a/packages/textfield/locales/nb/messages.po
+++ b/packages/textfield/locales/nb/messages.po
@@ -15,5 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
+#: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
 msgstr "(valgfritt)"

--- a/packages/textfield/locales/nb/messages.po
+++ b/packages/textfield/locales/nb/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
-msgstr "(valgfritt)"
+msgstr "Valgfri"

--- a/packages/textfield/locales/sv/messages.po
+++ b/packages/textfield/locales/sv/messages.po
@@ -17,4 +17,4 @@ msgstr ""
 #. js-lingui-explicit-id
 #: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
-msgstr "(valfritt)"
+msgstr "Valfritt"

--- a/packages/textfield/locales/sv/messages.po
+++ b/packages/textfield/locales/sv/messages.po
@@ -15,5 +15,6 @@ msgstr ""
 
 #. Shown behind label when marked as optional
 #. js-lingui-explicit-id
+#: packages/textfield/textfield.ts:320
 msgid "textfield.label.optional"
 msgstr "(valfritt)"

--- a/packages/textfield/textfield.test.ts
+++ b/packages/textfield/textfield.test.ts
@@ -1,3 +1,4 @@
+import { i18n } from "@lingui/core";
 import { userEvent } from "vitest/browser";
 import { html } from "lit";
 import { expect, test, vi } from "vitest";
@@ -5,6 +6,11 @@ import { render } from "vitest-browser-lit";
 
 import "../affix/affix.js";
 import "./textfield.js";
+import { messages } from "./locales/en/messages.mjs";
+
+// Initialize i18n with English locale for tests
+i18n.load("en", messages);
+i18n.activate("en");
 
 test("renders the textfield", async () => {
 	const component = html`<w-textfield label="Test label"></w-textfield>`;
@@ -194,4 +200,13 @@ test("submits the associated form when input has focus and user presses Enter", 
 	await userEvent.keyboard("{Enter}");
 
 	expect(onSubmit).toHaveBeenCalled();
+});
+
+test("renders optional indicator as 'Optional' without parentheses", async () => {
+	const page = render(
+		html`<w-textfield label="Email" optional></w-textfield>`,
+	);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+	expect(page.getByText("(optional)").query()).toBeNull();
 });

--- a/packages/textfield/textfield.test.ts
+++ b/packages/textfield/textfield.test.ts
@@ -203,9 +203,7 @@ test("submits the associated form when input has focus and user presses Enter", 
 });
 
 test("renders optional indicator as 'Optional' without parentheses", async () => {
-	const page = render(
-		html`<w-textfield label="Email" optional></w-textfield>`,
-	);
+	const page = render(html`<w-textfield label="Email" optional></w-textfield>`);
 
 	await expect.element(page.getByText("Optional")).toBeVisible();
 	expect(page.getByText("(optional)").query()).toBeNull();
@@ -221,9 +219,7 @@ test("does not render optional indicator when both required and optional are set
 });
 
 test("includes optional indicator in the accessible name", async () => {
-	const page = render(
-		html`<w-textfield label="Email" optional></w-textfield>`,
-	);
+	const page = render(html`<w-textfield label="Email" optional></w-textfield>`);
 
 	await expect
 		.element(page.getByRole("textbox", { name: /Email.*Optional/ }))
@@ -232,7 +228,11 @@ test("includes optional indicator in the accessible name", async () => {
 
 test("removes optional indicator when required is added dynamically", async () => {
 	const page = render(
-		html`<w-textfield label="Email" optional data-testid="field"></w-textfield>`,
+		html`<w-textfield
+			label="Email"
+			optional
+			data-testid="field"
+		></w-textfield>`,
 	);
 
 	await expect.element(page.getByText("Optional")).toBeVisible();
@@ -295,7 +295,11 @@ test("renders localized optional text based on document lang", async () => {
 	document.documentElement.lang = "nb";
 
 	const page = render(
-		html`<w-textfield label="Email" optional data-testid="field"></w-textfield>`,
+		html`<w-textfield
+			label="Email"
+			optional
+			data-testid="field"
+		></w-textfield>`,
 	);
 
 	const el = page.getByTestId("field").element() as HTMLElement & {

--- a/packages/textfield/textfield.test.ts
+++ b/packages/textfield/textfield.test.ts
@@ -277,3 +277,32 @@ test("does not render optional indicator when there is no label", async () => {
 	await expect.element(page.getByLabelText("Email")).toBeVisible();
 	expect(page.getByText("Optional").query()).toBeNull();
 });
+
+test("excludes optional indicator from accessible name when required suppresses it", async () => {
+	const page = render(
+		html`<w-textfield label="Email" required optional></w-textfield>`,
+	);
+
+	const input = page.getByRole("textbox", { name: "Email" });
+	await expect.element(input).toBeVisible();
+
+	// Verify "Optional" is not part of the accessible name
+	expect(page.getByRole("textbox", { name: /Optional/ }).query()).toBeNull();
+});
+
+test("renders localized optional text based on document lang", async () => {
+	const originalLang = document.documentElement.lang;
+	document.documentElement.lang = "nb";
+
+	const page = render(
+		html`<w-textfield label="Email" optional data-testid="field"></w-textfield>`,
+	);
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		updateComplete: Promise<unknown>;
+	};
+	await el.updateComplete;
+	await expect.element(page.getByText("Valgfri")).toBeVisible();
+
+	document.documentElement.lang = originalLang;
+});

--- a/packages/textfield/textfield.test.ts
+++ b/packages/textfield/textfield.test.ts
@@ -210,3 +210,70 @@ test("renders optional indicator as 'Optional' without parentheses", async () =>
 	await expect.element(page.getByText("Optional")).toBeVisible();
 	expect(page.getByText("(optional)").query()).toBeNull();
 });
+
+test("does not render optional indicator when both required and optional are set", async () => {
+	const page = render(
+		html`<w-textfield label="Email" required optional></w-textfield>`,
+	);
+
+	await expect.element(page.getByText("Email")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("includes optional indicator in the accessible name", async () => {
+	const page = render(
+		html`<w-textfield label="Email" optional></w-textfield>`,
+	);
+
+	await expect
+		.element(page.getByRole("textbox", { name: /Email.*Optional/ }))
+		.toBeVisible();
+});
+
+test("removes optional indicator when required is added dynamically", async () => {
+	const page = render(
+		html`<w-textfield label="Email" optional data-testid="field"></w-textfield>`,
+	);
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	el.required = true;
+	await el.updateComplete;
+
+	expect(page.getByText("Optional").query()).toBeNull();
+});
+
+test("shows optional indicator when required is removed dynamically", async () => {
+	const page = render(
+		html`<w-textfield
+			label="Email"
+			required
+			optional
+			data-testid="field"
+		></w-textfield>`,
+	);
+
+	expect(page.getByText("Optional").query()).toBeNull();
+
+	const el = page.getByTestId("field").element() as HTMLElement & {
+		required: boolean;
+		updateComplete: Promise<unknown>;
+	};
+	el.required = false;
+	await el.updateComplete;
+
+	await expect.element(page.getByText("Optional")).toBeVisible();
+});
+
+test("does not render optional indicator when there is no label", async () => {
+	const page = render(
+		html`<w-textfield aria-label="Email" optional></w-textfield>`,
+	);
+
+	await expect.element(page.getByLabelText("Email")).toBeVisible();
+	expect(page.getByText("Optional").query()).toBeNull();
+});

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -315,7 +315,7 @@ class WarpTextField extends FormControlMixin(LitElement) {
 	get _label() {
 		if (this.label) {
 			return html`<label for="${this._id}"
-				>${this.label}${this.optional
+				>${this.label}${this.label.length && this.optional && !this.required
 					? html` <span>
 							${i18n._({
 								id: "textfield.label.optional",

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -319,7 +319,7 @@ class WarpTextField extends FormControlMixin(LitElement) {
 					? html` <span>
 							${i18n._({
 								id: "textfield.label.optional",
-								message: "(optional)",
+								message: "Optional",
 								comment: "Shown behind label when marked as optional",
 							})}
 						</span>`

--- a/packages/toast/locales/da/messages.po
+++ b/packages/toast/locales/da/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:150
+#: packages/toast/toast.ts:154
 msgid "toast.aria.error"
 msgstr "Fejl"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:156
+#: packages/toast/toast.ts:160
 msgid "toast.aria.successful"
 msgstr "Fuldført"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:143
+#: packages/toast/toast.ts:147
 msgid "toast.aria.warning"
 msgstr "Advarsel"

--- a/packages/toast/locales/en/messages.po
+++ b/packages/toast/locales/en/messages.po
@@ -16,18 +16,18 @@ msgstr ""
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:150
+#: packages/toast/toast.ts:154
 msgid "toast.aria.error"
 msgstr "Error"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:156
+#: packages/toast/toast.ts:160
 msgid "toast.aria.successful"
 msgstr "Successful"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:143
+#: packages/toast/toast.ts:147
 msgid "toast.aria.warning"
 msgstr "Warning"

--- a/packages/toast/locales/fi/messages.po
+++ b/packages/toast/locales/fi/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:150
+#: packages/toast/toast.ts:154
 msgid "toast.aria.error"
 msgstr "Virhe"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:156
+#: packages/toast/toast.ts:160
 msgid "toast.aria.successful"
 msgstr "Onnistui"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:143
+#: packages/toast/toast.ts:147
 msgid "toast.aria.warning"
 msgstr "Varoitus"

--- a/packages/toast/locales/nb/messages.po
+++ b/packages/toast/locales/nb/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:150
+#: packages/toast/toast.ts:154
 msgid "toast.aria.error"
 msgstr "Feil"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:156
+#: packages/toast/toast.ts:160
 msgid "toast.aria.successful"
 msgstr "Vellykket"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:143
+#: packages/toast/toast.ts:147
 msgid "toast.aria.warning"
 msgstr "Advarsel"

--- a/packages/toast/locales/sv/messages.po
+++ b/packages/toast/locales/sv/messages.po
@@ -19,18 +19,18 @@ msgstr ""
 
 #. Default screenreader message for error in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:150
+#: packages/toast/toast.ts:154
 msgid "toast.aria.error"
 msgstr "Fel"
 
 #. Default screenreader message for successful in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:156
+#: packages/toast/toast.ts:160
 msgid "toast.aria.successful"
 msgstr "Genomfört"
 
 #. Default screenreader message for warning in toast component
 #. js-lingui-explicit-id
-#: packages/toast/toast.ts:143
+#: packages/toast/toast.ts:147
 msgid "toast.aria.warning"
 msgstr "Varning"

--- a/specs/align-optional-usage.md
+++ b/specs/align-optional-usage.md
@@ -134,15 +134,15 @@ When both `required` and `optional` are set:
 
 4. Given any supported component with `required optional`, when rendered, then the optional indicator is not visible.
 
-5. Given any supported component with `required optional`, when submitted empty or invalid according to its existing required behavior, then the component behaves as required.
+5. Given any supported component with `required optional`, when submitted empty or invalid according to its existing required behavior, then the component behaves as required. Note. `w-select` does not have a `required` attribute.
 
 6. Given any supported component initially rendered with `optional`, when `required` is added dynamically, then the optional indicator is removed.
 
-7. Given any supported component initially rendered with `required optional`, when `required` is removed dynamically, then the optional indicator is shown.
+7. Given any supported component initially rendered with `required optional`, when `required` is removed dynamically, then the optional indicator is shown. Note. `w-select` does not have a `required` attribute.
 
 8. Given any supported component with `optional`, when queried by accessible label/name, then the accessible label/name includes both the label text and the optional indicator.
 
-9. Given any supported component with `required optional`, when queried by accessible label/name, then the accessible label/name does not include the optional indicator.
+9. Given any supported component with `required optional`, when queried by accessible label/name, then the accessible label/name does not include the optional indicator. Note. `w-select` does not have a `required` attribute.
 
 10. Given `w-slider label="Price" optional`, when rendered in English, then the slider legend includes `Price Optional`.
 
@@ -169,6 +169,7 @@ When both `required` and `optional` are set:
 - `w-slider` with a label attribute.
 - `w-slider` with a slotted label.
 - `w-slider` with single-thumb and range-thumb configurations.
+- Note. `w-select` does not have a `required` attribute.
 
 ## Test Notes
 

--- a/specs/align-optional-usage.md
+++ b/specs/align-optional-usage.md
@@ -1,0 +1,181 @@
+# Feature: Align Optional Usage
+
+## Problem
+
+Form components do not present optional field text consistently.
+
+Some components render the optional indicator with parentheses, such as `(optional)`, while others render it as `Optional`. Some form components with labels and required-state support do not expose the same optional indicator pattern in their public API or examples.
+
+This creates inconsistent visual language, inconsistent localized strings, and inconsistent developer expectations across form components.
+
+## Goal
+
+Align optional field usage across supported form components so that:
+
+- the visible optional indicator uses the same format;
+- localized optional text is handled consistently;
+- optional fields are announced consistently by assistive technologies;
+- `required` and `optional` states do not conflict visually;
+- documentation and examples show the same usage pattern across components.
+
+## Scope
+
+This change applies to:
+
+- `w-textfield`
+- `w-textarea`
+- `w-select`
+- `w-combobox`
+- `w-slider`
+- `w-radio-group`
+- `w-checkbox-group`
+
+## Non-Goals
+
+- Do not change native form validation behavior.
+- Do not change the meaning of the `required` attribute.
+- Do not add optional indicators to standalone `w-checkbox`, `w-radio`, or `w-switch` in this change.
+- Do not introduce a configurable optional indicator string in this change.
+- Do not require parentheses around translated optional text.
+- Do not remove existing optional styling tokens or parts.
+
+## Definitions
+
+- **Optional indicator**: localized text displayed after a form control label when the control or group is explicitly marked as optional.
+- **Canonical English optional text**: `Optional`.
+- **Supported component**: one of the components listed in Scope.
+
+## User Behavior
+
+When a supported component has a visible label and `optional` is set:
+
+- the label includes an optional indicator immediately after the label text;
+- the English indicator text is `Optional`;
+- the indicator is visually separated from the label text;
+- the indicator is included in the accessible label or accessible name;
+- the component remains optional for form validation unless `required` is also set.
+
+Example:
+
+```html
+<w-textfield label="Email" optional></w-textfield>
+```
+
+The rendered label should communicate:
+
+```text
+Email Optional
+```
+
+When both `required` and `optional` are set:
+
+- `required` wins;
+- the optional indicator is not rendered;
+- the component keeps required validation behavior;
+- an implementation may emit a development warning, but warning behavior is not required for this change.
+
+## Requirements
+
+### Optional Text Format
+
+- The English optional indicator must be `Optional`.
+- The English optional indicator must not be rendered as `(optional)`.
+- Localized optional strings must be translated as plain localized text without a product requirement to add parentheses.
+- Existing translations that already use plain localized text, such as `Valgfritt`, are valid.
+- Optional text must be provided through the existing localization system for each supported component.
+
+### Component API
+
+- Each supported component must expose an `optional` boolean attribute/property.
+- `w-slider` must add support for the `optional` boolean attribute/property.
+- Existing supported components that already expose `optional` must preserve that public API.
+- `optional` must reflect to an attribute where the component already follows that pattern for boolean form state.
+- `optional` must not make the component required, invalid, or exempt from required validation.
+
+### Rendering
+
+- A supported component with `optional` and a visible label must render the optional indicator after the label text.
+- The optional indicator must not appear before the label text.
+- The optional indicator must not replace the label text.
+- The optional indicator must not render when there is no visible label.
+- The optional indicator must not render when `required` is set.
+- The optional indicator must update when `optional` or `required` changes after initial render.
+- Components with slotted label content must support the optional indicator when a visible label is present.
+
+### Accessibility
+
+- The optional indicator must be part of the accessible label or accessible name for the control or group.
+- A screen reader should be able to announce both the label text and the optional indicator.
+- The optional indicator must not create a separate focus target.
+- Hiding the optional indicator because `required` is set must remove it from both the visual label and the accessible label/name.
+- Existing label associations, `aria-describedby` relationships, help text, and validation error behavior must remain unchanged.
+
+### Required Precedence
+
+- If `required` and `optional` are both present, the component must behave as required.
+- If `required` and `optional` are both present, the optional indicator must not be rendered.
+- If `required` is removed while `optional` remains present, the optional indicator must render again.
+
+### Documentation
+
+- Documentation examples for each supported component must use `Optional`, not `(optional)`, as the English visible text.
+- `w-textfield` documentation must include an optional example.
+- `w-slider` documentation must include an optional example after the component supports the `optional` API.
+- Existing optional examples for `w-textarea`, `w-select`, `w-radio-group`, `w-checkbox-group`, and `w-combobox` must be updated or added so the pattern is visible.
+- Documentation must state that `required` takes precedence over `optional`.
+
+## Acceptance Criteria
+
+1. Given any supported component with `label="Email"` and `optional`, when rendered in English, then the visible label includes `Email Optional`.
+
+2. Given any supported component with `optional`, when rendered in English, then the optional indicator text is exactly `Optional` and does not include parentheses.
+
+3. Given any supported component with `optional`, when rendered in a non-English locale, then the optional indicator uses that component's localized optional message without adding product-mandated parentheses.
+
+4. Given any supported component with `required optional`, when rendered, then the optional indicator is not visible.
+
+5. Given any supported component with `required optional`, when submitted empty or invalid according to its existing required behavior, then the component behaves as required.
+
+6. Given any supported component initially rendered with `optional`, when `required` is added dynamically, then the optional indicator is removed.
+
+7. Given any supported component initially rendered with `required optional`, when `required` is removed dynamically, then the optional indicator is shown.
+
+8. Given any supported component with `optional`, when queried by accessible label/name, then the accessible label/name includes both the label text and the optional indicator.
+
+9. Given any supported component with `required optional`, when queried by accessible label/name, then the accessible label/name does not include the optional indicator.
+
+10. Given `w-slider label="Price" optional`, when rendered in English, then the slider legend includes `Price Optional`.
+
+11. Given `w-slider required optional`, when rendered, then the slider does not show the optional indicator and retains existing required behavior for its thumbs.
+
+12. Given `w-textfield`, when reviewing docs/examples, then there is an example showing the `optional` attribute.
+
+13. Given existing optional examples in supported component docs/stories, when updated, then they use `Optional` as the English visible text and do not describe the indicator as `(optional)`.
+
+14. Given existing optional styling APIs, when this change is implemented, then existing optional indicator styling tokens and parts continue to apply to the optional indicator.
+
+15. Given a supported component without a visible label but with `aria-label` and `optional`, when rendered, then no visible optional indicator is rendered.
+
+## Edge Cases
+
+- `optional` with no `label`.
+- `optional` with an empty `label`.
+- `optional` with slotted label content.
+- `optional` and `required` both present at first render.
+- `optional` and `required` toggled after first render.
+- Locale changes after first render.
+- Components with help text and validation error text.
+- Disabled or readonly optional fields.
+- `w-slider` with a label attribute.
+- `w-slider` with a slotted label.
+- `w-slider` with single-thumb and range-thumb configurations.
+
+## Test Notes
+
+- Unit tests should cover visible optional text for every supported component.
+- Unit tests should assert that English optional text is `Optional`, not `(optional)`.
+- Unit tests should cover `required optional` precedence for every supported component.
+- Accessibility tests should verify that the optional indicator is included in the accessible label/name when rendered.
+- Accessibility tests should verify that the optional indicator is not included when `required` suppresses it.
+- Dynamic update tests should cover toggling `optional`, toggling `required`, and locale changes.
+- Documentation checks should cover the presence of an optional example for `w-textfield` and `w-slider`.

--- a/specs/align-optional-usage.md
+++ b/specs/align-optional-usage.md
@@ -81,7 +81,7 @@ When both `required` and `optional` are set:
 - The English optional indicator must be `Optional`.
 - The English optional indicator must not be rendered as `(optional)`.
 - Localized optional strings must be translated as plain localized text without a product requirement to add parentheses.
-- Existing translations that already use plain localized text, such as `Valgfritt`, are valid.
+- Existing translations that already use plain localized text, such as `Valgfri`, are valid.
 - Optional text must be provided through the existing localization system for each supported component.
 
 ### Component API


### PR DESCRIPTION
I took a round to fix the inconsistencies in the use of the "Optional" text in form components.