### PR TITLE
fix(modal-header): constrain close button column width to prevent title overflow

### DIFF
--- a/packages/modal-header/styles.ts
+++ b/packages/modal-header/styles.ts
@@ -35,7 +35,7 @@ export const styles = css`
 	[part="header"][show-close]:not([show-back]) {
 		grid-template:
 			"top top top"
-			"title title close";
+			"title title close" / 1fr 1fr 44px;
 	}
 
 	[part="header"][show-back][show-close] {


### PR DESCRIPTION
Fixes #742 - long modal header titles no longer overflow behind the close button.

## Summary

Added CSS Grid column sizing (`/ 1fr 1fr 44px`) to the modal header layout, constraining the close button to a fixed 44px column so the title truncates correctly instead of overlapping it.

## Screenshots

### Before
<img width="731" height="169" alt="Screenshot 2026-07-30 at 14 29 03" src="https://github.com/user-attachments/assets/53e7f18a-4c31-491a-af8a-1a8070c26fb3" />

### After
<img width="709" height="154" alt="Screenshot 2026-07-30 at 14 28 32" src="https://github.com/user-attachments/assets/bc352ef2-39a9-46b2-888c-23857a2d6b20" />
