### PR TITLE
feat(box): add styling api

### DIFF
--- a/packages/box/box.stories.ts
+++ b/packages/box/box.stories.ts
@@ -84,3 +84,49 @@ export const AccessibleRegion: Story = {
 		`;
 	},
 };
+
+export const StylingApi: Story = {
+	args: {
+		bordered: true,
+	},
+	render(args) {
+		return html`
+			<pre>
+<code>
+&lt;style&gt;
+w-box {
+	--w-c-box-bg: rebeccapurple;
+	--w-c-box-border-color: cyan;
+	--w-c-box-border-radius: 24px;
+	--w-c-box-border-width: 4px;
+	--w-c-box-padding: 2rem;
+}
+
+w-box::part(base) {
+	color: white;
+	box-shadow: inset 0 0 0 2px magenta;
+}
+&lt;/style&gt;
+</code>
+			</pre>
+			<style>
+				w-box {
+					--w-c-box-bg: rebeccapurple;
+					--w-c-box-border-color: cyan;
+					--w-c-box-border-radius: 24px;
+					--w-c-box-border-width: 4px;
+					--w-c-box-padding: 2rem;
+				}
+
+				w-box::part(base) {
+					color: white;
+					box-shadow: inset 0 0 0 2px magenta;
+				}
+			</style>
+			<w-box ${spread(prespread(args))}>
+				<h3>Styled box</h3>
+				<p>This story demonstrates box tokens and the base part.</p>
+			</w-box>
+		`;
+	},
+};

--- a/packages/box/box.test.ts
+++ b/packages/box/box.test.ts
@@ -10,3 +10,74 @@ test("renders the slotted label", async () => {
 	const page = render(component);
 	await expect.element(page.getByText("This is not a button")).toBeVisible();
 });
+
+test("supports styling through component tokens", async () => {
+	const component = html`
+		<w-box
+			data-testid="box"
+			style="--w-c-box-bg: rgb(1, 2, 3); --w-c-box-border-color: rgb(4, 5, 6); --w-c-box-border-radius: 13px; --w-c-box-border-width: 3px; --w-c-box-padding: 21px;"
+		>
+			Styled box
+		</w-box>
+	`;
+
+	const page = render(component);
+	const el = page.getByTestId("box").element() as HTMLElement;
+
+	await expect
+		.poll(() => {
+			const base = el.shadowRoot?.querySelector('[part="base"]') as
+				| HTMLElement
+				| null;
+			if (!base) return null;
+
+			const style = getComputedStyle(base);
+			return {
+				backgroundColor: style.backgroundColor,
+				borderColor: style.borderColor,
+				borderRadius: style.borderRadius,
+				borderWidth: style.borderTopWidth,
+				padding: style.paddingTop,
+			};
+		})
+		.toEqual({
+			backgroundColor: "rgb(1, 2, 3)",
+			borderColor: "rgb(4, 5, 6)",
+			borderRadius: "13px",
+			borderWidth: "3px",
+			padding: "21px",
+		});
+});
+
+test("supports styling through the base part", async () => {
+	const component = html`
+		<style>
+			w-box::part(base) {
+				background-color: rgb(7, 8, 9);
+				border-radius: 17px;
+			}
+		</style>
+		<w-box data-testid="box">Part styled box</w-box>
+	`;
+
+	const page = render(component);
+	const el = page.getByTestId("box").element() as HTMLElement;
+
+	await expect
+		.poll(() => {
+			const base = el.shadowRoot?.querySelector('[part="base"]') as
+				| HTMLElement
+				| null;
+			if (!base) return null;
+
+			const style = getComputedStyle(base);
+			return {
+				backgroundColor: style.backgroundColor,
+				borderRadius: style.borderRadius,
+			};
+		})
+		.toEqual({
+			backgroundColor: "rgb(7, 8, 9)",
+			borderRadius: "17px",
+		});
+});

--- a/packages/box/box.test.ts
+++ b/packages/box/box.test.ts
@@ -26,9 +26,9 @@ test("supports styling through component tokens", async () => {
 
 	await expect
 		.poll(() => {
-			const base = el.shadowRoot?.querySelector('[part="base"]') as
-				| HTMLElement
-				| null;
+			const base = el.shadowRoot?.querySelector(
+				'[part="base"]',
+			) as HTMLElement | null;
 			if (!base) return null;
 
 			const style = getComputedStyle(base);
@@ -65,9 +65,9 @@ test("supports styling through the base part", async () => {
 
 	await expect
 		.poll(() => {
-			const base = el.shadowRoot?.querySelector('[part="base"]') as
-				| HTMLElement
-				| null;
+			const base = el.shadowRoot?.querySelector(
+				'[part="base"]',
+			) as HTMLElement | null;
 			if (!base) return null;
 
 			const style = getComputedStyle(base);

--- a/packages/box/box.ts
+++ b/packages/box/box.ts
@@ -1,7 +1,4 @@
-// @warp-css;
-
-import { classNames } from "@chbphone55/classnames";
-import { css, html, LitElement, PropertyValues } from "lit";
+import { html, LitElement, PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import { FormControlMixin } from "@open-wc/form-control";
 
@@ -54,18 +51,7 @@ class WarpBox extends FormControlMixin(LitElement) {
 	// ::slotted([Simple Selector]) confirms to Specificity rules, but (being simple) does not add weight to lightDOM skin selectors,
 	// so never gets higher Specificity. Thus in order to overwrite style linked within shadowDOM, we need to use !important.
 	// https://stackoverflow.com/a/61631668
-	static styles = [
-		reset,
-		styles,
-		css`
-			:host {
-				display: block;
-			}
-			::slotted(:last-child) {
-				margin-bottom: 0px !important;
-			}
-		`,
-	];
+	static styles = [reset, styles];
 
 	connectedCallback(): void {
 		super.connectedCallback();
@@ -79,20 +65,9 @@ class WarpBox extends FormControlMixin(LitElement) {
 		}
 	}
 
-	/** @internal */
-	get _class() {
-		return classNames([
-			"group block relative break-words last-child:mb-0 p-16 rounded-8",
-			this.bleed && "-mx-16 sm:mx-0 rounded-l-0 rounded-r-0 sm:rounded-8",
-			this.info && "s-bg-info-subtle",
-			this.neutral && "s-surface-sunken",
-			this.bordered && "border-2 s-border s-bg",
-		]);
-	}
-
 	render() {
 		return html`
-			<div class="${this._class}">
+			<div part="base">
 				<slot></slot>
 			</div>
 		`;

--- a/packages/box/docs/styling.md
+++ b/packages/box/docs/styling.md
@@ -1,1 +1,41 @@
 ## Styling API
+
+Box supports styling through **component tokens** (CSS custom properties with a `--w-c-` prefix) and **parts**.
+
+### Parts
+
+Use `::part(part-name)` from outside the component.
+
+- `base` - the root element of the box
+
+```css
+w-box::part(base) {
+	box-shadow: inset 0 0 0 1px currentColor;
+	text-transform: uppercase;
+}
+```
+
+### Component tokens
+
+Set these on `<w-box>` to override visuals.
+
+```css
+w-box {
+	--w-c-box-bg: rebeccapurple;
+	--w-c-box-border-color: cyan;
+	--w-c-box-border-radius: 12px;
+	--w-c-box-padding: 2rem;
+}
+```
+
+##### Surface and border
+
+- `--w-c-box-bg`
+- `--w-c-box-border-color`
+- `--w-c-box-border-radius`
+- `--w-c-box-border-width`
+
+##### Layout
+
+- `--w-c-box-padding`
+- `--w-c-box-bleed-margin-inline`

--- a/packages/box/styles.ts
+++ b/packages/box/styles.ts
@@ -1,4 +1,61 @@
-import { unsafeCSS } from "lit";
-export const styles = unsafeCSS(
-	"*,:before,:after{--w-rotate:0;--w-rotate-x:0;--w-rotate-y:0;--w-rotate-z:0;--w-scale-x:1;--w-scale-y:1;--w-scale-z:1;--w-skew-x:0;--w-skew-y:0;--w-translate-x:0;--w-translate-y:0;--w-translate-z:0}.border-2{border-width:2px}.rounded{border-radius:4px}.rounded-8{border-radius:8px}.rounded-l-0{border-top-left-radius:0;border-bottom-left-radius:0}.rounded-r-0{border-top-right-radius:0;border-bottom-right-radius:0}.block{display:block}.relative{position:relative}.static{position:static}.s-bg{background-color:var(--w-s-color-background)}.s-bg-info-subtle{background-color:var(--w-s-color-background-info-subtle)}.s-border{border-color:var(--w-s-color-border)}.s-surface-sunken{background-color:var(--w-s-color-surface-sunken)}.-mx-16{margin-left:-1.6rem;margin-right:-1.6rem}.last-child\\:mb-0>:last-child{margin-bottom:0}.p-16{padding:1.6rem}.break-words{overflow-wrap:break-word}@media (min-width:480px){.sm\\:rounded-8{border-radius:8px}.sm\\:mx-0{margin-left:0;margin-right:0}}",
-);
+import { css } from "lit";
+
+export const styles = css`
+	:host {
+		display: block;
+		--_background-color: var(--w-c-box-bg, transparent);
+		--_border-color: var(--w-c-box-border-color, transparent);
+		--_border-radius: var(--w-c-box-border-radius, 8px);
+		--_border-width: var(--w-c-box-border-width, 0px);
+		--_padding: var(--w-c-box-padding, 1.6rem);
+		--_bleed-margin-inline: var(--w-c-box-bleed-margin-inline, 1.6rem);
+	}
+
+	:host([info]) {
+		--_background-color: var(
+			--w-c-box-bg,
+			var(--w-s-color-background-info-subtle)
+		);
+	}
+
+	:host([neutral]) {
+		--_background-color: var(--w-c-box-bg, var(--w-s-color-surface-sunken));
+	}
+
+	:host([bordered]) {
+		--_background-color: var(--w-c-box-bg, var(--w-s-color-background));
+		--_border-color: var(--w-c-box-border-color, var(--w-s-color-border));
+		--_border-width: var(--w-c-box-border-width, 2px);
+	}
+
+	[part="base"] {
+		background-color: var(--_background-color);
+		border: var(--_border-width) solid var(--_border-color);
+		border-radius: var(--_border-radius);
+		display: block;
+		overflow-wrap: break-word;
+		padding: var(--_padding);
+		position: relative;
+	}
+
+	:host([bleed]) [part="base"] {
+		border-top-left-radius: 0;
+		border-bottom-left-radius: 0;
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		margin-left: calc(var(--_bleed-margin-inline) * -1);
+		margin-right: calc(var(--_bleed-margin-inline) * -1);
+	}
+
+	::slotted(:last-child) {
+		margin-bottom: 0px !important;
+	}
+
+	@media (min-width: 480px) {
+		:host([bleed]) [part="base"] {
+			border-radius: var(--_border-radius);
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+`;


### PR DESCRIPTION
## Intent

Add a style API for `w-box` consistent with the approach used by other components with documented styling surfaces.

This PR removes the UnoCSS/class-based styling implementation from `w-box` and replaces it with a documented style API built on:

- component tokens (`--w-c-box-*`)
- shadow parts (`::part(base)`)

It makes `w-box` easier for consumers to style without depending on internal utility classes, while preserving the existing public boolean API for visual states like `info`, `neutral`, `bordered`, and `bleed`.

## Approach

The implementation refactors `w-box` to style from `packages/box/styles.ts` using Lit `css` instead of generated utility CSS.

Key design decisions:

- Removed `@warp-css` and `classNames` usage from `w-box`
- Added `part="base"` to the internal wrapper so consumers can override styling with `::part(base)`
- Introduced component tokens for the main surface and layout properties:
  - `--w-c-box-bg`
  - `--w-c-box-border-color`
  - `--w-c-box-border-radius`
  - `--w-c-box-border-width`
  - `--w-c-box-padding`
  - `--w-c-box-bleed-margin-inline`
- Moved visual state styling to host selectors:
  - `:host([info])`
  - `:host([neutral])`
  - `:host([bordered])`
  - `:host([bleed])`
- Kept the existing boolean state API intact instead of redesigning it into a single variant model
- Preserved the slotted last-child margin reset behavior
- Added styling API documentation in `packages/box/docs/styling.md`
- Added a Storybook `StylingApi` example to demonstrate tokens and `::part(base)`
- Added tests that verify the styling API via actual computed styles

## Risk

Main risks are visual regressions in `w-box` styling:

- default spacing, border radius, background, or border behavior could differ from the previous utility-class output
- bleed behavior could regress at narrow widths or at the `480px` breakpoint where margins/radius are restored
- combinations of boolean states like `bordered + neutral` or `bordered + info` could resolve differently if selector ordering changes in the future
- consumers depending on internal implementation details like generated classes would break, although those were not part of the intended public API

Affected surface area is limited to `w-box` consumers and layouts that depend on its current visual rendering.

## Verification

- [x] Tests added or updated
- [x] Existing tests pass
- [x] Manual verification completed, if relevant
- [ ] Screenshots or recordings attached, if UI changed

Commands run:

    pnpm vitest packages/box/box.test.ts

## AI involvement

Yes. AI was used to help implement the `w-box` style API refactor, including:

- converting the component from UnoCSS/class-based styling to CSS variable and part-based styling
- moving visual state styling to host selectors
- adding styling API docs
- adding a Storybook styling example
- adding computed-style tests for component tokens and `::part(base)`

Personally verified:

- the final code changes in `box.ts`, `styles.ts`, docs, stories, and tests
- that the component no longer depends on generated utility classes
- that the `base` part and documented component tokens are present
- that the updated `w-box` tests pass via `pnpm vitest packages/box/box.test.ts`