### PR TITLE
feat(modal): add --w-c-modal-padding-bottom, ModalContent React wrapper

### DIFF
--- a/packages/modal-footer/react.ts
+++ b/packages/modal-footer/react.ts
@@ -7,13 +7,30 @@ import type { WarpModalFooter } from "./modal-footer.js";
 // decouple from CDN by providing a dummy class
 class Component extends LitElement {}
 
+const BaseModalFooter = createComponent({
+	tagName: "w-modal-footer",
+	elementClass: Component as unknown as typeof WarpModalFooter,
+	react: React,
+});
+
+type BaseModalFooterProps = React.ComponentPropsWithoutRef<
+	typeof BaseModalFooter
+>;
+
+type ModalFooterProps = BaseModalFooterProps;
+
 /**
  * The footer section of a modal, typically where you place actions.
  *
  * [Warp component reference](https://warp-ds.github.io/docs/components/modal/frameworks/elements)
  */
-export const ModalFooter = createComponent({
-	tagName: "w-modal-footer",
-	elementClass: Component as unknown as typeof WarpModalFooter,
-	react: React,
-});
+export const ModalFooter = React.forwardRef<WarpModalFooter, ModalFooterProps>(
+	({ ...props }, ref) =>
+		React.createElement(BaseModalFooter, {
+			slot: "footer",
+			...props,
+			ref,
+		} as React.ComponentProps<typeof BaseModalFooter>),
+);
+
+ModalFooter.displayName = "ModalFooter";

--- a/packages/modal-header/react.ts
+++ b/packages/modal-header/react.ts
@@ -33,6 +33,7 @@ type ModalHeaderProps = Omit<BaseModalHeaderProps, "no-close"> & {
 export const ModalHeader = React.forwardRef<WarpModalHeader, ModalHeaderProps>(
 	({ noClose, ...props }, ref) =>
 		React.createElement(BaseModalHeader, {
+			slot: "header",
 			...props,
 			...(noClose ? { "no-close": true } : {}),
 			ref,

--- a/packages/modal/docs/styling.md
+++ b/packages/modal/docs/styling.md
@@ -41,6 +41,7 @@ w-modal {
 - `--w-c-modal-height`
 - `--w-c-modal-max-height`
 - `--w-c-modal-min-height`
+- `--w-c-modal-padding-bottom`
 - `--w-c-modal-translate-distance`
 - `--w-c-modal-width`
 

--- a/packages/modal/modal.ts
+++ b/packages/modal/modal.ts
@@ -30,6 +30,7 @@ import { ProvidesCanCloseToSlotsMixin } from "./util.js";
  * @cssprop --w-c-modal-max-height
  * @cssprop --w-c-modal-min-height
  * @cssprop --w-c-modal-translate-distance
+ * @cssprop --w-c-modal-padding-bottom
  * @cssprop --w-c-modal-width
  */
 export class WarpModal extends ProvidesCanCloseToSlotsMixin(LitElement) {

--- a/packages/modal/react.ts
+++ b/packages/modal/react.ts
@@ -50,11 +50,11 @@ type ModalProps = Omit<
  *     </Button>
  *     <Modal show={open} id="example-modal-one" onHidden={() => setOpen(false)} onShown={() => setOpen(true)}>
  *       <ModalHeader slot="header" title="An example modal" />
- *       <div slot="content">
+ *       <ModalContent>
  *         <p>
  *           <!-- modal content -->
  *         </p>
- *       </div>
+ *       </ModalContent>
  *       <ModalFooter slot="footer">
  *         <Button variant="primary" id="modal-close-button-one" onClick={() => setOpen(false)}>
  *           OK
@@ -79,3 +79,10 @@ export const Modal = React.forwardRef<WarpModal, ModalProps>(
 );
 
 Modal.displayName = "Modal";
+
+/**
+ * Convenience component to get a root element in the content slot of the modal.
+ */
+export const ModalContent = ({ ...props }) => {
+	return React.createElement("div", { slot: "content", ...props });
+};

--- a/packages/modal/react.ts
+++ b/packages/modal/react.ts
@@ -49,13 +49,13 @@ type ModalProps = Omit<
  *       Open modal
  *     </Button>
  *     <Modal show={open} id="example-modal-one" onHidden={() => setOpen(false)} onShown={() => setOpen(true)}>
- *       <ModalHeader slot="header" title="An example modal" />
+ *       <ModalHeader title="An example modal" />
  *       <ModalContent>
  *         <p>
  *           <!-- modal content -->
  *         </p>
  *       </ModalContent>
- *       <ModalFooter slot="footer">
+ *       <ModalFooter>
  *         <Button variant="primary" id="modal-close-button-one" onClick={() => setOpen(false)}>
  *           OK
  *         </Button>

--- a/packages/modal/styles.ts
+++ b/packages/modal/styles.ts
@@ -23,6 +23,10 @@ export const styles = css`
 			var(--w-modal-min-heigh)
 				/* --w-modal-min-height kept for backwards compat */
 		);
+		--_padding-bottom: var(
+			--w-c-modal-padding-bottom,
+			calc(32px + env(safe-area-inset-bottom, 0px))
+		);
 		--_translate-distance: var(
 			--w-c-modal-translate-distance,
 			var(--w-modal-translate-distance, 100%)
@@ -68,7 +72,7 @@ export const styles = css`
 		min-height: var(--_min-height);
 		width: var(--_width);
 		backface-visibility: hidden;
-		padding-bottom: calc(32px + env(safe-area-inset-bottom, 0px));
+		padding-bottom: var(--_padding-bottom);
 		transition-property: all;
 		transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 		transition-duration: 150ms;


### PR DESCRIPTION
- Apply the default slot value in the Modal React wrapper components
- Add a `ModalContent` for convenience
- Add `--w-c-modal-padding-bottom` so users can get a scroll that goes to the screen edge on mobile when there's no footer (favorites modal, the "footer" is a pagination component that scrolls into view).

For WARP-1397