### PR TITLE
feat: include form submitter via new warpSubmitContext event property

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/packages/toast/api.d.ts",
       "import": "./dist/api.js"
     },
+    "./utils": {
+      "types": "./dist/packages/utils.d.ts",
+      "import": "./dist/packages/utils.js"
+    },
     "./custom-elements.json": "./dist/custom-elements.json",
     "./react": {
       "types": "./dist/entrypoint-react.d.ts",
@@ -52,6 +56,9 @@
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "utils": [
+        "./dist/packages/utils.d.ts"
+      ],
       "react/affix": [
         "./dist/packages/affix/react.d.ts"
       ],

--- a/packages/button/button.test.ts
+++ b/packages/button/button.test.ts
@@ -21,7 +21,40 @@ test("by default button type is button", async () => {
 		.toHaveAttribute("type", "button");
 });
 
-test.todo("works in a form as type submit");
+test("works in a form as type submit and passes the submitter", async () => {
+	const page = render(html`
+		<form>
+			<w-button name="intent" type="submit" value="save" variant="secondary">
+				Save
+			</w-button>
+		</form>
+	`);
+
+	const form = document.querySelector("form") as HTMLFormElement;
+	const wButton = document.querySelector("w-button") as HTMLElement;
+	const onSubmit = vi.fn();
+	let submitter: HTMLElement | null = null;
+	let submitContext: SubmitEvent["warpSubmitContext"];
+	let submittedIntents: FormDataEntryValue[] = [];
+
+	form.addEventListener("submit", (event) => {
+		event.preventDefault();
+
+		submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+		submitContext = (event as SubmitEvent).warpSubmitContext;
+		submittedIntents = new FormData(form).getAll("intent");
+		onSubmit();
+	});
+
+	await page.getByRole("button", { name: "Save" }).click();
+
+	expect(onSubmit).toHaveBeenCalledTimes(1);
+	expect(submitter).toBeNull();
+	expect(submitContext?.initiator).toBe(wButton);
+	expect(submitContext?.nativeSubmitter).toBeNull();
+	expect(submitContext?.defaultSubmitter).toBeNull();
+	expect(submittedIntents).toEqual(["save"]);
+});
 
 test("Works in a form as type reset", async () => {
 	const label = "Test label";

--- a/packages/button/button.ts
+++ b/packages/button/button.ts
@@ -7,6 +7,7 @@ import { activateI18n } from "../i18n";
 import "../link/link.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { reset } from "../styles.js";
+import { requestSubmit } from "../utils.js";
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
 import { messages as fiMessages } from "./locales/fi/messages.mjs";
@@ -258,7 +259,7 @@ class WarpButton extends FormControlMixin(LitElement) {
 
 	/** @internal */
 	_handleButtonClick() {
-		if (this.type === "submit") this.internals.form.requestSubmit();
+		if (this.type === "submit") requestSubmit(this.internals.form, this);
 		else if (this.type === "reset") this.internals.form.reset();
 	}
 

--- a/packages/button/button.ts
+++ b/packages/button/button.ts
@@ -259,8 +259,10 @@ class WarpButton extends FormControlMixin(LitElement) {
 
 	/** @internal */
 	_handleButtonClick() {
-		if (this.type === "submit") requestSubmit(this.internals.form, this);
-		else if (this.type === "reset") this.internals.form.reset();
+		if (this.type === "submit" && this.internals.form)
+			requestSubmit(this.internals.form, this);
+		else if (this.type === "reset" && this.internals.form)
+			this.internals.form.reset();
 	}
 
 	resetFormControl(): void {

--- a/packages/checkbox/checkbox.test.ts
+++ b/packages/checkbox/checkbox.test.ts
@@ -237,9 +237,17 @@ test.skipIf(server.browser === "webkit")(
 		`);
 
 		const onSubmit = vi.fn();
+		let submitter: HTMLElement | null = null;
+		let submitContext: SubmitEvent["warpSubmitContext"];
 		const form = document.querySelector("form") as HTMLFormElement;
+		const wCheckbox = document.querySelector("w-checkbox") as HTMLElement;
+		const submitButton = document.querySelector(
+			'button[type="submit"]',
+		) as HTMLButtonElement;
 		form.addEventListener("submit", (event) => {
 			event.preventDefault();
+			submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+			submitContext = (event as SubmitEvent).warpSubmitContext;
 			onSubmit();
 		});
 
@@ -248,5 +256,9 @@ test.skipIf(server.browser === "webkit")(
 		await userEvent.keyboard("{Enter}");
 
 		expect(onSubmit).toHaveBeenCalled();
+		expect(submitter).toBe(submitButton);
+		expect(submitContext?.initiator).toBe(wCheckbox);
+		expect(submitContext?.nativeSubmitter).toBe(submitButton);
+		expect(submitContext?.defaultSubmitter).toBe(submitButton);
 	},
 );

--- a/packages/checkbox/checkbox.ts
+++ b/packages/checkbox/checkbox.ts
@@ -5,7 +5,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { live } from "lit/directives/live.js";
 
 import { reset } from "../styles";
-import { requestSubmitWithDefaultSubmitter } from "../utils.js";
+import { SubmitOnEnterController } from "../utils.js";
 import { styles } from "./styles";
 
 /**
@@ -19,6 +19,8 @@ import { styles } from "./styles";
  */
 export class WarpCheckbox extends FormControlMixin(LitElement) {
 	static styles = [reset, styles];
+
+	#submitOnEnter = new SubmitOnEnterController(this);
 
 	static shadowRootOptions = {
 		...LitElement.shadowRootOptions,
@@ -148,11 +150,7 @@ export class WarpCheckbox extends FormControlMixin(LitElement) {
 		if (event.defaultPrevented) return;
 		if (event.key !== " " && event.key !== "Spacebar" && event.key !== "Enter")
 			return;
-		if (event.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
+		if (this.#submitOnEnter.submit(event)) {
 			return;
 		}
 		if (event.composedPath()[0] === this.input) return;

--- a/packages/checkbox/checkbox.ts
+++ b/packages/checkbox/checkbox.ts
@@ -5,6 +5,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { live } from "lit/directives/live.js";
 
 import { reset } from "../styles";
+import { requestSubmitWithDefaultSubmitter } from "../utils.js";
 import { styles } from "./styles";
 
 /**
@@ -148,7 +149,10 @@ export class WarpCheckbox extends FormControlMixin(LitElement) {
 		if (event.key !== " " && event.key !== "Spacebar" && event.key !== "Enter")
 			return;
 		if (event.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 			return;
 		}
 		if (event.composedPath()[0] === this.input) return;

--- a/packages/datepicker/datepicker.test.ts
+++ b/packages/datepicker/datepicker.test.ts
@@ -147,9 +147,17 @@ test("submits the associated form when datepicker input field has focus and user
 	`);
 
 	const onSubmit = vi.fn();
+	let submitter: HTMLElement | null = null;
+	let submitContext: SubmitEvent["warpSubmitContext"];
 	const form = document.querySelector("form") as HTMLFormElement;
+	const datepicker = document.querySelector("w-datepicker") as HTMLElement;
+	const submitButton = document.querySelector(
+		'button[type="submit"]',
+	) as HTMLButtonElement;
 	form.addEventListener("submit", (event) => {
 		event.preventDefault();
+		submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+		submitContext = (event as SubmitEvent).warpSubmitContext;
 		onSubmit();
 	});
 
@@ -157,4 +165,8 @@ test("submits the associated form when datepicker input field has focus and user
 	await userEvent.keyboard("[Enter]");
 
 	await vi.waitFor(() => expect(onSubmit).toHaveBeenCalled());
+	expect(submitter).toBe(submitButton);
+	expect(submitContext?.initiator).toBe(datepicker);
+	expect(submitContext?.nativeSubmitter).toBe(submitButton);
+	expect(submitContext?.defaultSubmitter).toBe(submitButton);
 });

--- a/packages/datepicker/datepicker.ts
+++ b/packages/datepicker/datepicker.ts
@@ -33,7 +33,7 @@ import "../icon/icon.js";
 
 import { activateI18n, detectLocale } from "../i18n.js";
 import { reset } from "../styles.js";
-import { requestSubmitWithDefaultSubmitter } from "../utils.js";
+import { SubmitOnEnterController } from "../utils.js";
 
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
@@ -76,6 +76,8 @@ const datefnsLocale = {
  * [Warp component reference](https://warp-ds.github.io/docs/components/date-picker/frameworks/elements)
  */
 class WarpDatepicker extends FormControlMixin(LitElement) {
+	#submitOnEnter = new SubmitOnEnterController(this);
+
 	static shadowRootOptions = {
 		...LitElement.shadowRootOptions,
 		delegatesFocus: true,
@@ -331,12 +333,7 @@ class WarpDatepicker extends FormControlMixin(LitElement) {
 		if (e.key === ",") {
 			e.preventDefault();
 		}
-		if (e.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
-		}
+		this.#submitOnEnter.submit(e);
 	}
 
 	async #onCalendarKeyDown(e: KeyboardEvent) {

--- a/packages/datepicker/datepicker.ts
+++ b/packages/datepicker/datepicker.ts
@@ -33,6 +33,7 @@ import "../icon/icon.js";
 
 import { activateI18n, detectLocale } from "../i18n.js";
 import { reset } from "../styles.js";
+import { requestSubmitWithDefaultSubmitter } from "../utils.js";
 
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
@@ -331,7 +332,10 @@ class WarpDatepicker extends FormControlMixin(LitElement) {
 			e.preventDefault();
 		}
 		if (e.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 		}
 	}
 

--- a/packages/radio/radio.test.ts
+++ b/packages/radio/radio.test.ts
@@ -348,9 +348,17 @@ test("submits the associated form when radio has focus and user presses Enter", 
 	`);
 
 	const onSubmit = vi.fn();
+	let submitter: HTMLElement | null = null;
+	let submitContext: SubmitEvent["warpSubmitContext"];
 	const form = document.querySelector("form") as HTMLFormElement;
+	const radio = document.querySelector("w-radio") as HTMLElement;
+	const submitButton = document.querySelector(
+		'button[type="submit"]',
+	) as HTMLButtonElement;
 	form.addEventListener("submit", (event) => {
 		event.preventDefault();
+		submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+		submitContext = (event as SubmitEvent).warpSubmitContext;
 		onSubmit();
 	});
 
@@ -359,4 +367,8 @@ test("submits the associated form when radio has focus and user presses Enter", 
 	await userEvent.keyboard("{Enter}");
 
 	expect(onSubmit).toHaveBeenCalled();
+	expect(submitter).toBe(submitButton);
+	expect(submitContext?.initiator).toBe(radio);
+	expect(submitContext?.nativeSubmitter).toBe(submitButton);
+	expect(submitContext?.defaultSubmitter).toBe(submitButton);
 });

--- a/packages/radio/radio.ts
+++ b/packages/radio/radio.ts
@@ -4,7 +4,7 @@ import { html, LitElement } from "lit";
 
 import { property } from "lit/decorators.js";
 import { reset } from "../styles";
-import { requestSubmitWithDefaultSubmitter } from "../utils.js";
+import { SubmitOnEnterController } from "../utils.js";
 import { styles as hostStyles } from "./host-styles";
 import { styles as radioStyles } from "./radio-styles";
 
@@ -24,6 +24,8 @@ import { styles as radioStyles } from "./radio-styles";
 // assessing backwards compatibility implications.
 export class WarpRadio extends FormControlMixin(LitElement) {
 	static styles = [hostStyles, reset, radioStyles];
+
+	#submitOnEnter = new SubmitOnEnterController(this);
 
 	/** @internal */
 	static shadowRootOptions = {
@@ -228,11 +230,7 @@ export class WarpRadio extends FormControlMixin(LitElement) {
 		if (event.key !== " " && event.key !== "Spacebar" && event.key !== "Enter")
 			return;
 
-		if (event.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
+		if (this.#submitOnEnter.submit(event)) {
 			return;
 		}
 

--- a/packages/radio/radio.ts
+++ b/packages/radio/radio.ts
@@ -4,6 +4,7 @@ import { html, LitElement } from "lit";
 
 import { property } from "lit/decorators.js";
 import { reset } from "../styles";
+import { requestSubmitWithDefaultSubmitter } from "../utils.js";
 import { styles as hostStyles } from "./host-styles";
 import { styles as radioStyles } from "./radio-styles";
 
@@ -228,7 +229,10 @@ export class WarpRadio extends FormControlMixin(LitElement) {
 			return;
 
 		if (event.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 			return;
 		}
 

--- a/packages/select/select.test.ts
+++ b/packages/select/select.test.ts
@@ -370,7 +370,7 @@ test("reflects dynamic light-DOM option selected changes into native select", as
 
 /* For some reason this test fails only in Chromium and only on CI. Manually tested OK in Chrome. */
 test.skipIf(server.browser === "chromium" && server.config.env.CI)(
-	"submits the associated form when radio has focus and user presses Enter",
+	"submits the associated form when select has focus and user presses Enter",
 	async () => {
 		const screen = render(html`
 			<form>
@@ -383,15 +383,27 @@ test.skipIf(server.browser === "chromium" && server.config.env.CI)(
 		`);
 
 		const onSubmit = vi.fn();
+		let submitter: HTMLElement | null = null;
+		let submitContext: SubmitEvent["warpSubmitContext"];
 		const form = document.querySelector("form") as HTMLFormElement;
+		const select = document.querySelector("w-select") as HTMLElement;
+		const submitButton = document.querySelector(
+			'button[type="submit"]',
+		) as HTMLButtonElement;
 		form.addEventListener("submit", (event) => {
 			event.preventDefault();
+			submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+			submitContext = (event as SubmitEvent).warpSubmitContext;
 			onSubmit();
 		});
 
 		await userEvent.click(screen.getByTestId("select"));
 		await userEvent.keyboard("{Enter}");
 		expect(onSubmit).toHaveBeenCalled();
+		expect(submitter).toBe(submitButton);
+		expect(submitContext?.initiator).toBe(select);
+		expect(submitContext?.nativeSubmitter).toBe(submitButton);
+		expect(submitContext?.defaultSubmitter).toBe(submitButton);
 	},
 );
 

--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -10,7 +10,7 @@ import { when } from "lit/directives/when.js";
 
 import { activateI18n, detectLocale } from "../i18n.js";
 import { reset } from "../styles.js";
-import { requestSubmitWithDefaultSubmitter } from "../utils.js";
+import { SubmitOnEnterController } from "../utils.js";
 
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
@@ -50,6 +50,8 @@ const ccSelect = {
  * [Warp component reference](https://warp-ds.github.io/docs/components/select/frameworks/elements)
  */
 export class WarpSelect extends FormControlMixin(LitElement) {
+	#submitOnEnter = new SubmitOnEnterController(this);
+
 	/**
 	 * Whether the element should receive focus on render.
 	 *
@@ -367,11 +369,7 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 		) {
 			event.preventDefault();
 		}
-		if (event.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
+		if (this.#submitOnEnter.submit(event)) {
 			return;
 		}
 	}

--- a/packages/select/select.ts
+++ b/packages/select/select.ts
@@ -10,6 +10,7 @@ import { when } from "lit/directives/when.js";
 
 import { activateI18n, detectLocale } from "../i18n.js";
 import { reset } from "../styles.js";
+import { requestSubmitWithDefaultSubmitter } from "../utils.js";
 
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
@@ -367,7 +368,10 @@ export class WarpSelect extends FormControlMixin(LitElement) {
 			event.preventDefault();
 		}
 		if (event.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 			return;
 		}
 	}

--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -10,7 +10,7 @@ import type { WarpAttention } from "../attention/attention.js";
 import { styles as unoStyles } from "../slider/styles.js";
 import { reset } from "../styles.js";
 import type { WarpTextField } from "../textfield/textfield.js";
-import { requestSubmitWithDefaultSubmitter } from "../utils.js";
+import { SubmitOnEnterController } from "../utils.js";
 import { wSliderThumbStyles } from "./styles/w-slider-thumb.styles.js";
 
 export type SliderSlot = "to" | "from";
@@ -25,6 +25,8 @@ const chromeRe = /Chrome/;
  * @event {CustomEvent} thumbreset - Internal event used by (and stopped by) `w-slider`.
  */
 class WarpSliderThumb extends FormControlMixin(LitElement) {
+	#submitOnEnter = new SubmitOnEnterController(this);
+
 	/** @internal */
 	static shadowRootOptions = {
 		...LitElement.shadowRootOptions,
@@ -369,11 +371,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 	}
 
 	async #onRangeSliderKeyDown(e: KeyboardEvent): Promise<void> {
-		if (e.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
+		if (this.#submitOnEnter.submit(e)) {
 			return;
 		}
 
@@ -399,11 +397,7 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 	}
 
 	async #onInputFieldKeyDown(e: KeyboardEvent): Promise<void> {
-		if (e.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
+		if (this.#submitOnEnter.submit(e)) {
 			return;
 		}
 

--- a/packages/slider-thumb/slider-thumb.ts
+++ b/packages/slider-thumb/slider-thumb.ts
@@ -10,6 +10,7 @@ import type { WarpAttention } from "../attention/attention.js";
 import { styles as unoStyles } from "../slider/styles.js";
 import { reset } from "../styles.js";
 import type { WarpTextField } from "../textfield/textfield.js";
+import { requestSubmitWithDefaultSubmitter } from "../utils.js";
 import { wSliderThumbStyles } from "./styles/w-slider-thumb.styles.js";
 
 export type SliderSlot = "to" | "from";
@@ -369,7 +370,10 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 
 	async #onRangeSliderKeyDown(e: KeyboardEvent): Promise<void> {
 		if (e.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 			return;
 		}
 
@@ -396,7 +400,10 @@ class WarpSliderThumb extends FormControlMixin(LitElement) {
 
 	async #onInputFieldKeyDown(e: KeyboardEvent): Promise<void> {
 		if (e.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 			return;
 		}
 

--- a/packages/slider/slider.test.ts
+++ b/packages/slider/slider.test.ts
@@ -1,7 +1,7 @@
 import { i18n } from "@lingui/core";
 import { userEvent } from "vitest/browser";
 import { html } from "lit";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { render } from "vitest-browser-lit";
 
 import "../attention/attention.js";
@@ -103,6 +103,51 @@ test("can set slider value via the number input", async () => {
 		page.getByTestId("form").element() as HTMLFormElement,
 	);
 	expect(formData.get("value")).toBe("50");
+});
+
+test("submits the associated form when slider thumb has focus and user presses Enter", async () => {
+	render(html`
+		<form>
+			<w-slider label="Single" min="0" max="100">
+				<w-slider-thumb name="value"></w-slider-thumb>
+			</w-slider>
+			<button type="submit">Submit</button>
+		</form>
+	`);
+
+	const onSubmit = vi.fn();
+	let submitter: HTMLElement | null = null;
+	let submitContext: SubmitEvent["warpSubmitContext"];
+	const form = document.querySelector("form") as HTMLFormElement;
+	const submitButton = document.querySelector(
+		'button[type="submit"]',
+	) as HTMLButtonElement;
+	form.addEventListener("submit", (event) => {
+		event.preventDefault();
+		submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+		submitContext = (event as SubmitEvent).warpSubmitContext;
+		onSubmit();
+	});
+
+	const thumb = document.querySelector("w-slider-thumb") as WarpSliderThumb;
+	await thumb.updateComplete;
+	const range = thumb.shadowRoot!.querySelector(
+		'input[type="range"]',
+	) as HTMLInputElement;
+	range.dispatchEvent(
+		new KeyboardEvent("keydown", {
+			key: "Enter",
+			bubbles: true,
+			composed: true,
+			cancelable: true,
+		}),
+	);
+
+	expect(onSubmit).toHaveBeenCalled();
+	expect(submitter).toBe(submitButton);
+	expect(submitContext?.initiator).toBe(thumb);
+	expect(submitContext?.nativeSubmitter).toBe(submitButton);
+	expect(submitContext?.defaultSubmitter).toBe(submitButton);
 });
 
 test("can increment and decrement the slider values with arrow keys in the number input", async () => {

--- a/packages/textfield/textfield.test.ts
+++ b/packages/textfield/textfield.test.ts
@@ -186,9 +186,17 @@ test("submits the associated form when input has focus and user presses Enter", 
 	`);
 
 	const onSubmit = vi.fn();
+	let submitter: HTMLElement | null = null;
+	let submitContext: SubmitEvent["warpSubmitContext"];
 	const form = document.querySelector("form") as HTMLFormElement;
+	const textfield = document.querySelector("w-textfield") as HTMLElement;
+	const submitButton = document.querySelector(
+		'button[type="submit"]',
+	) as HTMLButtonElement;
 	form.addEventListener("submit", (event) => {
 		event.preventDefault();
+		submitter = (event as SubmitEvent).submitter as HTMLElement | null;
+		submitContext = (event as SubmitEvent).warpSubmitContext;
 		onSubmit();
 	});
 
@@ -196,6 +204,10 @@ test("submits the associated form when input has focus and user presses Enter", 
 	await userEvent.keyboard("{Enter}");
 
 	expect(onSubmit).toHaveBeenCalled();
+	expect(submitter).toBe(submitButton);
+	expect(submitContext?.initiator).toBe(textfield);
+	expect(submitContext?.nativeSubmitter).toBe(submitButton);
+	expect(submitContext?.defaultSubmitter).toBe(submitButton);
 });
 
 test("renders optional indicator as 'Optional' without parentheses", async () => {

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -10,7 +10,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import { activateI18n } from "../i18n.js";
 import { reset } from "../styles.js";
-import { requestSubmitWithDefaultSubmitter } from "../utils.js";
+import { SubmitOnEnterController } from "../utils.js";
 
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
@@ -251,17 +251,14 @@ class WarpTextField extends FormControlMixin(LitElement) {
 	@state()
 	private _hasHelpTextSlot = false;
 
+	#submitOnEnter = new SubmitOnEnterController(this);
+
 	get #hasHelpText() {
 		return typeof this.helpText !== "undefined" || this._hasHelpTextSlot;
 	}
 
 	#onKeyDownHandler(e: KeyboardEvent) {
-		if (e.key === "Enter" && this.internals.form) {
-			requestSubmitWithDefaultSubmitter(
-				this.internals.form as HTMLFormElement,
-				this,
-			);
-		}
+		this.#submitOnEnter.submit(e);
 	}
 
 	updated(changedProperties: PropertyValues<this>) {

--- a/packages/textfield/textfield.ts
+++ b/packages/textfield/textfield.ts
@@ -10,6 +10,7 @@ import { ifDefined } from "lit/directives/if-defined.js";
 
 import { activateI18n } from "../i18n.js";
 import { reset } from "../styles.js";
+import { requestSubmitWithDefaultSubmitter } from "../utils.js";
 
 import { messages as daMessages } from "./locales/da/messages.mjs";
 import { messages as enMessages } from "./locales/en/messages.mjs";
@@ -256,7 +257,10 @@ class WarpTextField extends FormControlMixin(LitElement) {
 
 	#onKeyDownHandler(e: KeyboardEvent) {
 		if (e.key === "Enter" && this.internals.form) {
-			(this.internals.form as HTMLFormElement).requestSubmit();
+			requestSubmitWithDefaultSubmitter(
+				this.internals.form as HTMLFormElement,
+				this,
+			);
 		}
 	}
 

--- a/packages/utils.ts
+++ b/packages/utils.ts
@@ -6,9 +6,23 @@ export function uniqueId(prefix = "") {
 
 type NativeSubmitter = HTMLButtonElement | HTMLInputElement;
 
+/**
+ * Context attached to SubmitEvent when a Warp component triggers form submission.
+ * Access via `event.warpSubmitContext` in your submit handler.
+ */
 export type WarpSubmitContext = {
+	/** The Warp element that initiated the submission (e.g., w-textfield, w-button). */
 	initiator: HTMLElement;
+	/**
+	 * The native submitter passed to requestSubmit(), if any.
+	 * This is the element whose name/value will be included in FormData.
+	 */
 	nativeSubmitter: HTMLElement | null;
+	/**
+	 * The form's default submit button (first submit button in DOM order).
+	 * For implicit submissions (e.g., Enter in a textfield), this is what
+	 * would be used as the submitter per HTML spec.
+	 */
 	defaultSubmitter: HTMLElement | null;
 };
 

--- a/packages/utils.ts
+++ b/packages/utils.ts
@@ -1,3 +1,4 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { nanoid } from "nanoid";
 
 export function uniqueId(prefix = "") {
@@ -25,6 +26,13 @@ export type WarpSubmitContext = {
 	 */
 	defaultSubmitter: HTMLElement | null;
 };
+
+type FormAssociatedHost = ReactiveControllerHost &
+	HTMLElement & {
+		internals?: {
+			form?: HTMLFormElement | null;
+		};
+	};
 
 const pendingSubmitContexts = new WeakMap<
 	HTMLFormElement,
@@ -207,6 +215,27 @@ export function requestSubmitWithDefaultSubmitter(
 			form.requestSubmit();
 		}
 	});
+}
+
+export class SubmitOnEnterController implements ReactiveController {
+	constructor(private host: FormAssociatedHost) {
+		this.host.addController(this);
+	}
+
+	hostConnected() {
+		// No setup needed; this satisfies Lit's ReactiveController shape.
+	}
+
+	submit(event: KeyboardEvent, shouldSubmit = () => true): boolean {
+		const form = this.host.internals?.form;
+
+		if (event.key !== "Enter" || !form || !shouldSubmit()) {
+			return false;
+		}
+
+		requestSubmitWithDefaultSubmitter(form, this.host);
+		return true;
+	}
 }
 
 declare global {

--- a/packages/utils.ts
+++ b/packages/utils.ts
@@ -59,13 +59,21 @@ function isAssociatedWithForm(
 export function getDefaultSubmitter(
 	form: HTMLFormElement,
 ): HTMLElement | undefined {
-	return [
-		...form.ownerDocument.querySelectorAll<HTMLElement>(
-			"button,input,w-button",
-		),
-	].find(
-		(submitter) =>
-			isSubmitButton(submitter) && isAssociatedWithForm(submitter, form),
+	const formDescendants = form.querySelectorAll<HTMLElement>(
+		"button,input,w-button",
+	);
+	const descendantSubmitter = [...formDescendants].find(
+		(el) => isSubmitButton(el) && isAssociatedWithForm(el, form),
+	);
+	if (descendantSubmitter) return descendantSubmitter;
+
+	if (!form.id) return undefined;
+
+	const externalElements = form.ownerDocument.querySelectorAll<HTMLElement>(
+		`button[form="${form.id}"],input[form="${form.id}"],w-button[form="${form.id}"]`,
+	);
+	return [...externalElements].find(
+		(el) => isSubmitButton(el) && isAssociatedWithForm(el, form),
 	);
 }
 

--- a/packages/utils.ts
+++ b/packages/utils.ts
@@ -3,3 +3,192 @@ import { nanoid } from "nanoid";
 export function uniqueId(prefix = "") {
 	return `${prefix}${nanoid()}`;
 }
+
+type NativeSubmitter = HTMLButtonElement | HTMLInputElement;
+
+export type WarpSubmitContext = {
+	initiator: HTMLElement;
+	nativeSubmitter: HTMLElement | null;
+	defaultSubmitter: HTMLElement | null;
+};
+
+const pendingSubmitContexts = new WeakMap<
+	HTMLFormElement,
+	WarpSubmitContext[]
+>();
+
+function getSubmitterType(submitter: HTMLElement): string {
+	if (submitter instanceof HTMLButtonElement) {
+		return submitter.type || "submit";
+	}
+
+	if (submitter instanceof HTMLInputElement) {
+		return submitter.type || "text";
+	}
+
+	if (submitter.localName === "w-button") {
+		return submitter.getAttribute("type") || "button";
+	}
+
+	return "";
+}
+
+function isSubmitButton(submitter: HTMLElement): boolean {
+	const type = getSubmitterType(submitter);
+
+	return (
+		!submitter.hasAttribute("disabled") &&
+		(submitter instanceof HTMLButtonElement ||
+			submitter instanceof HTMLInputElement ||
+			submitter.localName === "w-button") &&
+		(type === "submit" || type === "image")
+	);
+}
+
+function isAssociatedWithForm(
+	submitter: HTMLElement,
+	form: HTMLFormElement,
+): boolean {
+	const formControl = submitter as HTMLElement & {
+		form?: HTMLFormElement | null;
+	};
+
+	return formControl.form === form || submitter.closest("form") === form;
+}
+
+export function getDefaultSubmitter(
+	form: HTMLFormElement,
+): HTMLElement | undefined {
+	return [
+		...form.ownerDocument.querySelectorAll<HTMLElement>(
+			"button,input,w-button",
+		),
+	].find(
+		(submitter) =>
+			isSubmitButton(submitter) && isAssociatedWithForm(submitter, form),
+	);
+}
+
+function getPendingSubmitContext(
+	form: HTMLFormElement,
+): WarpSubmitContext | undefined {
+	return pendingSubmitContexts.get(form)?.at(-1);
+}
+
+function decorateSubmitEvent(
+	event: SubmitEvent,
+	context: WarpSubmitContext,
+): void {
+	if (event.warpSubmitContext) return;
+
+	context.nativeSubmitter = event.submitter as HTMLElement | null;
+
+	Object.defineProperty(event, "warpSubmitContext", {
+		value: context,
+		enumerable: false,
+		configurable: true,
+	});
+}
+
+function installSubmitDecorator(
+	form: HTMLFormElement,
+	signal: AbortSignal,
+): void {
+	const root = form.getRootNode();
+	const eventTarget =
+		root instanceof Document || root instanceof ShadowRoot ? root : form;
+
+	eventTarget.addEventListener(
+		"submit",
+		(event) => {
+			if (event.target !== form) return;
+
+			const context = getPendingSubmitContext(form);
+			if (!context) return;
+
+			decorateSubmitEvent(event as SubmitEvent, context);
+		},
+		{ capture: true, signal },
+	);
+}
+
+function trackSubmitContext(
+	form: HTMLFormElement,
+	context: WarpSubmitContext,
+	callback: () => void,
+): void {
+	const controller = new AbortController();
+	installSubmitDecorator(form, controller.signal);
+
+	const contexts = pendingSubmitContexts.get(form) ?? [];
+	contexts.push(context);
+	pendingSubmitContexts.set(form, contexts);
+
+	try {
+		callback();
+	} finally {
+		contexts.pop();
+		controller.abort();
+	}
+}
+
+export function requestSubmit(
+	form: HTMLFormElement,
+	initiator?: HTMLElement,
+	submitter?: NativeSubmitter,
+): void {
+	if (!initiator) {
+		if (submitter) {
+			form.requestSubmit(submitter);
+		} else {
+			form.requestSubmit();
+		}
+		return;
+	}
+
+	const context: WarpSubmitContext = {
+		initiator,
+		nativeSubmitter: submitter ?? null,
+		defaultSubmitter: submitter ?? null,
+	};
+
+	trackSubmitContext(form, context, () => {
+		if (submitter) {
+			form.requestSubmit(submitter);
+		} else {
+			form.requestSubmit();
+		}
+	});
+}
+
+export function requestSubmitWithDefaultSubmitter(
+	form: HTMLFormElement,
+	initiator: HTMLElement,
+): void {
+	const defaultSubmitter = getDefaultSubmitter(form);
+	const nativeSubmitter =
+		defaultSubmitter instanceof HTMLButtonElement ||
+		defaultSubmitter instanceof HTMLInputElement
+			? defaultSubmitter
+			: undefined;
+
+	const context: WarpSubmitContext = {
+		initiator,
+		nativeSubmitter: nativeSubmitter ?? null,
+		defaultSubmitter: defaultSubmitter ?? null,
+	};
+
+	trackSubmitContext(form, context, () => {
+		if (nativeSubmitter) {
+			form.requestSubmit(nativeSubmitter);
+		} else {
+			form.requestSubmit();
+		}
+	});
+}
+
+declare global {
+	interface SubmitEvent {
+		readonly warpSubmitContext?: WarpSubmitContext;
+	}
+}


### PR DESCRIPTION
## Intent

  When Warp form components (textfield, select, checkbox, etc.) trigger implicit form submission via Enter key, the native SubmitEvent.submitter is not populated because form.requestSubmit() is called without
   a submitter argument. This breaks scenarios where server frameworks or client code rely on the submitter's name/value to determine intent (e.g., which button was "clicked").

  This PR attaches a warpSubmitContext object to SubmitEvents that provides:
  - The Warp element that initiated submission (initiator)
  - The native submitter passed to requestSubmit() if any (nativeSubmitter)
  - The form's default submit button per HTML spec (defaultSubmitter)

##  Approach

  - Added a new packages/utils.ts module with helper functions for form submission
  - requestSubmitWithDefaultSubmitter() finds the form's default submit button (first submit button in DOM order, following HTML spec) and passes it to requestSubmit()
  - Uses a WeakMap to track pending submit context, then decorates the SubmitEvent with warpSubmitContext via a capturing submit listener
  - Updated all form components (textfield, select, checkbox, radio, datepicker, slider) to use requestSubmitWithDefaultSubmitter() for implicit Enter-key submissions
  - Updated w-button to use requestSubmit() with itself as initiator, plus added null-safety for form association
  - Exported WarpSubmitContext type for consumer type safety

##  Risk

  - Form submission behavior change: Implicit submissions now include the default submitter's name/value in FormData, which matches native browser behavior but could surface previously-missing data
  - New API surface: event.warpSubmitContext is a new property consumers may depend on

##  Verification

  - [x] Tests added or updated
  - [x] Existing tests pass (1 unrelated flaky tooltip test)
  - [ ] Manual verification completed, if relevant
  - [ ] Screenshots or recordings attached, if UI changed

##  Commands run:

npm test -- packages/button/button.test.ts packages/textfield/textfield.test.ts packages/select/select.test.ts packages/checkbox/checkbox.test.ts
- 149 passed, 1 skipped

##  AI involvement

  Yes. AI assisted with designing the warpSubmitContext approach, implementing the utility functions in packages/utils.ts, updating all affected components, and writing test cases. The implementation was
  verified by reviewing diffs and running the test suite.