### PR TITLE
feat(badge): provide styling api

### DIFF
--- a/packages/badge/badge.stories.ts
+++ b/packages/badge/badge.stories.ts
@@ -84,3 +84,48 @@ export const Positioned: Story = {
 		`;
 	},
 };
+
+export const StylingApi: Story = {
+	args: {
+		variant: "info",
+	},
+	render(args) {
+		return html`
+			<pre>
+<code>
+&lt;style&gt;
+w-badge {
+	--w-c-badge-bg: rebeccapurple;
+	--w-c-badge-color: white;
+	--w-c-badge-border-radius: 9999px;
+	--w-c-badge-padding-x: 1.2rem;
+	--w-c-badge-padding-y: 0.6rem;
+}
+
+w-badge::part(base) {
+	border: 2px solid cyan;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+&lt;/style&gt;
+</code>
+			</pre>
+			<style>
+				w-badge {
+					--w-c-badge-bg: rebeccapurple;
+					--w-c-badge-color: white;
+					--w-c-badge-border-radius: 9999px;
+					--w-c-badge-padding-x: 1.2rem;
+					--w-c-badge-padding-y: 0.6rem;
+				}
+
+				w-badge::part(base) {
+					border: 2px solid cyan;
+					text-transform: uppercase;
+					letter-spacing: 0.08em;
+				}
+			</style>
+			<w-badge ${spread(prespread(args))}>Styled badge</w-badge>
+		`;
+	},
+};

--- a/packages/badge/badge.test.ts
+++ b/packages/badge/badge.test.ts
@@ -30,3 +30,70 @@ test("defaults to neutral variant when no variant attribute is set", async () =>
 		})
 		.toBe(true);
 });
+
+test("supports styling through component tokens", async () => {
+	const component = html`
+		<w-badge
+			data-testid="badge"
+			style="--w-c-badge-bg: rgb(1, 2, 3); --w-c-badge-color: rgb(4, 5, 6); --w-c-badge-border-radius: 13px;"
+		>
+			Styled badge
+		</w-badge>
+	`;
+
+	const page = render(component);
+	const el = page.getByTestId("badge").element() as HTMLElement;
+
+	await expect
+		.poll(() => {
+			const base = el.shadowRoot?.querySelector('[part="base"]') as
+				| HTMLElement
+				| null;
+			if (!base) return null;
+
+			const style = getComputedStyle(base);
+			return {
+				backgroundColor: style.backgroundColor,
+				color: style.color,
+				borderRadius: style.borderRadius,
+			};
+		})
+		.toEqual({
+			backgroundColor: "rgb(1, 2, 3)",
+			color: "rgb(4, 5, 6)",
+			borderRadius: "13px",
+		});
+});
+
+test("supports styling through the base part", async () => {
+	const component = html`
+		<style>
+			w-badge::part(base) {
+				background-color: rgb(7, 8, 9);
+				border-radius: 17px;
+			}
+		</style>
+		<w-badge data-testid="badge">Part styled badge</w-badge>
+	`;
+
+	const page = render(component);
+	const el = page.getByTestId("badge").element() as HTMLElement;
+
+	await expect
+		.poll(() => {
+			const base = el.shadowRoot?.querySelector('[part="base"]') as
+				| HTMLElement
+				| null;
+			if (!base) return null;
+
+			const style = getComputedStyle(base);
+			return {
+				backgroundColor: style.backgroundColor,
+				borderRadius: style.borderRadius,
+			};
+		})
+		.toEqual({
+			backgroundColor: "rgb(7, 8, 9)",
+			borderRadius: "17px",
+		});
+});

--- a/packages/badge/badge.test.ts
+++ b/packages/badge/badge.test.ts
@@ -25,10 +25,8 @@ test("defaults to neutral variant when no variant attribute is set", async () =>
 	// But the neutral styles should still be applied
 	await expect
 		.poll(() => {
-			const inner = el.shadowRoot?.querySelector("div");
-			return inner?.className.includes(
-				"bg-[--w-color-badge-neutral-background]",
-			);
+			const inner = el.shadowRoot?.querySelector('[part="base"]');
+			return inner?.classList.contains("badge--neutral");
 		})
 		.toBe(true);
 });

--- a/packages/badge/badge.test.ts
+++ b/packages/badge/badge.test.ts
@@ -14,21 +14,48 @@ test("renders the slotted label", async () => {
 });
 
 test("defaults to neutral variant when no variant attribute is set", async () => {
-	const component = html`<w-badge data-testid="badge">Default badge</w-badge>`;
+	const component = html`
+		<w-badge data-testid="default-badge">Default badge</w-badge>
+		<w-badge data-testid="neutral-badge" variant="neutral"
+			>Neutral badge</w-badge
+		>
+	`;
 
 	const page = render(component);
-	const el = page.getByTestId("badge").element() as HTMLElement;
+	const defaultBadge = page.getByTestId("default-badge").element() as HTMLElement;
+	const neutralBadge = page.getByTestId("neutral-badge").element() as HTMLElement;
 
 	// The variant attribute should not be reflected (to avoid hydration mismatch)
-	expect(el.hasAttribute("variant")).toBe(false);
+	expect(defaultBadge.hasAttribute("variant")).toBe(false);
 
 	// But the neutral styles should still be applied
 	await expect
 		.poll(() => {
-			const inner = el.shadowRoot?.querySelector('[part="base"]');
-			return inner?.classList.contains("badge--neutral");
+			const defaultBase = defaultBadge.shadowRoot?.querySelector(
+				'[part="base"]',
+			) as HTMLElement | null;
+			const neutralBase = neutralBadge.shadowRoot?.querySelector(
+				'[part="base"]',
+			) as HTMLElement | null;
+
+			if (!defaultBase || !neutralBase) return null;
+
+			const defaultStyle = getComputedStyle(defaultBase);
+			const neutralStyle = getComputedStyle(neutralBase);
+
+			return {
+				backgroundColor: defaultStyle.backgroundColor,
+				color: defaultStyle.color,
+				matchesNeutral:
+					defaultStyle.backgroundColor === neutralStyle.backgroundColor &&
+					defaultStyle.color === neutralStyle.color,
+			};
 		})
-		.toBe(true);
+		.toEqual({
+			backgroundColor: expect.any(String),
+			color: expect.any(String),
+			matchesNeutral: true,
+		});
 });
 
 test("supports styling through component tokens", async () => {

--- a/packages/badge/badge.test.ts
+++ b/packages/badge/badge.test.ts
@@ -22,8 +22,12 @@ test("defaults to neutral variant when no variant attribute is set", async () =>
 	`;
 
 	const page = render(component);
-	const defaultBadge = page.getByTestId("default-badge").element() as HTMLElement;
-	const neutralBadge = page.getByTestId("neutral-badge").element() as HTMLElement;
+	const defaultBadge = page
+		.getByTestId("default-badge")
+		.element() as HTMLElement;
+	const neutralBadge = page
+		.getByTestId("neutral-badge")
+		.element() as HTMLElement;
 
 	// The variant attribute should not be reflected (to avoid hydration mismatch)
 	expect(defaultBadge.hasAttribute("variant")).toBe(false);
@@ -73,9 +77,9 @@ test("supports styling through component tokens", async () => {
 
 	await expect
 		.poll(() => {
-			const base = el.shadowRoot?.querySelector('[part="base"]') as
-				| HTMLElement
-				| null;
+			const base = el.shadowRoot?.querySelector(
+				'[part="base"]',
+			) as HTMLElement | null;
 			if (!base) return null;
 
 			const style = getComputedStyle(base);
@@ -108,9 +112,9 @@ test("supports styling through the base part", async () => {
 
 	await expect
 		.poll(() => {
-			const base = el.shadowRoot?.querySelector('[part="base"]') as
-				| HTMLElement
-				| null;
+			const base = el.shadowRoot?.querySelector(
+				'[part="base"]',
+			) as HTMLElement | null;
 			if (!base) return null;
 
 			const style = getComputedStyle(base);

--- a/packages/badge/badge.ts
+++ b/packages/badge/badge.ts
@@ -1,9 +1,7 @@
-import { classMap } from 'lit/directives/class-map.js';
 import { html, LitElement } from "lit";
 import { property } from "lit/decorators.js";
 
 import { reset } from "../styles";
-
 import { styles } from "./styles";
 
 /**
@@ -40,23 +38,8 @@ class WarpBadge extends LitElement {
 
 	static styles = [reset, styles];
 
-	/** @internal */
-	get _class() {
-		const classes = {
-			badge: true,
-			[`badge--${this.variant}`]: true,
-			"badge--positioned": !!this.position,
-			[`badge--${this.position}`]: !!this.position,
-		};
-		return classMap(classes);
-	}
-
 	render() {
-		return html`
-			<div part="base" class="${this._class}">
-				<slot></slot>
-			</div>
-		`;
+		return html`<div part="base"><slot></slot></div>`;
 	}
 }
 

--- a/packages/badge/badge.ts
+++ b/packages/badge/badge.ts
@@ -1,6 +1,4 @@
-// @warp-css;
-
-import { classNames } from "@chbphone55/classnames";
+import { classMap } from 'lit/directives/class-map.js';
 import { html, LitElement } from "lit";
 import { property } from "lit/decorators.js";
 
@@ -19,7 +17,7 @@ class WarpBadge extends LitElement {
 	 * If omitted, the badge uses neutral styling without reflecting a `variant` attribute.
 	 * Accepted values are `neutral`, `info`, `positive`, `warning`, `negative`, `disabled`, `price`, and `sponsored`. If omitted, the badge uses neutral styling without reflecting a `variant` attribute.
 	 */
-	@property({ type: String, reflect: true })
+	@property({ type: String, reflect: true, useDefault: true })
 	variant:
 		| "neutral"
 		| "info"
@@ -29,7 +27,7 @@ class WarpBadge extends LitElement {
 		| "disabled"
 		| "price"
 		| "sponsored"
-		| undefined;
+		| undefined = "neutral";
 
 	/**
 	 * Positions the badge in a corner of a parent element.
@@ -44,35 +42,18 @@ class WarpBadge extends LitElement {
 
 	/** @internal */
 	get _class() {
-		const variant = this.variant || "neutral";
-		return classNames([
-			"py-4 px-8 border-0 rounded-4 text-xs inline-flex",
-			variant === "neutral" && "bg-[--w-color-badge-neutral-background] s-text",
-			variant === "info" && "bg-[--w-color-badge-info-background] s-text",
-			variant === "positive" &&
-				"bg-[--w-color-badge-positive-background] s-text",
-			variant === "warning" && "bg-[--w-color-badge-warning-background] s-text",
-			variant === "negative" &&
-				"bg-[--w-color-badge-negative-background] s-text",
-			variant === "disabled" && "s-bg-disabled s-text",
-			variant === "price" && "bg-[--w-black/70] s-text-inverted-static",
-			variant === "sponsored" &&
-				"bg-[--w-color-badge-sponsored-background] s-text",
-			!!this.position && "absolute backdrop-blur",
-			this.position === "top-left" &&
-				"rounded-tl-0 rounded-tr-0 rounded-bl-0 top-0 left-0",
-			this.position === "top-right" &&
-				"rounded-tl-0 rounded-tr-0 rounded-br-0 top-0 right-0",
-			this.position === "bottom-right" &&
-				"rounded-tr-0 rounded-br-0 rounded-bl-0 bottom-0 right-0",
-			this.position === "bottom-left" &&
-				"rounded-tl-0 rounded-br-0 rounded-bl-0 bottom-0 left-0",
-		]);
+		const classes = {
+			badge: true,
+			[`badge--${this.variant}`]: true,
+			"badge--positioned": !!this.position,
+			[`badge--${this.position}`]: !!this.position,
+		};
+		return classMap(classes);
 	}
 
 	render() {
 		return html`
-			<div class="${this._class}">
+			<div part="base" class="${this._class}">
 				<slot></slot>
 			</div>
 		`;

--- a/packages/badge/docs/styling.md
+++ b/packages/badge/docs/styling.md
@@ -40,6 +40,11 @@ w-badge {
 - `--w-c-badge-bg`
 - `--w-c-badge-color`
 
+##### Border
+
+- `--w-c-badge-border-width`
+- `--w-c-badge-border-color`
+
 ##### Positioned badges
 
 - `--w-c-badge-backdrop-filter`

--- a/packages/badge/docs/styling.md
+++ b/packages/badge/docs/styling.md
@@ -1,1 +1,45 @@
 ## Styling API
+
+Badge supports styling through **component tokens** (CSS custom properties with a `--w-c-` prefix) and **parts**.
+
+### Parts
+
+Use `::part(part-name)` from outside the component.
+
+- `base` - the root element of the badge
+
+```css
+w-badge::part(base) {
+	text-transform: uppercase;
+	border: 1px solid currentColor;
+}
+```
+
+### Component tokens
+
+Set these on `<w-badge>` to override visuals.
+
+```css
+w-badge {
+	--w-c-badge-bg: rebeccapurple;
+	--w-c-badge-color: white;
+	--w-c-badge-border-radius: 9999px;
+}
+```
+
+##### Layout and typography
+
+- `--w-c-badge-border-radius`
+- `--w-c-badge-font-size`
+- `--w-c-badge-line-height`
+- `--w-c-badge-padding-x`
+- `--w-c-badge-padding-y`
+
+##### Background and text
+
+- `--w-c-badge-bg`
+- `--w-c-badge-color`
+
+##### Positioned badges
+
+- `--w-c-badge-backdrop-filter`

--- a/packages/badge/styles.ts
+++ b/packages/badge/styles.ts
@@ -8,6 +8,8 @@ export const styles = css`
 		);
 		--_color: var(--w-c-badge-color, var(--w-s-color-text));
 		--_border-radius: var(--w-c-badge-border-radius, 4px);
+		--_border-width: var(--w-c-badge-border-width, 0);
+		--_border-color: var(--w-c-badge-border-color, transparent);
 		--_font-size: var(--w-c-badge-font-size, var(--w-font-size-xs));
 		--_line-height: var(--w-c-badge-line-height, var(--w-line-height-xs));
 		--_padding-x: var(--w-c-badge-padding-x, 0.8rem);
@@ -15,49 +17,49 @@ export const styles = css`
 		--_backdrop-filter: var(--w-c-badge-backdrop-filter, none);
 	}
 
-	.badge--neutral {
+	:host([variant="neutral"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-color-badge-neutral-background)
 		);
 	}
 
-	.badge--info {
+	:host([variant="info"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-color-badge-info-background)
 		);
 	}
 
-	.badge--positive {
+	:host([variant="positive"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-color-badge-positive-background)
 		);
 	}
 
-	.badge--warning {
+	:host([variant="warning"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-color-badge-warning-background)
 		);
 	}
 
-	.badge--negative {
+	:host([variant="negative"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-color-badge-negative-background)
 		);
 	}
 
-	.badge--disabled {
+	:host([variant="disabled"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-s-color-background-disabled)
 		);
 	}
 
-	.badge--price {
+	:host([variant="price"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			rgba(var(--w-rgb-black), 0.7)
@@ -65,16 +67,36 @@ export const styles = css`
 		--_color: var(--w-c-badge-color, var(--w-s-color-text-inverted-static));
 	}
 
-	.badge--sponsored {
+	:host([variant="sponsored"]) {
 		--_background-color: var(
 			--w-c-badge-bg,
 			var(--w-color-badge-sponsored-background)
 		);
 	}
 
-	.badge {
+	:host([position]) {
+		--_backdrop-filter: var(--w-c-badge-backdrop-filter, blur(4px));
+	}
+
+	:host([position="top-left"]) {
+		inset: 0 auto auto 0;
+	}
+
+	:host([position="top-right"]) {
+		inset: 0 0 auto auto;
+	}
+
+	:host([position="bottom-right"]) {
+		inset: auto 0 0 auto;
+	}
+
+	:host([position="bottom-left"]) {
+		inset: auto auto 0 0;
+	}
+
+	[part="base"] {
 		background-color: var(--_background-color);
-		border: 0;
+		border: var(--_border-width) solid var(--_border-color);
 		border-radius: var(--_border-radius);
 		color: var(--_color);
 		display: inline-flex;
@@ -83,42 +105,36 @@ export const styles = css`
 		padding: var(--_padding-y) var(--_padding-x);
 	}
 
-	.badge--positioned {
-		--_backdrop-filter: var(--w-c-badge-backdrop-filter, blur(4px));
+	:host([position]) [part="base"] {
 		-webkit-backdrop-filter: var(--_backdrop-filter);
 		backdrop-filter: var(--_backdrop-filter);
+	}
+
+	:host([position]) {
 		position: absolute;
 	}
 
-	.badge--top-left {
+	:host([position="top-left"]) [part="base"] {
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 		border-bottom-left-radius: 0;
-		top: 0;
-		left: 0;
 	}
 
-	.badge--top-right {
+	:host([position="top-right"]) [part="base"] {
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
-		top: 0;
-		right: 0;
 	}
 
-	.badge--bottom-right {
+	:host([position="bottom-right"]) [part="base"] {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 		border-bottom-left-radius: 0;
-		bottom: 0;
-		right: 0;
 	}
 
-	.badge--bottom-left {
+	:host([position="bottom-left"]) [part="base"] {
 		border-top-left-radius: 0;
 		border-bottom-right-radius: 0;
 		border-bottom-left-radius: 0;
-		bottom: 0;
-		left: 0;
 	}
 `;

--- a/packages/badge/styles.ts
+++ b/packages/badge/styles.ts
@@ -60,10 +60,7 @@ export const styles = css`
 	}
 
 	:host([variant="price"]) {
-		--_background-color: var(
-			--w-c-badge-bg,
-			rgba(var(--w-rgb-black), 0.7)
-		);
+		--_background-color: var(--w-c-badge-bg, rgba(var(--w-rgb-black), 0.7));
 		--_color: var(--w-c-badge-color, var(--w-s-color-text-inverted-static));
 	}
 

--- a/packages/badge/styles.ts
+++ b/packages/badge/styles.ts
@@ -1,4 +1,124 @@
-import { unsafeCSS } from "lit";
-export const styles = unsafeCSS(
-	"*,:before,:after{--w-rotate:0;--w-rotate-x:0;--w-rotate-y:0;--w-rotate-z:0;--w-scale-x:1;--w-scale-y:1;--w-scale-z:1;--w-skew-x:0;--w-skew-y:0;--w-translate-x:0;--w-translate-y:0;--w-translate-z:0}.backdrop-blur{-webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px)}.bg-\\[--w-black\\/70\\]{background-color:rgba(var(--w-rgb-black),.7)}.bg-\\[--w-color-badge-info-background\\]{background-color:var(--w-color-badge-info-background)}.bg-\\[--w-color-badge-negative-background\\]{background-color:var(--w-color-badge-negative-background)}.bg-\\[--w-color-badge-neutral-background\\]{background-color:var(--w-color-badge-neutral-background)}.bg-\\[--w-color-badge-positive-background\\]{background-color:var(--w-color-badge-positive-background)}.bg-\\[--w-color-badge-sponsored-background\\]{background-color:var(--w-color-badge-sponsored-background)}.bg-\\[--w-color-badge-warning-background\\]{background-color:var(--w-color-badge-warning-background)}.border-0{border-width:0}.rounded-4{border-radius:4px}.rounded-bl-0{border-bottom-left-radius:0}.rounded-br-0{border-bottom-right-radius:0}.rounded-tl-0{border-top-left-radius:0}.rounded-tr-0{border-top-right-radius:0}.inline-flex{display:inline-flex}.bottom-0{bottom:0}.left-0{left:0}.right-0{right:0}.top-0{top:0}.absolute{position:absolute}.relative{position:relative}.static{position:static}.s-bg-disabled{background-color:var(--w-s-color-background-disabled)}.s-text{color:var(--w-s-color-text)}.s-text-inverted-static{color:var(--w-s-color-text-inverted-static)}.px-8{padding-left:.8rem;padding-right:.8rem}.py-4{padding-top:.4rem;padding-bottom:.4rem}.text-xs{font-size:var(--w-font-size-xs);line-height:var(--w-line-height-xs)}",
-);
+import { css } from "lit";
+
+export const styles = css`
+	:host {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-neutral-background)
+		);
+		--_color: var(--w-c-badge-color, var(--w-s-color-text));
+		--_border-radius: var(--w-c-badge-border-radius, 4px);
+		--_font-size: var(--w-c-badge-font-size, var(--w-font-size-xs));
+		--_line-height: var(--w-c-badge-line-height, var(--w-line-height-xs));
+		--_padding-x: var(--w-c-badge-padding-x, 0.8rem);
+		--_padding-y: var(--w-c-badge-padding-y, 0.4rem);
+		--_backdrop-filter: var(--w-c-badge-backdrop-filter, none);
+	}
+
+	.badge--neutral {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-neutral-background)
+		);
+	}
+
+	.badge--info {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-info-background)
+		);
+	}
+
+	.badge--positive {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-positive-background)
+		);
+	}
+
+	.badge--warning {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-warning-background)
+		);
+	}
+
+	.badge--negative {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-negative-background)
+		);
+	}
+
+	.badge--disabled {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-s-color-background-disabled)
+		);
+	}
+
+	.badge--price {
+		--_background-color: var(
+			--w-c-badge-bg,
+			rgba(var(--w-rgb-black), 0.7)
+		);
+		--_color: var(--w-c-badge-color, var(--w-s-color-text-inverted-static));
+	}
+
+	.badge--sponsored {
+		--_background-color: var(
+			--w-c-badge-bg,
+			var(--w-color-badge-sponsored-background)
+		);
+	}
+
+	.badge {
+		background-color: var(--_background-color);
+		border: 0;
+		border-radius: var(--_border-radius);
+		color: var(--_color);
+		display: inline-flex;
+		font-size: var(--_font-size);
+		line-height: var(--_line-height);
+		padding: var(--_padding-y) var(--_padding-x);
+	}
+
+	.badge--positioned {
+		--_backdrop-filter: var(--w-c-badge-backdrop-filter, blur(4px));
+		-webkit-backdrop-filter: var(--_backdrop-filter);
+		backdrop-filter: var(--_backdrop-filter);
+		position: absolute;
+	}
+
+	.badge--top-left {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+		border-bottom-left-radius: 0;
+		top: 0;
+		left: 0;
+	}
+
+	.badge--top-right {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		top: 0;
+		right: 0;
+	}
+
+	.badge--bottom-right {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		border-bottom-left-radius: 0;
+		bottom: 0;
+		right: 0;
+	}
+
+	.badge--bottom-left {
+		border-top-left-radius: 0;
+		border-bottom-right-radius: 0;
+		border-bottom-left-radius: 0;
+		bottom: 0;
+		left: 0;
+	}
+`;


### PR DESCRIPTION
## Intent

Add a style API for `w-badge` consistent with other components such as `w-button` and `w-card`.

This PR removes the remaining UnoCSS/class-based styling approach from `w-badge` and replaces it with a documented style API built on:

- component tokens (`--w-c-badge-*`)
- shadow parts (`::part(base)`)

It also aligns badge styling architecture with other components by moving variant and position styling onto the host via attribute selectors instead of shadow DOM classes.

## Approach

The implementation refactors `w-badge` to use CSS in `packages/badge/styles.ts` instead of generated UnoCSS utility classes.

Key design decisions:

- Added a proper style API for `w-badge`:
  - component tokens for background, color, radius, typography, spacing, and positioned backdrop filter
  - `part="base"` as the escape hatch for full consumer overrides
- Moved variant styling to host selectors such as `:host([variant="info"])`, matching the pattern used by `w-button` and `w-card`
- Moved position styling to host selectors such as `:host([position="top-right"])`
- Kept neutral styling as the default on bare `:host` so the badge still renders neutral when `variant` is omitted
- Removed class-based styling hooks entirely:
  - no UnoCSS usage
  - no variant/position classes
  - no final base class
  - `classMap` removed from the component
- Updated tests to validate the new style API through actual computed styles
- Added a Storybook story demonstrating styling through both tokens and `::part(base)`
- Added/expanded `packages/badge/docs/styling.md` to document the style API

## Risk

Main risks are visual regressions in `w-badge` styling:

- variant colors may differ if host-based token resolution behaves differently than the old class-based approach
- positioned badges could regress in corner placement or corner radius behavior
- consumers relying on internal shadow classes would break, although those classes were internal implementation details
- Storybook/docs examples could drift from runtime behavior if the style API changes later

Affected surface area is limited to `w-badge` consumers and any flows rendering badges in product UIs.

## Verification

- [x] Tests added or updated
- [x] Existing tests pass
- [x] Manual verification completed, if relevant
- [ ] Screenshots or recordings attached, if UI changed

Commands run:

```text
pnpm vitest packages/badge/badge.test.ts
```

## AI involvement
Yes. AI was used to help apply and iterate on the w-badge style API refactor, including:

- refactoring badge styling from UnoCSS/class-based styling to CSS variables and parts
- moving variant and position styling to host attribute selectors
- adding and adjusting tests for tokens and ::part(base)
- adding a Storybook styling example
- updating styling documentation

### Personally verified:

- the applied code changes in badge.ts, styles.ts, tests, docs, and stories
- that classMap and class-based styling hooks were fully removed
- that the badge test suite passes after each refactor step via pnpm vitest packages/badge/badge.test.ts