### PR TITLE
fix(button): apply custom focus outline styles instead of browser default

### DIFF
--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -263,7 +263,7 @@ export const wButtonStyles = css`
 		color: var(--_color-active);
 	}
 
-	:host(:focus-visible) button[part="base"] {
+	:host button[part="base"]:focus-visible {
 		outline: var(--_outline-width) solid var(--_outline-color);
 		outline-offset: var(--_outline-offset);
 	}


### PR DESCRIPTION
## Summary

- Moves `:focus-visible` from `:host(:focus-visible) button[part="base"]` to `button[part="base"]:focus-visible`
- When placed on `:host`, `:focus-visible` does not propagate into shadow DOM - the browser ignored the custom `--_outline-width`, `--_outline-color`, and `--_outline-offset` variables and fell back to its default focus outline instead
- The fix ensures the design system's focus outline styles are applied correctly on keyboard navigation

## Screenshots

### Before
<img width="150" height="83" alt="Screenshot 2026-07-30 at 14 27 46" src="https://github.com/user-attachments/assets/b010ed15-6973-4bd2-94c0-7f7880f39273" /><img width="202" height="70" alt="Screenshot 2026-07-30 at 14 27 50" src="https://github.com/user-attachments/assets/c51de169-dd1c-4012-909b-e223bc91db45" />

### After
<img width="176" height="96" alt="Screenshot 2026-07-30 at 14 27 30" src="https://github.com/user-attachments/assets/5ca2d383-c762-4363-8a13-e932020a13d5" />
<img width="182" height="70" alt="Screenshot 2026-07-30 at 14 27 36" src="https://github.com/user-attachments/assets/c20d8c09-ca5d-4708-8f96-3ac2e0350b44" />
