### PR TITLE
fix: use correct background color token on buttons

### DIFF
--- a/packages/button/docs/styling.md
+++ b/packages/button/docs/styling.md
@@ -22,8 +22,8 @@ Set these on `w-button` to override visuals.
 
 ```css
 w-button {
-  --w-c-button-bg: var(--w-s-color-background-primary);
-  --w-c-button-color: var(--w-s-color-text-inverted);
+	--w-c-button-bg: var(--w-color-button-primary-background);
+	--w-c-button-color: var(--w-s-color-text-inverted);
 }
 ```
 

--- a/packages/button/styles.ts
+++ b/packages/button/styles.ts
@@ -73,9 +73,9 @@ export const buttonSharedBase = css`
  */
 export const buttonSharedVariants = css`
 	:host([variant="primary"]) {
-		--w-c-button-bg: var(--w-s-color-background-primary);
-		--w-c-button-bg-hover: var(--w-s-color-background-primary-hover);
-		--w-c-button-bg-active: var(--w-s-color-background-primary-active);
+		--w-c-button-bg: var(--w-color-button-primary-background);
+		--w-c-button-bg-hover: var(--w-color-button-primary-background-hover);
+		--w-c-button-bg-active: var(--w-color-button-primary-background-active);
 		--w-c-button-color: var(--w-s-color-text-inverted);
 		--w-c-button-border-width: 0px;
 	}


### PR DESCRIPTION
Hotfix for button background colors which were incorrect after a recent refactor introduced a regression.