### PR TITLE
feat(expandable): expose wrapper div as the "wrapper" CSS part

### DIFF
--- a/packages/expandable/expandable.test.ts
+++ b/packages/expandable/expandable.test.ts
@@ -19,6 +19,21 @@ test("renders the given title prop and hides the slotted content", async () => {
 		.not.toBeVisible();
 });
 
+test("exposes the wrapper and toggle button as CSS parts", async () => {
+	const component = html`
+		<w-expandable title="I'm expandable">
+			<p>with expanded content</p>
+		</w-expandable>
+	`;
+
+	const page = render(component);
+	await expect.element(page.getByText("I'm expandable")).toBeVisible();
+
+	const shadowRoot = document.querySelector("w-expandable")?.shadowRoot;
+	expect(shadowRoot?.querySelector('[part="wrapper"]')).toBeTruthy();
+	expect(shadowRoot?.querySelector('button[part="button"]')).toBeTruthy();
+});
+
 test("clicking the expandable shows the slotted content", async () => {
 	const component = html`
 		<w-expandable title="I'm expandable">

--- a/packages/expandable/expandable.ts
+++ b/packages/expandable/expandable.ts
@@ -56,6 +56,9 @@ const ccExpandable = {
  * [Warp component reference](https://warp-ds.github.io/docs/components/expandable/frameworks/elements)
  *
  * @slot title - Alternative to the `title` attribute should you need to provide some additional markup.
+ *
+ * @csspart wrapper - the root wrapper element inside the component.
+ * @csspart button - the toggle button, if a title is present.
  */
 class WarpExpandable extends LitElement {
 	/**
@@ -231,11 +234,12 @@ class WarpExpandable extends LitElement {
 	}
 
 	render() {
-		return html` <div class="${this.#wrapperClasses}">
+		return html` <div part="wrapper" class="${this.#wrapperClasses}">
 			${
 				this._hasTitle
 					? html`<w-unstyled-heading level=${ifDefined(this.headingLevel)}>
 							<button
+								part="button"
 								type="button"
 								aria-expanded="${this.expanded}"
 								class="${this.#buttonClasses}"


### PR DESCRIPTION
# Summary

Allows consumers to style the root wrapper and toggle button from outside the shadow DOM, e.g. `<Expandable className="part-[wrapper]:s-bg part-[button]:px-0" />`.

## Intent

Currently the Expandable of `box` type is the only one that takes full width of its parent and places the chevron at the end. However, that type has a subtle background colour, which doesn't fit e.g. the [following design:](https://www.figma.com/design/eghm57Mjb0JEzqzhucwt6G/Mobility---Item---Dealer-Page?node-id=5870-47270&m=dev)
<img width="150" height="117" alt="Screenshot of an accordion section with white background" src="https://github.com/user-attachments/assets/f1f12b69-5af4-4b91-b95a-ce8b967c2a28" />

With this change the Expandable component can be used to implement the above design, preventing users from building their own components from scratch just to fix the background colour and title padding.

## Verification

- [x] Tests added or updated
- [x] Existing tests pass